### PR TITLE
fix: 修复画布组件嵌套拖拽的问题

### DIFF
--- a/packages/canvas/src/components/container/CanvasAction.vue
+++ b/packages/canvas/src/components/container/CanvasAction.vue
@@ -68,7 +68,7 @@
     <div v-show="hoverState.configure?.isContainer" class="corner-mark-bottom-right">拖放元素到容器内</div>
   </div>
   <div v-show="lineState.height && lineState.width" class="canvas-rect line">
-    <div :class="['hover-line', lineState.position, { forbid: lineState.forbid }]">
+    <div :class="['hover-line', lineState.position, { forbidden: lineState.forbidden }]">
       <div v-if="lineState.position === 'in' && hoverState.configure" class="choose-slots"></div>
     </div>
   </div>
@@ -540,10 +540,10 @@ export default {
       height: 100%;
       background: var(--ti-lowcode-canvas-hover-line-in-bg-color);
     }
-    &.forbid:not(.in) {
+    &.forbidden:not(.in) {
       background: var(--ti-lowcode-canvas-hover-line-forbid-bg-color);
     }
-    &.forbid.in {
+    &.forbidden.in {
       background: var(--ti-lowcode-canvas-hover-line-in-forbid-bg-color);
     }
   }

--- a/packages/canvas/src/components/container/CanvasAction.vue
+++ b/packages/canvas/src/components/container/CanvasAction.vue
@@ -68,7 +68,7 @@
     <div v-show="hoverState.configure?.isContainer" class="corner-mark-bottom-right">拖放元素到容器内</div>
   </div>
   <div v-show="lineState.height && lineState.width" class="canvas-rect line">
-    <div :class="['hover-line', lineState.position]">
+    <div :class="['hover-line', lineState.position, { forbid: lineState.forbid }]">
       <div v-if="lineState.position === 'in' && hoverState.configure" class="choose-slots"></div>
     </div>
   </div>
@@ -540,10 +540,11 @@ export default {
       height: 100%;
       background: var(--ti-lowcode-canvas-hover-line-in-bg-color);
     }
-    &.forbid {
-      width: 100%;
-      height: 100%;
+    &.forbid:not(.in) {
       background: var(--ti-lowcode-canvas-hover-line-forbid-bg-color);
+    }
+    &.forbid.in {
+      background: var(--ti-lowcode-canvas-hover-line-in-forbid-bg-color);
     }
   }
 

--- a/packages/canvas/src/components/container/container.js
+++ b/packages/canvas/src/components/container/container.js
@@ -97,7 +97,7 @@ const initialLineState = {
   width: 0,
   left: 0,
   position: '',
-  forbid: false,
+  forbidden: false,
   id: '',
   config: null,
   doc: null
@@ -440,7 +440,7 @@ const getPosLine = (rect, configure) => {
   const yAbs = Math.min(lineAbs, rect.height / 3)
   const xAbs = Math.min(lineAbs, rect.width / 3)
   let type
-  let forbid = false
+  let forbidden = false
 
   if (mousePos.y < rect.top + yAbs) {
     type = POSITION.TOP
@@ -453,7 +453,7 @@ const getPosLine = (rect, configure) => {
   } else if (configure.isContainer) {
     type = POSITION.IN
     if (!allowInsert()) {
-      forbid = true
+      forbidden = true
     }
   } else {
     type = POSITION.BOTTOM
@@ -462,10 +462,10 @@ const getPosLine = (rect, configure) => {
   // 如果被拖拽的节点不是新增的，并且是放置的节点的祖先节点，则禁止插入
   const draggedId = dragState.data?.id
   if (draggedId && isAncestor(draggedId, lineState.id)) {
-    forbid = true
+    forbidden = true
   }
 
-  return { type, forbid }
+  return { type, forbidden }
 }
 
 const isBodyEl = (element) => element.nodeName === 'BODY'
@@ -518,7 +518,7 @@ const setHoverRect = (element, data) => {
         top: top * scale + y - siteCanvasRect.y,
         left: left * scale + x - siteCanvasRect.x,
         position: canvasState.type === 'absolute' || posLine.type,
-        forbid: posLine.forbid
+        forbidden: posLine.forbidden
       })
     } else {
       const posLine = getPosLine(rect, configure)
@@ -528,7 +528,7 @@ const setHoverRect = (element, data) => {
         top: top * scale + y - siteCanvasRect.y,
         left: left * scale + x - siteCanvasRect.x,
         position: canvasState.type === 'absolute' || posLine.type,
-        forbid: posLine.forbid
+        forbidden: posLine.forbidden
       })
     }
 
@@ -701,12 +701,12 @@ export const copyNode = (id) => {
 
 export const onMouseUp = () => {
   const { draging, data } = dragState
-  const { position, forbid } = lineState
+  const { position, forbidden } = lineState
   const absolute = canvasState.type === 'absolute'
   const sourceId = data?.id
   const lineId = lineState.id
 
-  if (draging && !forbid) {
+  if (draging && !forbidden) {
     const { parent, node } = getNode(lineId, true) || {} // target
     const targetNode = { parent, node, data: toRaw(data) }
 

--- a/packages/canvas/src/components/container/container.js
+++ b/packages/canvas/src/components/container/container.js
@@ -25,8 +25,7 @@ export const POSITION = Object.freeze({
   BOTTOM: 'bottom',
   LEFT: 'left',
   RIGHT: 'right',
-  IN: 'in',
-  FORBID: 'forbid'
+  IN: 'in'
 })
 import { isVsCodeEnv } from '@opentiny/tiny-engine-controller/js/environments'
 
@@ -98,6 +97,7 @@ const initialLineState = {
   width: 0,
   left: 0,
   position: '',
+  forbid: false,
   id: '',
   config: null,
   doc: null
@@ -416,6 +416,23 @@ export const allowInsert = (configure = hoverState.configure || {}, data = dragS
   return flag
 }
 
+const isAncestor = (ancestor, descendant) => {
+  const ancestorId = typeof ancestor === 'string' ? ancestor : ancestor.id
+  let descendantId = typeof descendant === 'string' ? descendant : descendant.id
+
+  while (descendantId) {
+    const { parent } = getNode(descendantId, true) || {}
+
+    if (parent.id === ancestorId) {
+      return true
+    }
+
+    descendantId = parent.id
+  }
+
+  return false
+}
+
 // 获取位置信息，返回状态
 const lineAbs = 20
 const getPosLine = (rect, configure) => {
@@ -423,6 +440,7 @@ const getPosLine = (rect, configure) => {
   const yAbs = Math.min(lineAbs, rect.height / 3)
   const xAbs = Math.min(lineAbs, rect.width / 3)
   let type
+  let forbid = false
 
   if (mousePos.y < rect.top + yAbs) {
     type = POSITION.TOP
@@ -433,12 +451,21 @@ const getPosLine = (rect, configure) => {
   } else if (mousePos.x > rect.right - xAbs) {
     type = POSITION.RIGHT
   } else if (configure.isContainer) {
-    type = allowInsert() ? POSITION.IN : POSITION.FORBID
+    type = POSITION.IN
+    if (!allowInsert()) {
+      forbid = true
+    }
   } else {
     type = POSITION.BOTTOM
   }
 
-  return { type }
+  // 如果被拖拽的节点不是新增的，并且是放置的节点的祖先节点，则禁止插入
+  const draggedId = dragState.data?.id
+  if (draggedId && isAncestor(draggedId, lineState.id)) {
+    forbid = true
+  }
+
+  return { type, forbid }
 }
 
 const isBodyEl = (element) => element.nodeName === 'BODY'
@@ -484,20 +511,24 @@ const setHoverRect = (element, data) => {
       const childRect = getRect(childEle)
       const { left, height, top, width } = childRect
       const { x, y } = getOffset(childEle)
+      const posLine = getPosLine(childRect, lineState.configure)
       Object.assign(lineState, {
         width: width * scale,
         height: height * scale,
         top: top * scale + y - siteCanvasRect.y,
         left: left * scale + x - siteCanvasRect.x,
-        position: canvasState.type === 'absolute' || getPosLine(childRect, lineState.configure).type
+        position: canvasState.type === 'absolute' || posLine.type,
+        forbid: posLine.forbid
       })
     } else {
+      const posLine = getPosLine(rect, configure)
       Object.assign(lineState, {
         width: width * scale,
         height: height * scale,
         top: top * scale + y - siteCanvasRect.y,
         left: left * scale + x - siteCanvasRect.x,
-        position: canvasState.type === 'absolute' || getPosLine(rect, configure).type
+        position: canvasState.type === 'absolute' || posLine.type,
+        forbid: posLine.forbid
       })
     }
 
@@ -670,13 +701,12 @@ export const copyNode = (id) => {
 
 export const onMouseUp = () => {
   const { draging, data } = dragState
-  const { position } = lineState
+  const { position, forbid } = lineState
   const absolute = canvasState.type === 'absolute'
   const sourceId = data?.id
   const lineId = lineState.id
-  const allowInsert = position !== POSITION.FORBID
 
-  if (draging && allowInsert) {
+  if (draging && !forbid) {
     const { parent, node } = getNode(lineId, true) || {} // target
     const targetNode = { parent, node, data: toRaw(data) }
 

--- a/packages/theme/dark/canvas.less
+++ b/packages/theme/dark/canvas.less
@@ -1,7 +1,8 @@
 #canvas-wrap {
   --ti-lowcode-canvas-rect-border-color: var(--ti-lowcode-base-primary-color-2);
   --ti-lowcode-canvas-hover-line-in-bg-color: rgba(0, 255, 0, 0.1);
-  --ti-lowcode-canvas-hover-line-forbid-bg-color: rgb(255, 66, 77);
+  --ti-lowcode-canvas-hover-line-forbid-bg-color: var(--ti-lowcode-base-error-color);
+  --ti-lowcode-canvas-hover-line-in-forbid-bg-color: rgba(242, 48, 48, 0.3);
   --ti-lowcode-canvas-choose-slot-border-color: var(--ti-lowcode-base-text-color-2);
   --ti-lowcode-canvas-choose-slot-color: var(--ti-lowcode-base-text-color-2);
   --ti-lowcode-canvas-corner-mark-left-color: var(--ti-lowcode-base-text-color-2);

--- a/packages/theme/light/canvas.less
+++ b/packages/theme/light/canvas.less
@@ -1,7 +1,8 @@
 #canvas-wrap {
   --ti-lowcode-canvas-rect-border-color: var(--ti-lowcode-base-primary-color-2);
   --ti-lowcode-canvas-hover-line-in-bg-color: rgba(0, 255, 0, 0.1);
-  --ti-lowcode-canvas-hover-line-forbid-bg-color: rgb(255, 66, 77);
+  --ti-lowcode-canvas-hover-line-forbid-bg-color: var(--ti-lowcode-base-error-color);
+  --ti-lowcode-canvas-hover-line-in-forbid-bg-color: rgba(242, 48, 48, 0.3);
   --ti-lowcode-canvas-choose-slot-border-color: var(--ti-lowcode-base-text-color-2);
   --ti-lowcode-canvas-choose-slot-color: var(--ti-lowcode-base-text-color-2);
   --ti-lowcode-canvas-corner-mark-left-color: var(--ti-lowcode-base-text-color-2);


### PR DESCRIPTION
[English](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE.md) | 简体中文

# PR

## PR Checklist

请检查您的 PR 是否满足以下要求：

- [x] commit message遵循我们的[提交贡献指南](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] 添加了更改内容的测试用例（用于bugfix/功能）
- [ ] 文档已添加/更新（用于bugfix/功能）
- [ ] 是否构建了自己的设计器，经过了充分的自验证

## PR 类型

这个PR的类型是？

- [x] 日常 bug 修复
- [ ] 新特性支持
- [ ] 代码风格优化
- [ ] 重构
- [ ] 构建优化
- [ ] 测试用例
- [ ] 文档更新
- [ ] 分支合并
- [ ] 其他改动（请补充）


## 需求背景和解决方案

背景：在画布中拖拽节点，这个组件包含子节点，如果拖拽到了自身的内部，被拖拽的节点会消失
方案：拖拽松开后，会进行交换节点的操作，具体逻辑是先在组件树上删除被拖拽的节点（这一步会出现bug），然后插入到放下的节点。即使是交换流程，改成先插入再删除，最终也会删除被拖拽的节点。问题不是交换节点的逻辑导致的，需要增加一个禁止交换节点的判断。如果被拖拽的节点是放置的节点的祖先节点，则禁止插入

Issue Number: #344  

### 修改前
![drag-nested-1](https://github.com/opentiny/tiny-engine/assets/26267243/52f94713-121d-47a2-a24c-9181cefb8e6c)

### 修改后
![drag-nested-2](https://github.com/opentiny/tiny-engine/assets/26267243/bfb274a2-6d10-4f28-b3b7-8201f66d1d4d)

## 此PR是否含有 breaking change?

- [ ] 是
- [x] 否

<!-- 如果此 PR 包含breaking change，请在下面从用户角度描述具体变化和其他风险。-->

## Other information