### PR TITLE
feat: tinyvue grid slot generate code to template

### DIFF
--- a/designer-demo/public/mock/bundle.json
+++ b/designer-demo/public/mock/bundle.json
@@ -10153,6 +10153,54 @@
           }
         },
         {
+          "icon": "grid",
+          "name": {
+            "zh_CN": "表格行"
+          },
+          "component": "TinyGridColumn",
+          "description": "提供了非常强大数据表格功能，可以展示数据列表，可以对数据列表进行选择、编辑等",
+          "docUrl": "",
+          "screenshot": "",
+          "tags": "",
+          "keywords": "",
+          "devMode": "proCode",
+          "npm": {
+            "package": "@opentiny/vue",
+            "exportName": "TinyGridColumn"
+          },
+          "group": "component",
+          "priority": 2,
+          "schema": {
+            "properties": [],
+            "events": {},
+            "shortcuts": {},
+            "contentMenu": {
+              "actions": ["create symbol"]
+            }
+          },
+          "configure": {
+            "loop": true,
+            "condition": true,
+            "styles": true,
+            "isContainer": false,
+            "isModal": false,
+            "nestingRule": {
+              "childWhitelist": "",
+              "parentWhitelist": "",
+              "descendantBlacklist": "",
+              "ancestorWhitelist": ""
+            },
+            "isNullNode": false,
+            "isLayout": false,
+            "rootSelector": "",
+            "shortcuts": {},
+            "contextMenu": {
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
+            }
+          }
+        },
+        {
           "name": {
             "zh_CN": "分页"
           },

--- a/mockServer/src/assets/json/appinfo.json
+++ b/mockServer/src/assets/json/appinfo.json
@@ -26957,6 +26957,54 @@
         }
       },
       {
+        "icon": "grid",
+        "name": {
+          "zh_CN": "表格行"
+        },
+        "component": "TinyGridColumn",
+        "description": "提供了非常强大数据表格功能，可以展示数据列表，可以对数据列表进行选择、编辑等",
+        "docUrl": "",
+        "screenshot": "",
+        "tags": "",
+        "keywords": "",
+        "devMode": "proCode",
+        "npm": {
+          "package": "@opentiny/vue",
+          "exportName": "TinyGridColumn"
+        },
+        "group": "component",
+        "priority": 2,
+        "schema": {
+          "properties": [],
+          "events": {},
+          "shortcuts": {},
+          "contentMenu": {
+            "actions": ["create symbol"]
+          }
+        },
+        "configure": {
+          "loop": true,
+          "condition": true,
+          "styles": true,
+          "isContainer": false,
+          "isModal": false,
+          "nestingRule": {
+            "childWhitelist": "",
+            "parentWhitelist": "",
+            "descendantBlacklist": "",
+            "ancestorWhitelist": ""
+          },
+          "isNullNode": false,
+          "isLayout": false,
+          "rootSelector": "",
+          "shortcuts": {},
+          "contextMenu": {
+            "actions": ["create symbol"],
+            "disable": ["copy", "remove"]
+          }
+        }
+      },
+      {
         "name": {
           "zh_CN": "分页"
         },

--- a/mockServer/src/mock/get/app-center/v1/apps/schema/918.json
+++ b/mockServer/src/mock/get/app-center/v1/apps/schema/918.json
@@ -1905,6 +1905,13 @@
         "version": "0.1.16"
       },
       {
+        "componentName": "TinyGridColumn",
+        "package": "@opentiny/vue",
+        "exportName": "TinyGridColumn",
+        "destructuring": true,
+        "version": "0.1.16"
+      },
+      {
         "componentName": "TinyNumeric",
         "package": "@opentiny/vue",
         "exportName": "Numeric",

--- a/packages/engine-cli/template/designer/public/mock/bundle.json
+++ b/packages/engine-cli/template/designer/public/mock/bundle.json
@@ -10153,6 +10153,54 @@
           }
         },
         {
+          "icon": "grid",
+          "name": {
+            "zh_CN": "表格行"
+          },
+          "component": "TinyGridColumn",
+          "description": "提供了非常强大数据表格功能，可以展示数据列表，可以对数据列表进行选择、编辑等",
+          "docUrl": "",
+          "screenshot": "",
+          "tags": "",
+          "keywords": "",
+          "devMode": "proCode",
+          "npm": {
+            "package": "@opentiny/vue",
+            "exportName": "TinyGridColumn"
+          },
+          "group": "component",
+          "priority": 2,
+          "schema": {
+            "properties": [],
+            "events": {},
+            "shortcuts": {},
+            "contentMenu": {
+              "actions": ["create symbol"]
+            }
+          },
+          "configure": {
+            "loop": true,
+            "condition": true,
+            "styles": true,
+            "isContainer": false,
+            "isModal": false,
+            "nestingRule": {
+              "childWhitelist": "",
+              "parentWhitelist": "",
+              "descendantBlacklist": "",
+              "ancestorWhitelist": ""
+            },
+            "isNullNode": false,
+            "isLayout": false,
+            "rootSelector": "",
+            "shortcuts": {},
+            "contextMenu": {
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
+            }
+          }
+        },
+        {
           "name": {
             "zh_CN": "分页"
           },

--- a/packages/vue-generator/src/generator/vue/sfc/genSetupSFC.js
+++ b/packages/vue-generator/src/generator/vue/sfc/genSetupSFC.js
@@ -216,11 +216,10 @@ const generateSFCFile = (schema, componentsMap, config = {}, nextPage) => {
 
 export const genSFCWithDefaultPlugin = (schema, componentsMap, config = {}, nextPage) => {
   const { templateItemValidate = [], genTemplate = [], parseScript = [], genScript = {} } = config.hooks || {}
-  const defaultComponentHooks = [handleComponentNameHook, handleTinyIcon]
+  const defaultComponentHooks = [handleComponentNameHook, handleTinyIcon, handleTinyGrid]
 
   const defaultAttributeHook = [
     handleSlotParams,
-    handleTinyGrid,
     handleJsxModelValueUpdate,
     handleConditionAttrHook,
     handleLoopAttrHook,

--- a/packages/vue-generator/src/generator/vue/sfc/generateTemplate.js
+++ b/packages/vue-generator/src/generator/vue/sfc/generateTemplate.js
@@ -10,6 +10,7 @@ import {
 import { generateTag, HTML_DEFAULT_VOID_ELEMENTS } from './generateTag'
 import { specialTypeHandler } from './generateAttribute'
 import { thisPropsBindRe, thisRegexp } from '@/utils'
+import { getImportMap } from './parseImport'
 
 export const handleComponentNameHook = (optionData) => {
   const { componentName, schema } = optionData
@@ -66,37 +67,60 @@ export const handleTinyIcon = (nameObj, globalHooks) => {
   delete nameObj.schema.props.name
 }
 
-const handleTinyGridSlots = (value, globalHooks, config) => {
-  if (!Array.isArray(value)) {
+const transformSlots = (slots) => {
+  if (!slots || typeof slots !== 'object') {
+    return []
+  }
+
+  const res = Object.entries(slots).map(([key, value]) => {
+    return {
+      componentName: 'template',
+      props: {
+        slot: {
+          name: key,
+          params: value?.params || ''
+        }
+      },
+      children: value?.value
+    }
+  })
+
+  return res
+}
+
+const transformColumnToChildren = (columns) => {
+  if (!Array.isArray(columns)) {
     return
   }
 
-  value.forEach((slotItem) => {
-    const name = slotItem.componentName
+  const res = columns.map((item) => {
+    const { slots, ...restItem } = item
 
-    if (!name) {
-      return
+    let children = []
+
+    if (slots) {
+      children = transformSlots(slots)
     }
 
-    if (slotItem.componentType === 'Block') {
-      const importPath = `${config.blockRelativePath}${name}${config.blockSuffix}`
-
-      globalHooks.addImport(importPath, {
-        exportName: name,
-        componentName: name,
-        package: importPath
-      })
-    } else if (name?.startsWith?.('Tiny')) {
-      globalHooks.addImport('@opentiny/vue', {
-        destructuring: true,
-        exportName: name.slice(4),
-        componentName: name,
-        package: '@opentiny/vue'
-      })
+    return {
+      componentName: 'TinyGridColumn',
+      props: restItem,
+      children
     }
-
-    handleTinyGridSlots(slotItem.children, globalHooks, config)
   })
+
+  return res
+}
+
+// 检测 tinyGrid 表格列是否有插槽配置
+const columnHasSlots = (columns) => {
+  for (const columnItem of columns) {
+    if (columnItem.slots && typeof columnItem.slots === 'object' && Object.keys(columnItem.slots).length > 0) {
+      return true
+    }
+  }
+
+  return false
 }
 
 export const handleTinyGrid = (schemaData, globalHooks, config) => {
@@ -129,11 +153,26 @@ export const handleTinyGrid = (schemaData, globalHooks, config) => {
         value: name
       }
     }
-
-    if (typeof item.slots === 'object') {
-      Object.values(item.slots).forEach((slotItem) => handleTinyGridSlots(slotItem?.value, globalHooks, config))
-    }
   })
+
+  const hasSlots = columnHasSlots(props.columns)
+
+  // 存在 slots，将表格列转化成 children 的配置
+  if (hasSlots) {
+    schemaData.schema.children = schemaData.schema.children || []
+    schemaData.schema.children.push(...transformColumnToChildren(props.columns))
+
+    // 解析 slot 中的 依赖
+    const { pkgMap = {}, blockPkgMap = {} } = getImportMap(schemaData.schema, config.componentsMap, config)
+
+    Object.entries({ ...pkgMap, ...blockPkgMap }).forEach(([key, value]) => {
+      value.forEach((valueItem) => {
+        globalHooks.addImport(key, valueItem)
+      })
+    })
+
+    delete props.columns
+  }
 }
 
 /**

--- a/packages/vue-generator/test/testcases/sfc/case01/componentsMap.json
+++ b/packages/vue-generator/test/testcases/sfc/case01/componentsMap.json
@@ -28,6 +28,13 @@
     "destructuring": true
   },
   {
+    "componentName": "TinyGridColumn",
+    "exportName": "GridColumn",
+    "package": "@opentiny/vue",
+    "version": "^3.10.0",
+    "destructuring": true
+  },
+  {
     "componentName": "TinyInput",
     "exportName": "Input",
     "package": "@opentiny/vue",

--- a/packages/vue-generator/test/testcases/sfc/case01/expected/FormTable.vue
+++ b/packages/vue-generator/test/testcases/sfc/case01/expected/FormTable.vue
@@ -38,7 +38,26 @@
       <tiny-grid :columns="state.columns" :fetchData="{ api: getTableData }"></tiny-grid>
     </div>
     <div dataSource="a5f6ef4f">
-      <tiny-grid :fetchData="{ api: getTableData }" :columns="state.columns6cio"></tiny-grid>
+      <tiny-grid :fetchData="{ api: getTableData }">
+        <tiny-grid-column type="index" :width="60" title=""></tiny-grid-column>
+        <tiny-grid-column type="selection" :width="60"></tiny-grid-column>
+        <tiny-grid-column field="employees" title="员工数">
+          <template #default="{ row, rowIndex }"> <tiny-input></tiny-input></template
+        ></tiny-grid-column>
+        <tiny-grid-column field="city" title="城市"></tiny-grid-column>
+        <tiny-grid-column title="产品">
+          <template #default="{ row }">
+            <div>
+              <tiny-switch modelValue=""></tiny-switch></div></template
+        ></tiny-grid-column>
+        <tiny-grid-column title="操作">
+          <template #default="">
+            <tiny-button
+              text="删除"
+              :icon="TinyIconDel"
+              @click="(...eventArgs) => emit(eventArgs, row)"
+            ></tiny-button></template></tiny-grid-column
+      ></tiny-grid>
     </div>
     <div :style="{ width: props.quotePopWidth }">循环渲染：</div>
     <tiny-icon-help-circle v-if="false"></tiny-icon-help-circle>
@@ -72,6 +91,7 @@ import {
   Grid as TinyGrid,
   Input as TinyInput,
   Select as TinySelect,
+  GridColumn as TinyGridColumn,
   Switch as TinySwitch
 } from '@opentiny/vue'
 import { IconSearch, IconDel, iconHelpCircle, IconEdit } from '@opentiny/vue-icon'
@@ -97,30 +117,6 @@ const { utils } = wrap(function () {
   return this
 })()
 const state = vue.reactive({
-  columns6cio: [
-    { type: 'index', width: 60, title: '' },
-    { type: 'selection', width: 60 },
-    { field: 'employees', title: '员工数', slots: { default: ({ row, rowIndex }, h) => <TinyInput></TinyInput> } },
-    { field: 'city', title: '城市' },
-    {
-      title: '产品',
-      slots: {
-        default: ({ row }, h) => (
-          <div>
-            <TinySwitch modelValue=""></TinySwitch>
-          </div>
-        )
-      }
-    },
-    {
-      title: '操作',
-      slots: {
-        default: ({ row }, h) => (
-          <TinyButton text="删除" icon={TinyIconDel} onClick={(...eventArgs) => emit(eventArgs, row)}></TinyButton>
-        )
-      }
-    }
-  ],
   IconPlusSquare: utils.IconPlusSquare(),
   theme: "{   'id': 22,   'name': '@cloud/tinybuilder-theme-dark',   'description': '黑暗主题' }",
   companyName: '',

--- a/packages/vue-generator/test/testcases/sfc/slotModelValue/expected/slotModelValueTest.vue
+++ b/packages/vue-generator/test/testcases/sfc/slotModelValue/expected/slotModelValueTest.vue
@@ -2,8 +2,8 @@
   <div>
     <div>
       <tiny-grid
-        :editConfig="{ trigger: 'click', mode: 'cell', showStatus: true }"
         :columns="state.columns"
+        :editConfig="{ trigger: 'click', mode: 'cell', showStatus: true }"
         :data="[
           {
             id: '1',

--- a/packages/vue-generator/test/testcases/sfc/slotModelValue/page.schema.json
+++ b/packages/vue-generator/test/testcases/sfc/slotModelValue/page.schema.json
@@ -1,5 +1,93 @@
 {
-  "state": {},
+  "state": {
+    "columns": [
+      {
+        "type": "index",
+        "width": 60
+      },
+      {
+        "type": "selection",
+        "width": 60
+      },
+      {
+        "field": "employees",
+        "title": "员工数",
+        "slots": {
+          "default": {
+            "type": "JSSlot",
+            "value": [
+              {
+                "componentName": "div",
+                "id": "44523622",
+                "children": [
+                  {
+                    "componentName": "TinyNumeric",
+                    "props": {
+                      "allow-empty": true,
+                      "placeholder": "请输入",
+                      "controlsPosition": "right",
+                      "step": 1,
+                      "modelValue": {
+                        "type": "JSExpression",
+                        "value": "row.employees",
+                        "model": true
+                      },
+                      "onChange": {
+                        "type": "JSExpression",
+                        "value": "this.onChangeNumber",
+                        "params": ["row", "column", "rowIndex"]
+                      }
+                    },
+                    "id": "62166343"
+                  }
+                ]
+              }
+            ],
+            "params": ["row", "column", "rowIndex"]
+          }
+        }
+      },
+      {
+        "field": "created_date",
+        "title": "创建日期"
+      },
+      {
+        "field": "city",
+        "title": "城市",
+        "slots": {
+          "default": {
+            "type": "JSSlot",
+            "value": [
+              {
+                "componentName": "div",
+                "id": "66326314",
+                "children": [
+                  {
+                    "componentName": "TinyInput",
+                    "props": {
+                      "placeholder": "请输入",
+                      "modelValue": {
+                        "type": "JSExpression",
+                        "value": "row.city",
+                        "model": true
+                      },
+                      "onChange": {
+                        "type": "JSExpression",
+                        "value": "this.onChangeInput",
+                        "params": ["row", "column", "rowIndex"]
+                      }
+                    },
+                    "id": "22396a2a"
+                  }
+                ]
+              }
+            ],
+            "params": ["row", "column", "rowIndex"]
+          }
+        }
+      }
+    ]
+  },
   "methods": {
     "onChangeInput": {
       "type": "JSFunction",
@@ -28,93 +116,10 @@
               "mode": "cell",
               "showStatus": true
             },
-            "columns": [
-              {
-                "type": "index",
-                "width": 60
-              },
-              {
-                "type": "selection",
-                "width": 60
-              },
-              {
-                "field": "employees",
-                "title": "员工数",
-                "slots": {
-                  "default": {
-                    "type": "JSSlot",
-                    "value": [
-                      {
-                        "componentName": "div",
-                        "id": "44523622",
-                        "children": [
-                          {
-                            "componentName": "TinyNumeric",
-                            "props": {
-                              "allow-empty": true,
-                              "placeholder": "请输入",
-                              "controlsPosition": "right",
-                              "step": 1,
-                              "modelValue": {
-                                "type": "JSExpression",
-                                "value": "row.employees",
-                                "model": true
-                              },
-                              "onChange": {
-                                "type": "JSExpression",
-                                "value": "this.onChangeNumber",
-                                "params": ["row", "column", "rowIndex"]
-                              }
-                            },
-                            "id": "62166343"
-                          }
-                        ]
-                      }
-                    ],
-                    "params": ["row", "column", "rowIndex"]
-                  }
-                }
-              },
-              {
-                "field": "created_date",
-                "title": "创建日期"
-              },
-              {
-                "field": "city",
-                "title": "城市",
-                "slots": {
-                  "default": {
-                    "type": "JSSlot",
-                    "value": [
-                      {
-                        "componentName": "div",
-                        "id": "66326314",
-                        "children": [
-                          {
-                            "componentName": "TinyInput",
-                            "props": {
-                              "placeholder": "请输入",
-                              "modelValue": {
-                                "type": "JSExpression",
-                                "value": "row.city",
-                                "model": true
-                              },
-                              "onChange": {
-                                "type": "JSExpression",
-                                "value": "this.onChangeInput",
-                                "params": ["row", "column", "rowIndex"]
-                              }
-                            },
-                            "id": "22396a2a"
-                          }
-                        ]
-                      }
-                    ],
-                    "params": ["row", "column", "rowIndex"]
-                  }
-                }
-              }
-            ],
+            "columns": {
+              "type": "JSExpression",
+              "value": "state.columns"
+            },
             "data": [
               {
                 "id": "1",


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

【问题描述】
如  issue #754  所描述，当表格组件使用插槽并为插槽里面的组件添加样式时，页面预览以及下载代码后，为插槽里面的组件添加的样式无法生效。

【问题分析】
vue setup 中的 jsx，无法自动添加 scoped id，但是添加的样式却是默认是 scoped id 的。导致样式无法应用。

【解决方案】
 tinyvue grid 组件有插槽时，不直接在 setup 组件中生成 jsx，而是将表格列配置作为 tiny-grid-column 生成到 template 中。


即从生成 jsx ：
```vue
<template>
	<tiny-grid  :fetchData={ api: fetchData }  :columns="state.columns">
   </tiny-grid>
</template>
<script setup>
	const state = reactive({
        columns: [
        {
            field: 'city',
            slots: {
              default: ({ row }, h) => (
                //  这里的样式类不生效
                 <div  className="test-class">
                      { row.city }
                  </div>
              )
            }
         }
       ]
    })
</script>
<style scoped>
.test-class {
  color: red;
}
</style>
```


改成生成代码为：
```vue
<template>
	<tiny-grid  :fetchData={ api: fetchData } >
      <tiny-grid-column field="city">
          <template #default="{ row }">
              <div class="test-class">{{ row.city }}</div>
          </template>
     </tiny-grid-column>
   </tiny-grid>
</template>
<script setup>

</script>
<style scoped>
.test-class {
  color: red;
}
</style>
```


### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #754

### What is the new behavior?


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features  
  - Introduced a dedicated grid column component that enables a more modular and customizable table layout.  
  - Enhanced grid configurations to support explicit, interactive column definitions for data presentation.  

- Refactor  
  - Streamlined the grid template and mapping logic, offering improved clarity and dynamic configuration for a refined user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->