### PR TITLE
fix(controller-environment): preserve import.meta.env variable when b…

### DIFF
--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -15,7 +15,7 @@
   ],
   "exports": {
     ".": "./dist/index.js",
-    "./js/": "./js/",
+    "./js/": "./dist/js/",
     "./utils": "./dist/utils.js",
     "./adapter": "./dist/adapter.js"
   },
@@ -36,8 +36,8 @@
     "@babel/traverse": "7.18.13",
     "@opentiny/tiny-engine-builtin-component": "workspace:*",
     "@opentiny/tiny-engine-http": "workspace:*",
-    "@opentiny/tiny-engine-utils": "workspace:*",
     "@opentiny/tiny-engine-i18n-host": "workspace:*",
+    "@opentiny/tiny-engine-utils": "workspace:*",
     "@opentiny/vue": "~3.10.0",
     "@opentiny/vue-locale": "~3.10.0",
     "@opentiny/vue-renderless": "~3.10.0",
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.2.3",
     "@vitejs/plugin-vue-jsx": "^3.1.0",
+    "glob": "^10.3.4",
     "vite": "^4.3.7"
   },
   "peerDependencies": {

--- a/packages/controller/vite.config.js
+++ b/packages/controller/vite.config.js
@@ -14,6 +14,12 @@ import { defineConfig } from 'vite'
 import path from 'path'
 import vue from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'
+import { glob } from 'glob'
+import { fileURLToPath } from 'node:url'
+
+const jsEntries = glob.sync('./js/**.js').map((file) => {
+  return [file.slice(0, file.length - path.extname(file).length), fileURLToPath(new URL(file, import.meta.url))]
+})
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -21,7 +27,8 @@ export default defineConfig({
   publicDir: false,
   resolve: {},
   define: {
-    'process.env': {}
+    'process.env': {},
+    'import.meta': 'import.meta'
   },
   build: {
     cssCodeSplit: false,
@@ -29,14 +36,15 @@ export default defineConfig({
       entry: {
         index: path.resolve(__dirname, './src/index.js'),
         adapter: path.resolve(__dirname, './adapter.js'),
-        utils: path.resolve(__dirname, './utils.js')
+        utils: path.resolve(__dirname, './utils.js'),
+        ...Object.fromEntries(jsEntries)
       },
       name: 'controller',
       fileName: (formats, entryName) => `${entryName}.js`,
       formats: ['es']
     },
     rollupOptions: {
-      external: ['vue', /@opentiny\/tiny-engine.*/, /@opentiny\/vue.*/, /^prettier.*/]
+      external: ['vue', 'vue-i18n', /@opentiny\/tiny-engine.*/, /@opentiny\/vue.*/, /^prettier.*/, /^@babel.*/]
     }
   }
 })


### PR DESCRIPTION
…uild controller lib

English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?
controller/js 在 design-core 编译的时候才会编译，会导致在 js 中 import 引入的 controller 存在两份实例（一份是在编译 controller 时的实例，一份是编译 js 下面的文件时重新生成的实例），导致 js下面文件的状态判断不正确。

例如：packages/controller/js/canvas.js 中，存在对 userInfo 信息的判断。
![image](https://github.com/opentiny/tiny-engine/assets/26962197/15fb6c9f-6a11-4c4e-aaf3-921a896cff3f)

但是此时得到的 userInfo 的信息永远为空，因为这里得到的实例与 在 packages/design-core/src/App.vue  中获取 userInfo，然后存储 userInfo 得到的实例不一致。

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #348 #235

### What is the new behavior?
构建 controller 的时候，同时构建  js/xx 的文件，但是保留 `import.meta.xxx` 环境变量。

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
