### PR TITLE
fix: blockName regexp incorrect

### DIFF
--- a/packages/controller/js/verification.js
+++ b/packages/controller/js/verification.js
@@ -1,20 +1,20 @@
 /**
-* Copyright (c) 2023 - present TinyEngine Authors.
-* Copyright (c) 2023 - present Huawei Cloud Computing Technologies Co., Ltd.
-*
-* Use of this source code is governed by an MIT-style license.
-*
-* THE OPEN SOURCE SOFTWARE IN THIS PRODUCT IS DISTRIBUTED IN THE HOPE THAT IT WILL BE USEFUL,
-* BUT WITHOUT ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS FOR
-* A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
-*
-*/
+ * Copyright (c) 2023 - present TinyEngine Authors.
+ * Copyright (c) 2023 - present Huawei Cloud Computing Technologies Co., Ltd.
+ *
+ * Use of this source code is governed by an MIT-style license.
+ *
+ * THE OPEN SOURCE SOFTWARE IN THIS PRODUCT IS DISTRIBUTED IN THE HOPE THAT IT WILL BE USEFUL,
+ * BUT WITHOUT ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS FOR
+ * A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
+ *
+ */
 
 export const REGEXP_EVENT_NAME = /^[a-z]+([A-Z][a-z]*)*$/
 
 export const verifyEventName = (name) => REGEXP_EVENT_NAME.test(name)
 
-export const REGEXP_BLOCK_NAME = /^([A-Z][A-Za-z0-9]{2,})*?([A-Z][A-Za-z0-9]{2,})*?$/
+export const REGEXP_BLOCK_NAME = /^([A-Z][A-Za-z0-9]{1,}){2,}$/
 
 export const verifyBlockName = (string) => REGEXP_BLOCK_NAME.test(string)
 

--- a/packages/controller/js/verification.js
+++ b/packages/controller/js/verification.js
@@ -14,7 +14,7 @@ export const REGEXP_EVENT_NAME = /^[a-z]+([A-Z][a-z]*)*$/
 
 export const verifyEventName = (name) => REGEXP_EVENT_NAME.test(name)
 
-export const REGEXP_BLOCK_NAME = /^([A-Z][A-Za-z0-9]{1,}){2,}$/
+export const REGEXP_BLOCK_NAME = /^[A-Z][A-Za-z0-9]+[A-Z][A-Za-z0-9]*$/
 
 export const verifyBlockName = (string) => REGEXP_BLOCK_NAME.test(string)
 

--- a/packages/controller/js/verification.js
+++ b/packages/controller/js/verification.js
@@ -14,7 +14,7 @@ export const REGEXP_EVENT_NAME = /^[a-z]+([A-Z][a-z]*)*$/
 
 export const verifyEventName = (name) => REGEXP_EVENT_NAME.test(name)
 
-export const REGEXP_BLOCK_NAME = /^[A-Z][A-Za-z0-9]*?[A-Z][A-Za-z0-9]*$/
+export const REGEXP_BLOCK_NAME = /^([A-Z][a-z0-9]*){2,}$/
 
 export const verifyBlockName = (string) => REGEXP_BLOCK_NAME.test(string)
 

--- a/packages/controller/js/verification.js
+++ b/packages/controller/js/verification.js
@@ -14,7 +14,7 @@ export const REGEXP_EVENT_NAME = /^[a-z]+([A-Z][a-z]*)*$/
 
 export const verifyEventName = (name) => REGEXP_EVENT_NAME.test(name)
 
-export const REGEXP_BLOCK_NAME = /^[A-Z][A-Za-z0-9]+[A-Z][A-Za-z0-9]*$/
+export const REGEXP_BLOCK_NAME = /^[A-Z][A-Za-z0-9]*?[A-Z][A-Za-z0-9]*$/
 
 export const verifyBlockName = (string) => REGEXP_BLOCK_NAME.test(string)
 


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

原来的正则：`/^([A-Z][A-Za-z0-9]{2,})*?([A-Z][A-Za-z0-9]{2,})*?$/`

该正则会导致问题

- 只有一个单词也能通过校验，比如：`Abb` 也能通过校验

Issue Number: N/A

### What is the new behavior?

新正则：`/^[A-Z][A-Za-z0-9]*?[A-Z][A-Za-z0-9]*$/`

与后端对齐，必须两个单词以上。即 `Abb` 无法通过校验。

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Updated validation criteria for block names, now requiring that block names start with an uppercase letter followed by at least one lowercase letter or digit, and must contain at least two such segments.

- **Bug Fixes**
	- Improved accuracy of block name validation to enhance user input reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->