### PR TITLE
fix: 修复属性面板中设置空字符串的问题

### DIFF
--- a/packages/common/component/ConfigItem.vue
+++ b/packages/common/component/ConfigItem.vue
@@ -244,7 +244,7 @@ export default {
     })
 
     const updateValue = (value) => {
-      const { property } = props.property
+      const { property, type } = props.property
       const { setProp } = useProperties()
 
       // 是否双向绑定
@@ -283,7 +283,7 @@ export default {
         }
 
         if (props.isTopLayer) {
-          setProp(property, value)
+          setProp(property, value, type)
         }
       }
 

--- a/packages/controller/src/useProperties.js
+++ b/packages/controller/src/useProperties.js
@@ -178,14 +178,14 @@ const getProps = (schema, parent) => {
   properties.parent = parent
 }
 
-const setProp = (name, value) => {
+const setProp = (name, value, type) => {
   if (!properties.schema) {
     return
   }
 
   properties.schema.props = properties.schema.props || {}
 
-  if (value === '' || value === undefined || value === null) {
+  if ((value === '' && type !== 'String') || value === undefined || value === null) {
     delete properties.schema.props[name]
   } else {
     properties.schema.props[name] = value


### PR DESCRIPTION
[English](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE.md) | 简体中文

# PR

## PR Checklist

请检查您的 PR 是否满足以下要求：

- [x] commit message遵循我们的[提交贡献指南](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] 添加了更改内容的测试用例（用于bugfix/功能）
- [ ] 文档已添加/更新（用于bugfix/功能）
- [ ] 是否构建了自己的设计器，经过了充分的自验证

## PR 类型

这个PR的类型是？

- [x] 日常 bug 修复
- [ ] 新特性支持
- [ ] 代码风格优化
- [ ] 重构
- [ ] 构建优化
- [ ] 测试用例
- [ ] 文档更新
- [ ] 分支合并
- [ ] 其他改动（请补充）


## 需求背景和解决方案

背景：
- 属性面板中设置属性，如果是点击变量绑定，然后移除绑定，则会将属性设置为空字符串
- 在 `packages/controller/src/useProperties.js` 第188行中的 `setProp` 方法，如果值是空字符串，则删除此属性，也就是相当于设置成 `undefined`
- 组件显示属性面板中的值的逻辑：如果属性值是 `undefined` 或者 `null`，则显示默认值。

问题：如果对类型为字符串的属性进行了移除绑定的操作，并且此属性有默认值。然后去大纲树重新选中此组件，则属性面板中此属性会显示默认值，画布中渲染的是空字符串

解放方案：在 `setProp` 方法中判断类型，如果是字符串类型并且设置的值是空字符串，则不删除属性

### 修改前


### 修改后

## 此PR是否含有 breaking change?

- [ ] 是
- [ ] 否

<!-- 如果此 PR 包含breaking change，请在下面从用户角度描述具体变化和其他风险。-->

## Other information