### PR TITLE
fix: cycle deps between vue-generator and common pacakge

### DIFF
--- a/packages/common/composable/generateCode/index.js
+++ b/packages/common/composable/generateCode/index.js
@@ -1,8 +1,19 @@
 import { generateApp, parseRequiredBlocks, genSFCWithDefaultPlugin } from '@opentiny/tiny-engine-dsl-vue'
+import defaultPrettierConfig from '../../js/config-files/prettierrc'
+
+// 应用出码默认配置
+const defaultOptions = {
+  pluginConfig: {
+    formatCode: {
+      // 默认格式化配置
+      ...defaultPrettierConfig
+    }
+  }
+}
 
 // 应用出码
 const generateAppCode = async (appSchema, options = {}) => {
-  const instance = generateApp(options)
+  const instance = generateApp({ ...defaultOptions, ...options })
 
   return instance.generate(appSchema)
 }

--- a/packages/vue-generator/package.json
+++ b/packages/vue-generator/package.json
@@ -30,7 +30,6 @@
   "license": "MIT",
   "homepage": "https://opentiny.design/tiny-engine",
   "dependencies": {
-    "@opentiny/tiny-engine-common": "workspace:*",
     "@opentiny/tiny-engine-builtin-component": "workspace:*",
     "@vue/compiler-sfc": "3.2.45",
     "@vue/shared": "^3.3.4",

--- a/packages/vue-generator/src/utils/index.js
+++ b/packages/vue-generator/src/utils/index.js
@@ -13,7 +13,6 @@
 import { capitalize, hyphenate } from '@vue/shared'
 import { tinyIcon as unifyIconName } from '../pre-processor'
 import { TINY_ICON, JS_FUNCTION } from '../constant'
-import prettierConfig from '@opentiny/tiny-engine-common/js/config-files/prettierrc'
 
 const getTypeOfSchema = (schema) => schema.componentName
 
@@ -70,7 +69,14 @@ const lowerFirst = (str) => str[0].toLowerCase() + str.slice(1)
  */
 const toPascalCase = (input, delimiter = '-') => input.split(delimiter).map(capitalize).join('')
 
-const commonOpts = prettierConfig
+const commonOpts = {
+  semi: false,
+  singleQuote: true,
+  printWidth: 120,
+  trailingComma: 'none',
+  endOfLine: 'auto',
+  tabWidth: 2
+}
 const prettierOpts = {
   vue: { ...commonOpts, parser: 'vue', htmlWhitespaceSensitivity: 'ignore' },
   js: { ...commonOpts, parser: 'typescript' }


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new default configuration for code generation to simplify the setup process.

- **Refactor**
  - Updated `generateAppCode` function to merge user options with default settings.

- **Chores**
  - Removed unused dependency on `@opentiny/tiny-engine-common` to streamline package management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->