### PR TITLE
fix: cli generate platform issue

### DIFF
--- a/packages/engine-cli/src/commands/create.js
+++ b/packages/engine-cli/src/commands/create.js
@@ -46,7 +46,7 @@ export function createPlatform(name, options = {}) {
   const pkgContent = generatePackageJson(name, mergedOptions, templatePath)
 
   fs.outputFileSync(path.resolve(destPath, 'engine.config.js'), configContent)
-  fs.outputJSONSync(path.resolve(destPath, 'package.json'), pkgContent)
+  fs.outputJSONSync(path.resolve(destPath, 'package.json'), pkgContent, { spaces: 2 })
 
   logger.log(
     chalk.green(`create finish, run the follow command to start project: \ncd ${name} && npm install && npm run dev`)

--- a/packages/engine-cli/template/designer/vite.config.js
+++ b/packages/engine-cli/template/designer/vite.config.js
@@ -7,7 +7,6 @@ export default defineConfig((configEnv) => {
     viteConfigEnv: configEnv,
     root: __dirname,
     iconDirs: [path.resolve(__dirname, './node_modules/@opentiny/tiny-engine/assets/')],
-    useSourceAlias: true,
     envDir: './env'
   })
 


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?

1. 修复生成的平台模板仍然使用 useResourceAlias 配置的 bug
2. 修复生成的 package.json 未格式化的 bug

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved JSON output readability for platform creation, making it easier to read the generated `package.json` file.

- **Bug Fixes**
  - Removed unnecessary configuration property to streamline the setup process for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->