### PR TITLE
fix: 修复由于物料边框引起的左侧面板右侧边缘凹凸起伏的样式问题

### DIFF
--- a/packages/plugins/materials/src/component/Main.vue
+++ b/packages/plugins/materials/src/component/Main.vue
@@ -163,6 +163,12 @@ export default {
         white-space: nowrap;
       }
     }
+
+    :deep(.drag-item:nth-child(3n)) {
+      .component-item {
+        border-right: none;
+      }
+    }
   }
 
   .tiny-collapse {


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
由于左侧的面板物料每一项有右侧边框且边框颜色和画布编辑区域背景色相近，导致左侧的面板右侧边缘凹凸起伏。
![image](https://github.com/opentiny/tiny-engine/assets/7768535/abc04afe-5fba-462b-a161-5a0447baf5df)


### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
