### PR TITLE
fix: import fs-extra error in module project

### DIFF
--- a/packages/design-core/scripts/localCdnFile/copyBundleDeps.js
+++ b/packages/design-core/scripts/localCdnFile/copyBundleDeps.js
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { readJsonSync } from 'fs-extra'
+import fs from 'fs-extra'
 import { installPackageTemporary } from '../vite-plugins/installPackageTemporary'
 import { configServerAddProxy } from '../vite-plugins/configureServerAddProxy'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
@@ -9,6 +9,8 @@ import {
   dedupeCopyFiles,
   copyfileToDynamicSrcMapper
 } from './locateCdnNpmInfo'
+
+const { readJsonSync } = fs
 
 export function extraBundleCdnLink(filename, originCdnPrefix) {
   const result = []

--- a/packages/design-core/scripts/localCdnFile/copyPreviewImportMap.js
+++ b/packages/design-core/scripts/localCdnFile/copyPreviewImportMap.js
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { readJsonSync } from 'fs-extra'
+import fs from 'fs-extra'
 import {
   getPackageNeedToInstallAndFilesUsingSameVersion,
   copyfileToDynamicSrcMapper,
@@ -9,6 +9,8 @@ import {
 } from './locateCdnNpmInfo'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 import { installPackageTemporary } from '../vite-plugins/installPackageTemporary'
+
+const { readJsonSync } = fs
 
 export function extraPreviewImport(filename, originCdnPrefix) {
   const result = []

--- a/packages/design-core/scripts/localCdnFile/locateCdnNpmInfo.js
+++ b/packages/design-core/scripts/localCdnFile/locateCdnNpmInfo.js
@@ -1,9 +1,10 @@
 import path from 'node:path'
-import fs from 'node:fs'
+import fs from 'fs-extra'
 import fg from 'fast-glob'
 import { normalizePath } from 'vite'
-import { readJsonSync } from 'fs-extra'
 import { babelReplaceImportPathWithCertainFileName } from './replaceImportPath.mjs'
+
+const { readJsonSync } = fs
 
 function transform(content, filename) {
   if (filename.endsWith('.js')) {


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
启动时报错：
![image](https://github.com/opentiny/tiny-engine/assets/18585869/1087ca01-f926-4865-9405-71812866c417)
在esmodule项目中，fs-extra是commonjs模块，不支持import { readJsonSync } from 'fs-extra'这种写法, 需要改为使用引入默认导出。
Issue Number: N/A

### What is the new behavior?
启动正常
![image](https://github.com/opentiny/tiny-engine/assets/18585869/fef17ebc-2dc8-404c-a4b8-0f651490d14a)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified and standardized import statements for better consistency and maintainability.
  - Replaced `fs-extra` with `fs` for JSON reading operations in several scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->