### PR TITLE
fix(design-core): build error with monaco-editor

### DIFF
--- a/packages/design-core/vite.config.js
+++ b/packages/design-core/vite.config.js
@@ -213,8 +213,8 @@ const importMapStyles = [`https://unpkg.com/@opentiny/vue-theme@${importMapVersi
 export default defineConfig(({ command, mode }) => {
   const monacoPublicPath = {
     local: 'editor/monaco-workers',
-    alpha: '', // 需要填写openTiny的cdn地址
-    prod: '' // 需要填写openTiny的cdn地址
+    alpha: 'https://tinyengine-assets.obs.cn-north-4.myhuaweicloud.com/files/monaco-assets',
+    prod: 'https://tinyengine-assets.obs.cn-north-4.myhuaweicloud.com/files/monaco-assets'
   }
 
   let monacoEditorPluginInstance = monacoEditorPlugin({ publicPath: monacoPublicPath.local })


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
在windows环境下执行`pnpm run build:alpha --base=xxxx --outDir=yyyy` 时会出现报错：
> no such file or directory. mkdir  'yyyy\xxxx\monacoeditorwork'

原因是未配置monaco-editor publicPath时会错误拼接路径

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
构建出monaco-editor esm worker文件，上传到obs，替换publicPath为obs路径解决，之后构建不报错.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
