### PR TITLE
fix(styles-import): 解决tree组件选中样式背景色为黑色的问题

### DIFF
--- a/packages/design-core/vite.config.js
+++ b/packages/design-core/vite.config.js
@@ -204,7 +204,9 @@ const importmap = {
     '@opentiny/vue-icon': `https://unpkg.com/@opentiny/vue@${importMapVersions.tinyVue}/runtime/tiny-vue-icon.mjs`,
     '@opentiny/vue-common': `https://unpkg.com/@opentiny/vue@${importMapVersions.tinyVue}/runtime/tiny-vue-common.mjs`,
     '@opentiny/vue-locale': `https://unpkg.com/@opentiny/vue@${importMapVersions.tinyVue}/runtime/tiny-vue-locale.mjs`,
-    '@opentiny/vue-design-smb': `https://unpkg.com/@opentiny/vue-design-smb@${importMapVersions.tinyVue}/index.js`
+    '@opentiny/vue-design-smb': `https://unpkg.com/@opentiny/vue-design-smb@${importMapVersions.tinyVue}/index.js`,
+    '@opentiny/vue-theme/theme-tool': `https://unpkg.com/@opentiny/vue-theme@${importMapVersions.tinyVue}/theme-tool`,
+    '@opentiny/vue-theme/theme': `https://unpkg.com/@opentiny/vue-theme@${importMapVersions.tinyVue}/theme`
   }
 }
 

--- a/packages/plugins/page/src/PageTree.vue
+++ b/packages/plugins/page/src/PageTree.vue
@@ -373,12 +373,19 @@ export default {
     color: var(--ti-lowcode-page-manage-tree-color);
 
     .tiny-tree-node {
-      &.is-current {
-        .tiny-tree-node__content {
-          background-color: var(--ti-lowcode-page-manage-page-tree-background-color);
-          &:hover {
-            background-color: var(--ti-lowcode-page-manage-page-tree-background-hover-color);
-          }
+      &:hover {
+        background-color: var(--ti-lowcode-page-manage-page-tree-background-hover-color);
+      }
+      &.is-current,
+      &.is-current .tiny-tree-node__content,
+      &.is-current .tiny-tree-node__content-box {
+        color: var(--ti-lowcode-page-manage-tree-color);
+        background-color: var(--ti-lowcode-page-manage-page-tree-background-active-color);
+        &:hover {
+          background-color: var(--ti-lowcode-page-manage-page-tree-background-hover-color);
+        }
+        & > .tiny-tree-node__content-left {
+          font-weight: 700;
         }
       }
     }
@@ -408,7 +415,6 @@ export default {
         visibility: hidden;
       }
       &:hover {
-        background-color: var(--ti-lowcode-page-manage-page-tree-background-color) !important;
         border-radius: 0;
         .icons {
           .setting {

--- a/packages/theme/dark/pageManage.less
+++ b/packages/theme/dark/pageManage.less
@@ -13,7 +13,7 @@
   --ti-lowcode-page-manage-content-tips-color: var(--ti-lowcode-common-text-color-5);
   --ti-lowcode-page-manage-search-border-color: var(--ti-lowcode-common-border-color-2);
   --ti-lowcode-page-manage-tree-color: var(--ti-lowcode-common-secondary-text-color);
-  --ti-lowcode-page-manage-page-tree-background-color: var(--ti-lowcode-common-component-hover-bg);
+  --ti-lowcode-page-manage-page-tree-background-active-color: var(--ti-lowcode-common-component-hover-bg);
   --ti-lowcode-page-manage-page-tree-background-hover-color: var(--ti-lowcode-common-primary-hover-color);
   --ti-lowcode-page-manage-svg-hover-color: var(--ti-lowcode-common-primary-color);
   --ti-lowcode-page-manage-text-color: var(--ti-lowcode-common-secondary-text-color);

--- a/packages/theme/light/pageManage.less
+++ b/packages/theme/light/pageManage.less
@@ -10,8 +10,8 @@
   --ti-lowcode-page-manage-content-tips-color: var(--ti-lowcode-common-text-color-5);
   --ti-lowcode-page-manage-search-border-color: var(--ti-lowcode-base-gray-30);
   --ti-lowcode-page-manage-tree-color: var(--ti-lowcode-common-text-main-color);
-  --ti-lowcode-page-manage-page-tree-background-color: var(--ti-lowcode-common-component-hover-bg);
-  --ti-lowcode-page-manage-page-tree-background-hover-color: var(--ti-lowcode-common-primary-hover-color);
+  --ti-lowcode-page-manage-page-tree-background-active-color: var(--ti-lowcode-common-component-hover-bg);
+  --ti-lowcode-page-manage-page-tree-background-hover-color: var(--ti-lowcode-common-component-hover-bg);
   --ti-lowcode-page-manage-svg-hover-color: var(--ti-lowcode-base-bg-3);
   --ti-lowcode-page-manage-text-color: var(--ti-lowcode-base-text-color-1);
   --ti-lowcode-page-manage-input-head-text-color: var(--ti-lowcode-base-text-color);


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
在构建设计器时，由于我们当前使用的tiny-vue为cdn加载方式，引入了3.11的新版本，而vue-theme采用的是node_modules打包的模式，使用的是package.json里的~3.10.0版本，两边版本不一致导致样式冲突

![image](https://github.com/opentiny/tiny-engine/assets/14882982/c7f394d6-ca80-4d8d-9edd-a996e8bb3728)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
![image](https://github.com/opentiny/tiny-engine/assets/14882982/b8bbc740-9f3d-47ba-86f1-daf7d4a57a79)



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
