### PR TITLE
fix: 手动更新画布key导致表格渲染出错

### DIFF
--- a/packages/canvas/src/components/container/container.js
+++ b/packages/canvas/src/components/container/container.js
@@ -678,8 +678,8 @@ export const setState = (state) => {
   getRenderer().setState(state)
 }
 
-export const setUtils = (utils) => {
-  getRenderer().setUtils(utils)
+export const setUtils = (utils, clear, isForceRefresh) => {
+  getRenderer().setUtils(utils, clear, isForceRefresh)
 }
 
 export const deleteState = (variable) => {

--- a/packages/canvas/src/components/render/runner.js
+++ b/packages/canvas/src/components/render/runner.js
@@ -111,11 +111,15 @@ const create = () => {
 
   document.body.remove()
   document.body = document.createElement('body')
+  const app = document.createElement('div')
+  app.setAttribute('id', 'app')
+  document.body.appendChild(app)
+
   dispatch('canvasReady', { detail: renderer })
 
   App = Vue.createApp(Main).use(TinyI18nHost).provide(I18nInjectionKey, TinyI18nHost)
   App.config.globalProperties.lowcodeConfig = window.parent.TinyGlobalConfig
-  App.mount(document.body)
+  App.mount(document.querySelector('#app'))
 
   new ResizeObserver(() => {
     dispatch('canvasResize')


### PR DESCRIPTION
[English](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE.md) | 简体中文

# PR

## PR Checklist

请检查您的 PR 是否满足以下要求：

- [x] commit message遵循我们的[提交贡献指南](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] 添加了更改内容的测试用例（用于bugfix/功能）
- [ ] 文档已添加/更新（用于bugfix/功能）
- [ ] 是否构建了自己的设计器，经过了充分的自验证

## PR 类型

这个PR的类型是？

- [x] 日常 bug 修复
- [ ] 新特性支持
- [ ] 代码风格优化
- [ ] 重构
- [ ] 构建优化
- [ ] 测试用例
- [ ] 文档更新
- [ ] 分支合并
- [ ] 其他改动（请补充）


## 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 新增特性，需要进行功能描述，并附上效果图。
3. 涉及UI/交互变动/Bugfix需要有修改前&修改后截图或 GIF。
-->


Issue Number: N/A

### 修改前

画布App挂载到document.body上，如果更新画布的key，会导致表格Grid渲染失败

```
vue.runtime.esm-browser.js:9122 Uncaught (in promise) DOMException: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.
    at insert (https://unpkg.com/vue@3.3.10/dist/vue.runtime.esm-browser.js:9122:12)
    at mountElement (https://unpkg.com/vue@3.3.10/dist/vue.runtime.esm-browser.js:6664:5)
    at processElement (https://unpkg.com/vue@3.3.10/dist/vue.runtime.esm-browser.js:6574:7)
    at patch (https://unpkg.com/vue@3.3.10/dist/vue.runtime.esm-browser.js:6446:11)
    at ReactiveEffect.componentUpdateFn [as fn] (https://unpkg.com/vue@3.3.10/dist/vue.runtime.esm-browser.js:7180:9)
    at ReactiveEffect.run (https://unpkg.com/vue@3.3.10/dist/vue.runtime.esm-browser.js:428:19)
    at instance.update (https://unpkg.com/vue@3.3.10/dist/vue.runtime.esm-browser.js:7221:51)
    at callWithErrorHandling (https://unpkg.com/vue@3.3.10/dist/vue.runtime.esm-browser.js:1550:32)
    at flushJobs (https://unpkg.com/vue@3.3.10/dist/vue.runtime.esm-browser.js:1752:9)
```

单独使用TinyGrid即可复现
![image](https://github.com/opentiny/tiny-engine/assets/26267243/44a7b977-de64-4fe2-a880-30e51fd3fabb)
![image](https://github.com/opentiny/tiny-engine/assets/26267243/1ace1719-e2ab-4ef8-8f84-7b83f0bd1cc6)

### 修改后

将画布App挂载到document.body的子元素上，可正确渲染

## 此PR是否含有 breaking change?

- [ ] 是
- [x] 否

<!-- 如果此 PR 包含breaking change，请在下面从用户角度描述具体变化和其他风险。-->

## Other information