### PR TITLE
feat: 页面输入输出配置，配置内有内容时，按钮替换为展示部分文案内容。

### DIFF
--- a/packages/common/component/MetaCodeEditor.vue
+++ b/packages/common/component/MetaCodeEditor.vue
@@ -10,19 +10,19 @@
       </tiny-button>
     </slot>
     <tiny-dialog-box
-        v-model:visible="editorState.show"
-        :title="titleLabel"
-        width="50vw"
-        class="meta-code-editor-dialog-box"
-        append-to-body
+      v-model:visible="editorState.show"
+      :title="titleLabel"
+      width="50vw"
+      class="meta-code-editor-dialog-box"
+      append-to-body
     >
       <div class="source-code">
         <div v-if="editorTipsTitle" class="header-tips-container">
           <span class="header-tips-title" :title="editorTipsTitle">{{ editorTipsTitle }}</span>
           <div
-              v-if="editorTipsDemo"
-              class="header-tips-showdemo"
-              @click="editorState.showEditorDemo = !editorState.showEditorDemo"
+            v-if="editorTipsDemo"
+            class="header-tips-showdemo"
+            @click="editorState.showEditorDemo = !editorState.showEditorDemo"
           >
             <span>{{ editorState.showEditorDemo ? $t('common.collapseExample') : $t('common.expandExample') }}</span>
             <icon-chevron-up v-if="editorState.showEditorDemo" class="collapse-icon"></icon-chevron-up>
@@ -35,11 +35,11 @@
           </div>
         </div>
         <monaco-editor
-            ref="editor"
-            class="source-code-content"
-            :value="value"
-            :options="options"
-            @editorDidMount="editorDidMount"
+          ref="editor"
+          class="source-code-content"
+          :value="value"
+          :options="options"
+          @editorDidMount="editorDidMount"
         ></monaco-editor>
         <div v-if="showErrorMsg" class="error-msg">{{ editorState.errorMsg }}</div>
       </div>
@@ -273,8 +273,9 @@ export default {
 }
 .full-width {
   border: 1px solid #adb0b8;
-  border-radius: 2px;
+  border-radius: 6px;
   padding: 4px 8px;
+  height: 32px;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/packages/plugins/page/src/PageInputOutput.vue
+++ b/packages/plugins/page/src/PageInputOutput.vue
@@ -13,7 +13,7 @@
           title="输入配置"
           button-text="输入配置"
           language="json"
-          :buttonShowContent="isExitValue(inputValue)"
+          :buttonShowContent="hasContent(inputValue)"
           single
           @save="saveInputValue"
         ></meta-code-editor>
@@ -24,7 +24,7 @@
           title="输出配置"
           button-text="输出配置"
           language="json"
-          :buttonShowContent="isExitValue(outputValue)"
+          :buttonShowContent="hasContent(outputValue)"
           single
           @save="saveOutputValue"
         ></meta-code-editor>
@@ -88,7 +88,7 @@ export default {
       }
     }
 
-    const isExitValue = (value) =>
+    const hasContent = (value) =>
       (Array.isArray(value) && value.length > 0) || (typeof value === 'object' && Object.keys(value).length > 0)
 
     return {
@@ -97,7 +97,7 @@ export default {
       saveInputValue,
       saveOutputValue,
       pageSettingState,
-      isExitValue
+      hasContent
     }
   }
 }

--- a/packages/plugins/page/src/PageInputOutput.vue
+++ b/packages/plugins/page/src/PageInputOutput.vue
@@ -7,22 +7,24 @@
       class="life-cycle-alert"
     ></tiny-alert>
     <tiny-form label-position="left" class="input-output-form">
-      <tiny-form-item label="输入配置">
+      <tiny-form-item label="输入配置" class="item-wrap">
         <meta-code-editor
           :modelValue="inputValue"
           title="输入配置"
           button-text="输入配置"
           language="json"
+          :buttonShowContent="isExitValue(inputValue)"
           single
           @save="saveInputValue"
         ></meta-code-editor>
       </tiny-form-item>
-      <tiny-form-item label="输出配置">
+      <tiny-form-item label="输出配置" class="item-wrap">
         <meta-code-editor
           :modelValue="outputValue"
           title="输出配置"
           button-text="输出配置"
           language="json"
+          :buttonShowContent="isExitValue(outputValue)"
           single
           @save="saveOutputValue"
         ></meta-code-editor>
@@ -86,12 +88,16 @@ export default {
       }
     }
 
+    const isExitValue = (value) =>
+      (Array.isArray(value) && value.length > 0) || (typeof value === 'object' && Object.keys(value).length > 0)
+
     return {
       inputValue,
       outputValue,
       saveInputValue,
       saveOutputValue,
-      pageSettingState
+      pageSettingState,
+      isExitValue
     }
   }
 }
@@ -120,6 +126,9 @@ export default {
   .input-output-form {
     margin-top: 16px;
     margin-left: 28px;
+    .item-wrap {
+      width: 348px;
+    }
     :deep(.tiny-form-item) {
       .tiny-form-item__label {
         font-size: 14px;


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
当前输入输出配置里面不管是否有内容，按钮外都无法不体现
![image](https://github.com/opentiny/tiny-engine/assets/145339349/c0ac2440-d96f-4bdd-85b5-25d884ee91f0)

## What is the new behavior?
当配置中内容时，会展示一个输入框
![image](https://github.com/opentiny/tiny-engine/assets/145339349/fb3a7fef-e644-4674-9324-cac675f2358d)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
