### PR TITLE
fix(dsl-page):修复本地运行中对于props属性引用utils出码报错的问题

### DIFF
--- a/packages/vue-generator/src/generator/page.js
+++ b/packages/vue-generator/src/generator/page.js
@@ -159,6 +159,12 @@ function handleBinding(props, attrsArr, description, state) {
         return attrsArr.push(`v-model${modelArgs}="${item.value.replace(/this\.(props\.)?/g, '')}"`)
       }
 
+      // 弥补在recurseChildren方法中，当children为undefined，但是该元素的props存在变量绑定的情况
+      Object.keys(description.jsResource).forEach((jsResourceKey) => {
+        description.jsResource[jsResourceKey] =
+          description.jsResource[jsResourceKey] || item.value.includes(`.${jsResourceKey}.`)
+      })
+
       // expression 使用 v-bind 绑定
       return attrsArr.push(`:${key}="${item.value.replace(/this\.(props\.)?/g, '')}"`)
     }

--- a/packages/vue-generator/src/generator/page.js
+++ b/packages/vue-generator/src/generator/page.js
@@ -159,10 +159,13 @@ function handleBinding(props, attrsArr, description, state) {
         return attrsArr.push(`v-model${modelArgs}="${item.value.replace(/this\.(props\.)?/g, '')}"`)
       }
 
-      // 弥补在recurseChildren方法中，当children为undefined，但是该元素的props存在变量绑定的情况
+      // 弥补在recurseChildren方法中，当children为undefined，但是该元素的props存在变量绑定的情况，此变量绑定的为
+      // 当前JSResources在props的使用场景为变量绑定，使用范式一般为：this.xxx
+      const pickResourceKeys = item.value?.match(/(?<=this\.)\w+/g) || []
+      const itemObject = Object.fromEntries(pickResourceKeys.map((key) => [key, true]))
+
       Object.keys(description.jsResource).forEach((jsResourceKey) => {
-        description.jsResource[jsResourceKey] =
-          description.jsResource[jsResourceKey] || item.value.includes(`.${jsResourceKey}.`)
+        description.jsResource[jsResourceKey] = description.jsResource[jsResourceKey] || itemObject[jsResourceKey]
       })
 
       // expression 使用 v-bind 绑定


### PR DESCRIPTION
[English](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE.md) | 简体中文

# PR

## PR Checklist

请检查您的 PR 是否满足以下要求：

- [x] commit message遵循我们的[提交贡献指南](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] 添加了更改内容的测试用例（用于bugfix/功能）
- [ ] 文档已添加/更新（用于bugfix/功能）
- [x] 是否构建了自己的设计器，经过了充分的自验证

## PR 类型

这个PR的类型是？

- [x] 日常 bug 修复
- [ ] 新特性支持
- [ ] 代码风格优化
- [ ] 重构
- [ ] 构建优化
- [ ] 测试用例
- [ ] 文档更新
- [ ] 分支合并
- [ ] 其他改动（请补充）


## 需求背景和解决方案
问题发现来源：在定位#323问题时，先启动自己本地+mockServer定位，发现无法复现用户问题，但是有当前这个问题出现。

问题现象：给物料的props属性，如：id，进行变量绑定，绑定一个工具类时，在画布阶段能够正常使用，但是在预览阶段，会报错。
复现步骤：
![image](https://github.com/opentiny/tiny-engine/assets/14882982/45cd6089-0d01-4dfd-8f8b-c57db3d199b2)

点击保存，预览

具体报错内容如下：

![image](https://github.com/opentiny/tiny-engine/assets/14882982/ce2a8666-a4c7-4822-bd23-9e15dc9f6f9e)
![image](https://github.com/opentiny/tiny-engine/assets/14882982/2918b1bf-51ad-45a9-b7c4-528de16120ad)

定位后发现在DSL中，对于JSExpression的添加，只会在schema结构中被children包裹的情况，如
![image](https://github.com/opentiny/tiny-engine/assets/14882982/fae24c61-8145-486a-85c8-7d93024adc37)

而对于props属性，并没有被children包裹，那这一块内容会被忽略掉
![image](https://github.com/opentiny/tiny-engine/assets/14882982/fec3b86c-cb36-491b-91b7-eb7a994deebb)


Issue Number: #323 

### 修改前
预览报错，无法预览

### 修改后

可正常预览

## 此PR是否含有 breaking change?

- [ ] 是
- [x] 否

<!-- 如果此 PR 包含breaking change，请在下面从用户角度描述具体变化和其他风险。-->

## Other information