### PR TITLE
fix: mixed lifeCyclesContent when empty lifecycles

### DIFF
--- a/packages/common/component/LifeCycles.vue
+++ b/packages/common/component/LifeCycles.vue
@@ -129,7 +129,7 @@ export default {
     })
 
     watchEffect(() => {
-      state.bindLifeCycles = props.bindLifeCycles || useCanvas().canvasApi.value?.getSchema()?.lifeCycles || {}
+      state.bindLifeCycles = props.bindLifeCycles || {}
     })
 
     const searchLifeCyclesList = (value) => {


### PR DESCRIPTION
# 修复生命周期为空时，取当前页面schema生命周期值的 bug

English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?

打开页面设置，如果：
1. 当前设置页面与当前编辑页面（画布编辑的页面）不一致
2. 当前设置的页面生命周期为空

则当前设置的页面声明周期会取当前编辑页面生命周期的值

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #806

### What is the new behavior?

当前设置的页面声明周期不取当前编辑页面生命周期的值，保持为空


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
