### PR TITLE
feat: schemaDataAsync

### DIFF
--- a/designer-demo/public/mock/bundle.json
+++ b/designer-demo/public/mock/bundle.json
@@ -44,25 +44,13 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "type",
-                "size"
-              ]
+              "properties": ["type", "size"]
             },
             "contextMenu": {
-              "actions": [
-                "copy",
-                "remove",
-                "insert",
-                "updateAttr",
-                "bindEevent",
-                "createBlock"
-              ],
+              "actions": ["copy", "remove", "insert", "updateAttr", "bindEevent", "createBlock"],
               "disable": []
             },
-            "invalidity": [
-              ""
-            ],
+            "invalidity": [""],
             "clickCapture": true,
             "framework": "Vue"
           },
@@ -336,25 +324,13 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "type",
-                "size"
-              ]
+              "properties": ["type", "size"]
             },
             "contextMenu": {
-              "actions": [
-                "copy",
-                "remove",
-                "insert",
-                "updateAttr",
-                "bindEevent",
-                "createBlock"
-              ],
+              "actions": ["copy", "remove", "insert", "updateAttr", "bindEevent", "createBlock"],
               "disable": []
             },
-            "invalidity": [
-              ""
-            ],
+            "invalidity": [""],
             "clickCapture": true,
             "framework": "Vue"
           },
@@ -660,9 +636,7 @@
             "isModal": false,
             "isPopper": false,
             "nestingRule": {
-              "childWhitelist": [
-                "ElFormItem"
-              ],
+              "childWhitelist": ["ElFormItem"],
               "parentWhitelist": "",
               "descendantBlacklist": "",
               "ancestorWhitelist": ""
@@ -671,25 +645,13 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "inline",
-                "label-width"
-              ]
+              "properties": ["inline", "label-width"]
             },
             "contextMenu": {
-              "actions": [
-                "copy",
-                "remove",
-                "insert",
-                "updateAttr",
-                "bindEevent",
-                "createBlock"
-              ],
+              "actions": ["copy", "remove", "insert", "updateAttr", "bindEevent", "createBlock"],
               "disable": []
             },
-            "invalidity": [
-              ""
-            ],
+            "invalidity": [""],
             "clickCapture": true,
             "framework": "Vue"
           },
@@ -1138,25 +1100,13 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "inline",
-                "label-width"
-              ]
+              "properties": ["inline", "label-width"]
             },
             "contextMenu": {
-              "actions": [
-                "copy",
-                "remove",
-                "insert",
-                "updateAttr",
-                "bindEevent",
-                "createBlock"
-              ],
+              "actions": ["copy", "remove", "insert", "updateAttr", "bindEevent", "createBlock"],
               "disable": []
             },
-            "invalidity": [
-              ""
-            ],
+            "invalidity": [""],
             "clickCapture": true,
             "framework": "Vue"
           },
@@ -1490,9 +1440,7 @@
             "isModal": false,
             "isPopper": false,
             "nestingRule": {
-              "childWhitelist": [
-                "ElTableColumn"
-              ],
+              "childWhitelist": ["ElTableColumn"],
               "parentWhitelist": "",
               "descendantBlacklist": "",
               "ancestorWhitelist": ""
@@ -1501,25 +1449,13 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "inline",
-                "label-width"
-              ]
+              "properties": ["inline", "label-width"]
             },
             "contextMenu": {
-              "actions": [
-                "copy",
-                "remove",
-                "insert",
-                "updateAttr",
-                "bindEevent",
-                "createBlock"
-              ],
+              "actions": ["copy", "remove", "insert", "updateAttr", "bindEevent", "createBlock"],
               "disable": []
             },
-            "invalidity": [
-              ""
-            ],
+            "invalidity": [""],
             "clickCapture": true,
             "framework": "Vue"
           },
@@ -2750,25 +2686,13 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "inline",
-                "label-width"
-              ]
+              "properties": ["inline", "label-width"]
             },
             "contextMenu": {
-              "actions": [
-                "copy",
-                "remove",
-                "insert",
-                "updateAttr",
-                "bindEevent",
-                "createBlock"
-              ],
+              "actions": ["copy", "remove", "insert", "updateAttr", "bindEevent", "createBlock"],
               "disable": []
             },
-            "invalidity": [
-              ""
-            ],
+            "invalidity": [""],
             "clickCapture": true,
             "framework": "Vue"
           },
@@ -2914,19 +2838,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "disabled",
-                "size"
-              ]
+              "properties": ["disabled", "size"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -3243,9 +3159,7 @@
             "clickCapture": false,
             "isModal": false,
             "nestingRule": {
-              "childWhitelist": [
-                "TinyCarouselItem"
-              ],
+              "childWhitelist": ["TinyCarouselItem"],
               "parentWhitelist": "",
               "descendantBlacklist": "",
               "ancestorWhitelist": ""
@@ -3254,19 +3168,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "disabled",
-                "size"
-              ]
+              "properties": ["disabled", "size"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -3418,14 +3324,7 @@
           "name": {
             "zh_CN": "标题"
           },
-          "component": [
-            "h1",
-            "h2",
-            "h3",
-            "h4",
-            "h5",
-            "h6"
-          ],
+          "component": ["h1", "h2", "h3", "h4", "h5", "h6"],
           "icon": "h16",
           "description": "标题",
           "docUrl": "",
@@ -3510,19 +3409,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "disabled",
-                "size"
-              ]
+              "properties": ["disabled", "size"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -3879,19 +3770,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "disabled",
-                "size"
-              ]
+              "properties": ["disabled", "size"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -4137,9 +4020,7 @@
             ],
             "events": {},
             "shortcuts": {
-              "properties": [
-                "src"
-              ]
+              "properties": ["src"]
             },
             "contentMenu": {
               "actions": []
@@ -4789,19 +4670,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "disabled",
-                "size"
-              ]
+              "properties": ["disabled", "size"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -4947,19 +4820,118 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "label-width",
-                "disabled"
-              ]
+              "properties": ["label-width", "disabled"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
+            }
+          }
+        },
+        {
+          "icon": "row",
+          "name": {
+            "zh_CN": "row"
+          },
+          "component": "TinyLayout",
+          "description": "定义 Layout 的行配置信息",
+          "docUrl": "",
+          "screenshot": "",
+          "tags": "",
+          "keywords": "",
+          "devMode": "proCode",
+          "npm": {
+            "package": "@opentiny/vue",
+            "exportName": "Layout",
+            "version": "3.14.0",
+            "destructuring": true,
+            "script": "https://unpkg.com/@opentiny/vue@~3.14/runtime/tiny-vue.mjs",
+            "css": "https://unpkg.com/@opentiny/vue-theme@~3.14/index.css"
+          },
+          "group": "component",
+          "priority": 5,
+          "schema": {
+            "properties": [
+              {
+                "label": {
+                  "zh_CN": "基础信息"
+                },
+                "description": {
+                  "zh_CN": "基础信息"
+                },
+                "content": [
+                  {
+                    "property": "cols",
+                    "label": {
+                      "text": {
+                        "zh_CN": "总栅格数"
+                      }
+                    },
+                    "cols": 12,
+                    "widget": {
+                      "component": "ButtonGroupConfigurator",
+                      "props": {
+                        "options": [
+                          {
+                            "label": "12",
+                            "value": 12
+                          },
+                          {
+                            "label": "24",
+                            "value": 24
+                          }
+                        ]
+                      }
+                    },
+                    "description": {
+                      "zh_CN": "选择总栅格数"
+                    },
+                    "labelPosition": "none"
+                  },
+                  {
+                    "property": "tag",
+                    "label": {
+                      "text": {
+                        "zh_CN": "layout渲染的标签"
+                      }
+                    },
+                    "required": false,
+                    "readOnly": false,
+                    "disabled": false,
+                    "cols": 12,
+                    "widget": {
+                      "component": "InputConfigurator",
+                      "props": {}
+                    },
+                    "description": {
+                      "zh_CN": "定义Layout元素渲染后的标签，默认为 div"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "configure": {
+            "loop": true,
+            "condition": true,
+            "styles": true,
+            "isContainer": true,
+            "isModal": false,
+            "nestingRule": {
+              "childWhitelist": ["TinyRow", "TinyCol"],
+              "parentWhitelist": "",
+              "descendantBlacklist": "",
+              "ancestorWhitelist": ""
+            },
+            "isNullNode": false,
+            "isLayout": false,
+            "rootSelector": "",
+            "shortcuts": {
+              "properties": ["disabled"]
+            },
+            "contextMenu": {
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -5309,19 +5281,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "label-width",
-                "disabled"
-              ]
+              "properties": ["label-width", "disabled"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -5441,9 +5405,7 @@
             "isModal": false,
             "nestingRule": {
               "childWhitelist": "",
-              "parentWhitelist": [
-                "TinyForm"
-              ],
+              "parentWhitelist": ["TinyForm"],
               "descendantBlacklist": "",
               "ancestorWhitelist": ""
             },
@@ -5451,19 +5413,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "label",
-                "rules"
-              ]
+              "properties": ["label", "rules"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -5737,19 +5691,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "label",
-                "rules"
-              ]
+              "properties": ["label", "rules"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -6084,19 +6030,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "text",
-                "size"
-              ]
+              "properties": ["text", "size"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -6506,19 +6444,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "value",
-                "disabled"
-              ]
+              "properties": ["value", "disabled"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -6751,19 +6681,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "visible",
-                "width"
-              ]
+              "properties": ["visible", "width"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -7164,19 +7086,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "multiple",
-                "options"
-              ]
+              "properties": ["multiple", "options"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -7371,19 +7285,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "disabled",
-                "mini"
-              ]
+              "properties": ["disabled", "mini"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -7654,19 +7560,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "clearable",
-                "mini"
-              ]
+              "properties": ["clearable", "mini"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -7921,19 +7819,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "border",
-                "disabled"
-              ]
+              "properties": ["border", "disabled"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -8117,19 +8007,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "text",
-                "size"
-              ]
+              "properties": ["text", "size"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -8334,19 +8216,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "disabled",
-                "type"
-              ]
+              "properties": ["disabled", "type"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -8620,19 +8494,11 @@
             "isLayout": false,
             "rootSelector": ".tiny-dialog-box",
             "shortcuts": {
-              "properties": [
-                "visible",
-                "width"
-              ]
+              "properties": ["visible", "width"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -8900,9 +8766,7 @@
             "clickCapture": false,
             "isModal": false,
             "nestingRule": {
-              "childWhitelist": [
-                "TinyTabItem"
-              ],
+              "childWhitelist": ["TinyTabItem"],
               "parentWhitelist": [],
               "descendantBlacklist": [],
               "ancestorWhitelist": []
@@ -8911,19 +8775,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "size",
-                "tab-style"
-              ]
+              "properties": ["size", "tab-style"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -9020,9 +8876,7 @@
             "isModal": false,
             "nestingRule": {
               "childWhitelist": "",
-              "parentWhitelist": [
-                "TinyTab"
-              ],
+              "parentWhitelist": ["TinyTab"],
               "descendantBlacklist": "",
               "ancestorWhitelist": ""
             },
@@ -9030,19 +8884,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "name",
-                "title"
-              ]
+              "properties": ["name", "title"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -9168,9 +9014,7 @@
             "clickCapture": false,
             "isModal": false,
             "nestingRule": {
-              "childWhitelist": [
-                "TinyBreadcrumbItem"
-              ],
+              "childWhitelist": ["TinyBreadcrumbItem"],
               "parentWhitelist": [],
               "descendantBlacklist": [],
               "ancestorWhitelist": []
@@ -9179,18 +9023,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "separator"
-              ]
+              "properties": ["separator"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -9267,9 +9104,7 @@
             "isModal": false,
             "nestingRule": {
               "childWhitelist": "",
-              "parentWhitelist": [
-                "TinyBreadcrumb"
-              ],
+              "parentWhitelist": ["TinyBreadcrumb"],
               "descendantBlacklist": "",
               "ancestorWhitelist": ""
             },
@@ -9277,18 +9112,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "to"
-              ]
+              "properties": ["to"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -9411,19 +9239,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "label-width",
-                "disabled"
-              ]
+              "properties": ["label-width", "disabled"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -9530,19 +9350,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "label-width",
-                "disabled"
-              ]
+              "properties": ["label-width", "disabled"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -9757,10 +9569,7 @@
                             "widget": {
                               "component": "JsSlotConfigurator",
                               "props": {
-                                "slots": [
-                                  "header",
-                                  "default"
-                                ]
+                                "slots": ["header", "default"]
                               }
                             }
                           },
@@ -10432,15 +10241,10 @@
               }
             },
             "shortcuts": {
-              "properties": [
-                "sortable",
-                "columns"
-              ]
+              "properties": ["sortable", "columns"]
             },
             "contentMenu": {
-              "actions": [
-                "create symbol"
-              ]
+              "actions": ["create symbol"]
             },
             "onBeforeMount": "console.log('table on load'); this.pager = source.pager; this.fetchData = source.fetchData; this.data = source.data ;this.columns = source.columns"
           },
@@ -10460,19 +10264,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "sortable",
-                "columns"
-              ]
+              "properties": ["sortable", "columns"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -10701,19 +10497,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "currentPage",
-                "total"
-              ]
+              "properties": ["currentPage", "total"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -11072,19 +10860,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "modelValue",
-                "disabled"
-              ]
+              "properties": ["modelValue", "disabled"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -11415,19 +11195,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "data",
-                "show-checkbox"
-              ]
+              "properties": ["data", "show-checkbox"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -11630,19 +11402,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "active",
-                "data"
-              ]
+              "properties": ["active", "data"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -11859,19 +11623,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "disabled",
-                "content"
-              ]
+              "properties": ["disabled", "content"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -12362,19 +12118,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "visible",
-                "width"
-              ]
+              "properties": ["visible", "width"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -12785,19 +12533,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "value",
-                "disabled"
-              ]
+              "properties": ["value", "disabled"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         },
@@ -13236,19 +12976,11 @@
             "isLayout": false,
             "rootSelector": "",
             "shortcuts": {
-              "properties": [
-                "value",
-                "disabled"
-              ]
+              "properties": ["value", "disabled"]
             },
             "contextMenu": {
-              "actions": [
-                "create symbol"
-              ],
-              "disable": [
-                "copy",
-                "remove"
-              ]
+              "actions": ["create symbol"],
+              "disable": ["copy", "remove"]
             }
           }
         }
@@ -13633,10 +13365,7 @@
               "schema": {
                 "componentName": "TinyCheckboxGroup",
                 "props": {
-                  "modelValue": [
-                    "name1",
-                    "name2"
-                  ],
+                  "modelValue": ["name1", "name2"],
                   "type": "checkbox",
                   "options": [
                     {

--- a/designer-demo/public/mock/bundle.json
+++ b/designer-demo/public/mock/bundle.json
@@ -9720,7 +9720,7 @@
                     "required": true,
                     "readOnly": false,
                     "disabled": false,
-                    "onChange": "this.delProp('data')",
+                    "onChange": "function () { this.delProp('data') } ",
                     "cols": 12,
                     "widget": {
                       "component": "CodeConfigurator",

--- a/packages/canvas/DesignCanvas/README.md
+++ b/packages/canvas/DesignCanvas/README.md
@@ -1,4 +1,23 @@
-# schema 元服务相关API（初版）
+# schema 元服务相关API（Experimental）
+
+## 直接修改 schema 引用 & 调用通知更新
+
+使用示例：
+
+```javascript
+import { useCanvas, useMessage } from '@opentiny/tiny-engine-meta-register'
+
+const pageSchema = useCanvas().getPageSchema()
+
+pageSchema.css = "xxxx"
+
+useMessage().publish({ topic: 'schemaChange' })
+```
+
+注意：直接修改 schema 引用当前不能涉及到节点的增加、删除，不然会节点树 nodesMap 无法更新，导致画布无法选中新增的组件。
+
+
+> 注意：以下所有 API 皆为 Experimental 实验 API，请不要用在生产阶段
 
 ## 导入/导出 schema
 

--- a/packages/canvas/DesignCanvas/README.md
+++ b/packages/canvas/DesignCanvas/README.md
@@ -1,0 +1,176 @@
+# schema 元服务相关API（初版）
+
+## 导入/导出 schema
+
+> 这里的导入导出仅包含页面级别，不包含应用级别 schema
+
+**导入 schema:**
+
+```javascript
+import { useCanvas } from '@opentiny/tiny-engine-meta-register'
+
+const data = { /*页面/区块 schema*/ }
+
+useCanvas().importSchema(data)
+```
+
+**导出 schema:**
+
+```javascript
+import { useCanvas } from '@opentiny/tiny-engine-meta-register'
+
+useCanvas().exportSchema()
+```
+
+## 页面 schema相关操作
+
+> 主要描述对页面 schema 的增删查改操作
+
+### 获取当前页面/区块 schema:
+
+```javascript
+import { useCanvas } from '@opentiny/tiny-engine-meta-register'
+
+useCanvas().getPageSchema()
+```
+
+### 获取当前选中节点 schema:
+
+```javascript
+import { useProperties } from '@opentiny/tiny-engine-meta-register'
+
+const schema = useProperties().getSchema()
+```
+
+### 根据 id 查询对应的 节点schema(schema 片段)
+
+```javascript
+import { useCanvas } from '@opentiny/tiny-engine-meta-register'
+
+const schema = useCanvas().getNode('453254', false)
+```
+
+类型：
+
+```typescript
+/**
+ * 根据节点 id 获取 schema 片段
+ * id: schema id
+ * parent: 是否需要同时获取 parent 节点
+ */
+type getNode = (id: string, parent: boolean) => INode | { node: INode; parent: INode }
+```
+
+### 节点操作
+
+#### 插入节点
+
+使用示例：
+
+```javascript
+import { useCanvas } from '@opentiny/tiny-engine-meta-register'
+
+useCanvas().operateNode({
+  type: 'insert',
+  parentId: '432423',
+  newNodeData: { componentName: 'div', props: {}, children: [] },
+  position: 'after',
+  referTargetNodeId: '898432'
+})
+```
+
+类型：
+
+```typescript
+interface IInsertOperation {
+  // 操作类型为 insert
+  type: 'insert';
+  // 要插入的节点的 父节点 id
+  parentId: string;
+  // 新节点数据
+  newNodeData: INode;
+  // 相对节点的 id，比如我们想要插入父节点 id 中 第 5 个 children 的后面，或者前面
+  referTargetNodeId: string;
+  // 相对节点的位置
+  position: 'after' | 'before';
+}
+```
+
+#### 删除节点
+
+使用示例：
+
+```javascript
+import { useCanvas } from '@opentiny/tiny-engine-meta-register'
+
+useCanvas().operateNode({
+  type: 'delete',
+  id: '432423'
+})
+```
+
+类型：
+
+```typescript
+interface IDeleteOperation {
+  type: 'delete';
+  id: string;
+}
+```
+
+#### 修改节点 props
+
+使用示例：
+
+```javascript
+import { useCanvas } from '@opentiny/tiny-engine-meta-register'
+
+useCanvas().operateNode({
+  type: 'changeProps',
+  id: '432423',
+  value: { text: 'TinyEngine' },
+  option: { overwrite: false }
+})
+```
+
+类型：
+
+```typescript
+interface IChangePropsOperation {
+  type: 'changeProps';
+  // 节点 id
+  id: string;
+  // 新的 props 值
+  value: Record<string, any>;
+  // 操作类型：是否覆写
+  option: { overwrite: boolean; }
+}
+```
+
+#### 更新节点属性
+
+使用示例：
+
+```javascript
+import { useCanvas } from '@opentiny/tiny-engine-meta-register'
+
+useCanvas().operateNode({
+  type: 'updateAttributes',
+  id: '432423',
+  value: { props: { ... }, loop: { ... } },
+  overwrite: boolean
+})
+```
+
+类型：
+
+```typescript
+interface IUpdateAttrOperation {
+  type: 'updateAttributes';
+  id: string;
+  // 对节点的属性修改
+  value: Record<string, any>;
+  // 是否是直接覆盖
+  overwrite: boolean;
+}
+```

--- a/packages/canvas/DesignCanvas/src/DesignCanvas.vue
+++ b/packages/canvas/DesignCanvas/src/DesignCanvas.vue
@@ -66,7 +66,7 @@ export default {
 
     const removeNode = (node) => {
       const { pageState } = useCanvas()
-      footData.value = useCanvas().canvasApi.value.getNodePath(node?.id)
+      footData.value = useCanvas().getNodePath(node?.id)
       pageState.currentSchema = {}
       pageState.properties = null
     }
@@ -136,8 +136,7 @@ export default {
         useLayout().closePlugin()
       }
 
-      const { getNodePath } = useCanvas().canvasApi.value
-      const { getSchema } = useCanvas()
+      const { getSchema, getNodePath } = useCanvas()
       const schemaItem = useCanvas().getNodeById(id)
 
       const schema = getSchema()

--- a/packages/canvas/DesignCanvas/src/DesignCanvas.vue
+++ b/packages/canvas/DesignCanvas/src/DesignCanvas.vue
@@ -30,7 +30,8 @@ import {
   getMergeMeta,
   getOptions,
   getMetaApi,
-  META_SERVICE
+  META_SERVICE,
+  useMessage
 } from '@opentiny/tiny-engine-meta-register'
 import { constants } from '@opentiny/tiny-engine-utils'
 import * as ast from '@opentiny/tiny-engine-common/js/ast'
@@ -184,7 +185,9 @@ export default {
         addHistory: useHistory().addHistory,
         registerBlock: useMaterial().registerBlock,
         request: getMetaApi(META_SERVICE.Http).getHttp(),
-        ast
+        ast,
+        useModal,
+        useMessage
       },
       CanvasLayout,
       canvasRef,

--- a/packages/canvas/DesignCanvas/src/DesignCanvas.vue
+++ b/packages/canvas/DesignCanvas/src/DesignCanvas.vue
@@ -139,11 +139,11 @@ export default {
       const { getSchema, getNodePath } = useCanvas()
       const schemaItem = useCanvas().getNodeById(id)
 
-      const schema = getSchema()
+      const pageSchema = getSchema()
+
       // 如果选中的节点是画布，就设置成默认选中最外层schema
-      // TODO: 将 canvas 的 schema 改成 pageState 的 schema
-      useProperties().getProps(schemaItem || schema, parent)
-      useCanvas().setCurrentSchema(schemaItem || schema)
+      useProperties().getProps(schemaItem || pageSchema, parent)
+      useCanvas().setCurrentSchema(schemaItem || pageSchema)
       footData.value = getNodePath(schemaItem?.id)
       toolbars.visiblePopover = false
     }

--- a/packages/canvas/DesignCanvas/src/DesignCanvas.vue
+++ b/packages/canvas/DesignCanvas/src/DesignCanvas.vue
@@ -130,19 +130,21 @@ export default {
       }
     )
 
-    const nodeSelected = (node, parent, type) => {
+    const nodeSelected = (node, parent, type, id) => {
       const { toolbars } = useLayout().layoutState
       if (type !== 'clickTree') {
         useLayout().closePlugin()
       }
 
       const { getSchema, getNodePath } = useCanvas().canvasApi.value
+      const schemaItem = useCanvas().getNodeById(id)
 
       const schema = getSchema()
       // 如果选中的节点是画布，就设置成默认选中最外层schema
-      useProperties().getProps(node || schema, parent)
-      useCanvas().setCurrentSchema(node || schema)
-      footData.value = getNodePath(node?.id)
+      // TODO: 将 canvas 的 schema 改成 pageState 的 schema
+      useProperties().getProps(schemaItem || schema, parent)
+      useCanvas().setCurrentSchema(schemaItem || schema)
+      footData.value = getNodePath(schemaItem?.id)
       toolbars.visiblePopover = false
     }
 

--- a/packages/canvas/DesignCanvas/src/DesignCanvas.vue
+++ b/packages/canvas/DesignCanvas/src/DesignCanvas.vue
@@ -31,7 +31,8 @@ import {
   getOptions,
   getMetaApi,
   META_SERVICE,
-  useMessage
+  useMessage,
+  useNotify
 } from '@opentiny/tiny-engine-meta-register'
 import { constants } from '@opentiny/tiny-engine-utils'
 import * as ast from '@opentiny/tiny-engine-common/js/ast'
@@ -187,7 +188,8 @@ export default {
         request: getMetaApi(META_SERVICE.Http).getHttp(),
         ast,
         useModal,
-        useMessage
+        useMessage,
+        useNotify
       },
       CanvasLayout,
       canvasRef,

--- a/packages/canvas/DesignCanvas/src/DesignCanvas.vue
+++ b/packages/canvas/DesignCanvas/src/DesignCanvas.vue
@@ -136,7 +136,8 @@ export default {
         useLayout().closePlugin()
       }
 
-      const { getSchema, getNodePath } = useCanvas().canvasApi.value
+      const { getNodePath } = useCanvas().canvasApi.value
+      const { getSchema } = useCanvas()
       const schemaItem = useCanvas().getNodeById(id)
 
       const schema = getSchema()

--- a/packages/canvas/DesignCanvas/src/api/useCanvas.js
+++ b/packages/canvas/DesignCanvas/src/api/useCanvas.js
@@ -259,7 +259,6 @@ const getNode = (id, parent) => {
 const operationTypeMap = {
   insert: (operation) => {
     const { parentId, newNodeData, position, referTargetNodeId } = operation
-
     const parentNode = getNode(parentId) || pageState.pageSchema
 
     if (!parentNode) {
@@ -317,6 +316,11 @@ const operationTypeMap = {
   delete: (operation) => {
     const { id } = operation
     const targetNode = getNode(id, true)
+
+    if (!targetNode) {
+      return
+    }
+
     const { parent, node } = targetNode
 
     const index = parent.children.indexOf(node)
@@ -350,9 +354,8 @@ const operationTypeMap = {
   },
   changeProps: (operation) => {
     const { id, value, option: changeOption } = operation
-    const { node, parent } = getNode(id, true)
+    const { node } = getNode(id, true)
     const previous = deepClone(node)
-
     const { overwrite = false } = changeOption || {}
 
     if (!node) {
@@ -360,7 +363,7 @@ const operationTypeMap = {
     }
 
     if (overwrite) {
-      setNode({ id, ...value }, parent)
+      node.props = value.props
     } else {
       Object.assign(node, value || {})
     }
@@ -371,31 +374,45 @@ const operationTypeMap = {
     }
   },
   updateAttributes: (operation) => {
-    const { id, value } = operation
+    const { id, value, overwrite } = operation
     const { id: _id, children, ...restAttr } = value
-
     const node = getNode(id)
 
     // 其他属性直接浅  merge
-    Object.assign(node, deepClone(restAttr))
+    Object.assign(node, restAttr)
+
+    // 配置了 overwrite，需要将没有传入的属性进行删除（不包括 children）
+    if (overwrite) {
+      const { id: _unUsedId, children: _unUsedChildren, ...restOrigin } = node
+      const originKeys = Object.keys(restOrigin)
+      const newKeysSet = new Set(Object.keys(restAttr))
+
+      originKeys.forEach((key) => {
+        if (!newKeysSet.has(key)) {
+          delete node[key]
+        }
+      })
+    }
 
     if (!Array.isArray(children)) {
+      // 非数组类型的 children，比如是直接的字符串作为 children
+      if (children || typeof children === 'string') {
+        node.children = children
+      }
+
       return
     }
 
-    // 传了 children 进来，需要找出来被删除的、新增的，剩下的是修改的。
-    const originChildrenIds = (node.children || []).map(({ id }) => id)
-    const originChildrenSet = new Set(originChildrenIds)
     const newChildren = children.map((item) => {
       if (!item.id) {
-        return {
-          id: utils.guid(),
-          ...item
-        }
+        item.id = utils.guid()
       }
 
       return item
     })
+    // 传了 children 进来，需要找出来被删除的、新增的，剩下的是修改的。
+    const originChildrenIds = (node.children || []).filter(({ id }) => id).map(({ id }) => id)
+    const originChildrenSet = new Set(originChildrenIds)
 
     const newChildrenSet = new Set(newChildren.map(({ id }) => id))
     // 被删除的项
@@ -419,6 +436,17 @@ const operationTypeMap = {
           referTargetNodeId: changedChildren?.[index]?.id
         })
         return
+      }
+
+      // 直接改引用插入进来，但是没有构建对应的 Map，需要构建Map
+      if (!getNode(childItem.id)) {
+        setNode(childItem, node)
+
+        // 递归构建 nodeMap
+        if (Array.isArray(childItem?.children) && childItem.children.length) {
+          const newNode = getNode(childItem.id)
+          generateNodesMap(childItem.children, newNode)
+        }
       }
 
       // 递归修改

--- a/packages/canvas/DesignCanvas/src/api/useCanvas.js
+++ b/packages/canvas/DesignCanvas/src/api/useCanvas.js
@@ -90,8 +90,31 @@ const generateNodesMap = (nodes, parent) => {
   })
 }
 
+const jsondiffpatchInstance = jsondiffpatch.create({
+  objectHash: function (obj, index) {
+    return obj.fileName || obj.id || `$$index:${index}`
+  },
+  arrays: {
+    detectMove: true,
+    includeValueOnMove: false
+  },
+  textDiff: {
+    diffMatchPatch: DiffMatchPatch,
+    minLength: 60
+  },
+  // eslint-disable-next-line no-unused-vars
+  propertyFilter: function (name, context) {
+    return name.slice(0, 1) !== '$'
+  },
+  cloneDiffValues: false
+})
+
+const { publish } = useMessage()
+
 // 重置画布数据
 const resetCanvasState = async (state = {}) => {
+  const previousSchema = JSON.parse(JSON.stringify(pageState.pageSchema))
+
   Object.assign(pageState, defaultPageState, state)
 
   nodesMap.value.clear()
@@ -116,6 +139,10 @@ const resetCanvasState = async (state = {}) => {
   }
 
   await canvasApi.value?.setSchema(pageState.pageSchema)
+
+  const diffPatch = jsondiffpatchInstance.diff(previousSchema, pageState.pageSchema)
+
+  publish({ topic: 'schemaImport', data: { current: pageState.pageSchema, previous: previousSchema, diffPatch } })
 }
 
 // 页面重置画布数据
@@ -244,28 +271,9 @@ const getNode = (id, parent) => {
 //   return Object.prototype.toString.call(obj)
 // }
 
-const jsondiffpatchInstance = jsondiffpatch.create({
-  objectHash: function (obj, index) {
-    return obj.fileName || obj.id || `$$index:${index}`
-  },
-  arrays: {
-    detectMove: true,
-    includeValueOnMove: false
-  },
-  textDiff: {
-    diffMatchPatch: DiffMatchPatch,
-    minLength: 60
-  },
-  // eslint-disable-next-line no-unused-vars
-  propertyFilter: function (name, context) {
-    return name.slice(0, 1) !== '$'
-  },
-  cloneDiffValues: false
-})
-
-const optionTypeMap = {
-  insert: (option) => {
-    const { parentId, newNodeData, position, referTargetNodeId } = option
+const operationTypeMap = {
+  insert: (operation) => {
+    const { parentId, newNodeData, position, referTargetNodeId } = operation
 
     const parentNode = getNode(parentId) || pageState.pageSchema
 
@@ -305,8 +313,8 @@ const optionTypeMap = {
       previous: undefined
     }
   },
-  delete: (option) => {
-    const { id } = option
+  delete: (operation) => {
+    const { id } = operation
     let targetNode = getNode(id, true)
     let { parent, node } = targetNode
 
@@ -322,8 +330,8 @@ const optionTypeMap = {
       previous: node
     }
   },
-  changeProps: (option) => {
-    const { id, value, option: changeOption } = option
+  changeProps: (operation) => {
+    const { id, value, option: changeOption } = operation
     const { node, parent } = getNode(id, true)
     const previous = deepClone(node)
 
@@ -347,22 +355,21 @@ const optionTypeMap = {
 }
 
 const lastUpdateType = ref('')
-const { publish } = useMessage()
 
-const operateNode = (option) => {
-  if (!optionTypeMap[option.type]) {
+const operateNode = (operation) => {
+  if (!operationTypeMap[operation.type]) {
     return
   }
 
   const previousSchema = JSON.parse(JSON.stringify(pageState.pageSchema))
 
-  const { previous, current } = optionTypeMap[option.type](option)
+  const { previous, current } = operationTypeMap[operation.type](operation)
 
   const diffPatch = jsondiffpatchInstance.diff(previousSchema, pageState.pageSchema)
 
-  lastUpdateType.value = option.type
+  lastUpdateType.value = operation.type
 
-  publish({ topic: 'schemaChange', data: { current: deepClone(current), previous, option, diffPatch } })
+  publish({ topic: 'schemaChange', data: { current: deepClone(current), previous, operation, diffPatch } })
 }
 
 const getSchemaDiff = (schema) => {
@@ -373,6 +380,28 @@ const patchLatestSchema = (schema) => {
   const diff = jsondiffpatchInstance.diff(schema, pageState.pageSchema)
 
   jsondiffpatchInstance.patch(schema, diff)
+}
+
+const importSchema = (data) => {
+  let importData = data
+
+  if (typeof data === 'string') {
+    try {
+      importData = JSON.parse(data)
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('[useCanvas.importSchema] Invalid data')
+    }
+  }
+
+  // JSON 格式校验
+  resetCanvasState({
+    pageSchema: importData
+  })
+}
+
+const exportSchema = () => {
+  return JSON.stringify(pageState.pageSchema)
 }
 
 export default function () {
@@ -404,6 +433,8 @@ export default function () {
     lastUpdateType,
     jsondiffpatchInstance,
     getSchemaDiff,
-    patchLatestSchema
+    patchLatestSchema,
+    importSchema,
+    exportSchema
   }
 }

--- a/packages/canvas/DesignCanvas/src/api/useCanvas.js
+++ b/packages/canvas/DesignCanvas/src/api/useCanvas.js
@@ -255,22 +255,6 @@ const getNode = (id, parent) => {
   return parent ? nodesMap.value.get(id) : nodesMap.value.get(id)?.node
 }
 
-// const SIMPLE_TYPE = ['bigint', 'boolean', 'function', 'number', 'string', 'symbol', 'undefined']
-
-// const getType = (obj) => {
-//   const type = typeof obj
-
-//   if (SIMPLE_TYPE.includes(type)) {
-//     return type
-//   }
-
-//   if (!obj) {
-//     return 'null'
-//   }
-
-//   return Object.prototype.toString.call(obj)
-// }
-
 const operationTypeMap = {
   insert: (operation) => {
     const { parentId, newNodeData, position, referTargetNodeId } = operation
@@ -377,9 +361,12 @@ const getSchemaDiff = (schema) => {
 }
 
 const patchLatestSchema = (schema) => {
-  const diff = jsondiffpatchInstance.diff(schema, pageState.pageSchema)
+  // 这里 pageSchema 需要反序列化一下，不然 patch 的时候，会 patch 成同一个引用，造成画布无法更新
+  const diff = jsondiffpatchInstance.diff(schema, JSON.parse(JSON.stringify(pageState.pageSchema)))
 
-  jsondiffpatchInstance.patch(schema, diff)
+  if (diff) {
+    jsondiffpatchInstance.patch(schema, diff)
+  }
 }
 
 const importSchema = (data) => {
@@ -402,6 +389,10 @@ const importSchema = (data) => {
 
 const exportSchema = () => {
   return JSON.stringify(pageState.pageSchema)
+}
+
+const getSchema = () => {
+  return pageState.pageSchema || {}
 }
 
 export default function () {
@@ -431,10 +422,10 @@ export default function () {
     getNode,
     operateNode,
     lastUpdateType,
-    jsondiffpatchInstance,
     getSchemaDiff,
     patchLatestSchema,
     importSchema,
-    exportSchema
+    exportSchema,
+    getSchema
   }
 }

--- a/packages/canvas/DesignCanvas/src/api/useCanvas.js
+++ b/packages/canvas/DesignCanvas/src/api/useCanvas.js
@@ -11,8 +11,8 @@
  */
 
 /* eslint-disable no-new-func */
-import { reactive, ref } from 'vue'
-import * as jsondiffpatch from 'jsondiffpatch'
+import { reactive, ref, toRaw } from 'vue'
+import * as jsonDiffPatch from 'jsondiffpatch'
 import DiffMatchPatch from 'diff-match-patch'
 import { constants, utils } from '@opentiny/tiny-engine-utils'
 import { useHistory, getMetaApi, useMessage } from '@opentiny/tiny-engine-meta-register'
@@ -90,7 +90,7 @@ const generateNodesMap = (nodes, parent) => {
   })
 }
 
-const jsondiffpatchInstance = jsondiffpatch.create({
+const jsonDiffPatchInstance = jsonDiffPatch.create({
   objectHash: function (obj, index) {
     return obj.fileName || obj.id || `$$index:${index}`
   },
@@ -138,7 +138,7 @@ const resetCanvasState = async (state = {}) => {
     generateNodesMap(pageState.pageSchema.children, pageState.pageSchema)
   }
 
-  const diffPatch = jsondiffpatchInstance.diff(previousSchema, pageState.pageSchema)
+  const diffPatch = jsonDiffPatchInstance.diff(previousSchema, pageState.pageSchema)
 
   publish({ topic: 'schemaImport', data: { current: pageState.pageSchema, previous: previousSchema, diffPatch } })
 }
@@ -194,12 +194,12 @@ const isBlock = () => pageState.isBlock
 const initData = (schema = { ...defaultSchema }, currentPage) => {
   if (schema.componentName === COMPONENT_NAME.Block) {
     resetBlockCanvasState({
-      pageSchema: schema,
+      pageSchema: toRaw(schema),
       loading: false
     })
   } else {
     resetPageCanvasState({
-      pageSchema: schema,
+      pageSchema: toRaw(schema),
       currentPage,
       loading: false
     })
@@ -478,15 +478,15 @@ const operateNode = async (operation) => {
 
 // 获取传入的 schema 与最新 schema 的 diff
 const getSchemaDiff = (schema) => {
-  return jsondiffpatchInstance.diff(schema, pageState.pageSchema)
+  return jsonDiffPatchInstance.diff(schema, pageState.pageSchema)
 }
 
 const patchLatestSchema = (schema) => {
   // 这里 pageSchema 需要 deepClone，不然 patch 的时候，会 patch 成同一个引用，造成画布无法更新
-  const diff = jsondiffpatchInstance.diff(schema, deepClone(pageState.pageSchema))
+  const diff = jsonDiffPatchInstance.diff(schema, deepClone(pageState.pageSchema))
 
   if (diff) {
-    jsondiffpatchInstance.patch(schema, diff)
+    jsonDiffPatchInstance.patch(schema, diff)
   }
 }
 

--- a/packages/canvas/DesignCanvas/src/api/useCanvas.js
+++ b/packages/canvas/DesignCanvas/src/api/useCanvas.js
@@ -345,17 +345,14 @@ const operateNode = (operation) => {
     return
   }
 
-  const previousSchema = JSON.parse(JSON.stringify(pageState.pageSchema))
-
-  const { previous, current } = operationTypeMap[operation.type](operation)
-
-  const diffPatch = jsondiffpatchInstance.diff(previousSchema, pageState.pageSchema)
+  operationTypeMap[operation.type](operation)
 
   lastUpdateType.value = operation.type
 
-  publish({ topic: 'schemaChange', data: { current: deepClone(current), previous, operation, diffPatch } })
+  publish({ topic: 'schemaChange', data: { operation } })
 }
 
+// 获取传入的 schema 与最新 schema 的 diff
 const getSchemaDiff = (schema) => {
   return jsondiffpatchInstance.diff(schema, pageState.pageSchema)
 }
@@ -395,6 +392,26 @@ const getSchema = () => {
   return pageState.pageSchema || {}
 }
 
+const getNodePath = (id, nodes = []) => {
+  const { parent, node } = getNodeWithParentById(id) || {}
+
+  node && nodes.unshift({ name: node.componentName, node: id })
+
+  if (parent) {
+    parent && getNodePath(parent.id, nodes)
+  } else {
+    nodes.unshift({ name: 'BODY', node: id })
+  }
+
+  return nodes
+}
+
+const updateSchema = (data) => {
+  Object.assign(pageState.pageSchema, data)
+
+  publish({ topic: 'schemaChange', data: {} })
+}
+
 export default function () {
   return {
     pageState,
@@ -426,6 +443,8 @@ export default function () {
     patchLatestSchema,
     importSchema,
     exportSchema,
-    getSchema
+    getSchema,
+    getNodePath,
+    updateSchema
   }
 }

--- a/packages/canvas/DesignCanvas/src/api/useCanvas.js
+++ b/packages/canvas/DesignCanvas/src/api/useCanvas.js
@@ -354,12 +354,12 @@ const operationTypeMap = {
   },
   changeProps: (operation) => {
     const { id, value, option: changeOption } = operation
-    const { node } = getNode(id, true) || {}
+    let { node } = getNode(id, true) || {}
     const previous = deepClone(node)
     const { overwrite = false } = changeOption || {}
 
     if (!node) {
-      return
+      node = pageState.pageSchema
     }
 
     if (overwrite) {
@@ -457,6 +457,11 @@ const operationTypeMap = {
 
 const lastUpdateType = ref('')
 
+/**
+ * @experimental
+ * @param {*} operation
+ * @returns
+ */
 const operateNode = async (operation) => {
   if (!operationTypeMap[operation.type]) {
     return

--- a/packages/canvas/DesignCanvas/src/api/useCanvas.js
+++ b/packages/canvas/DesignCanvas/src/api/useCanvas.js
@@ -179,7 +179,7 @@ const clearCanvas = () => {
   const { fileName, componentName } = pageState.pageSchema || {}
 
   resetCanvasState({
-    pageSchema: { ...getDefaultSchema(componentName, fileName) }
+    pageSchema: { ...deepClone(getDefaultSchema(componentName, fileName)) }
   })
 
   setSaved(false)
@@ -254,6 +254,7 @@ const getNode = (id, parent) => {
 }
 
 const operationTypeMap = {
+  // TODO:insert 场景，要支持递归 insert
   insert: (operation) => {
     const { parentId, newNodeData, position, referTargetNodeId } = operation
 
@@ -295,16 +296,34 @@ const operationTypeMap = {
       previous: undefined
     }
   },
+  // TODO: 递归 delete
   delete: (operation) => {
     const { id } = operation
-    let targetNode = getNode(id, true)
-    let { parent, node } = targetNode
+    const targetNode = getNode(id, true)
+    const { parent, node } = targetNode
 
     const index = parent.children.indexOf(node)
 
     if (index > -1) {
       parent.children.splice(index, 1)
       nodesMap.value.delete(node.id)
+    }
+
+    let children = [...(node.children || [])]
+
+    // 递归清理 nodesMap
+    while (children?.length) {
+      const len = children.length
+      children.forEach((item) => {
+        const nodeItem = getNode(item.id)
+        nodesMap.value.delete(item.id)
+
+        if (Array.isArray(nodeItem.children) && nodeItem.children.length) {
+          children.push(...nodeItem.children)
+        }
+      })
+
+      children = children.slice(len)
     }
 
     return {
@@ -333,6 +352,61 @@ const operationTypeMap = {
       current: node,
       previous
     }
+  },
+  updateAttributes: (operation) => {
+    const { id, value } = operation
+    const { id: _id, children, ...restAttr } = value
+
+    const node = getNode(id)
+
+    // 其他属性直接浅  merge
+    Object.assign(node, deepClone(restAttr))
+
+    if (!Array.isArray(children)) {
+      return
+    }
+
+    // 传了 children 进来，需要找出来被删除的、新增的，剩下的是修改的。
+    const originChildrenIds = (node.children || []).map(({ id }) => id)
+    const originChildrenSet = new Set(originChildrenIds)
+    const newChildren = children.map((item) => {
+      if (!item.id) {
+        return {
+          id: utils.guid(),
+          ...item
+        }
+      }
+
+      return item
+    })
+
+    const newChildrenSet = new Set(newChildren.map(({ id }) => id))
+    // 被删除的项
+    const deletedIds = originChildrenIds.filter((id) => !newChildrenSet.has(id))
+    const deletedIdsSet = new Set(deletedIds)
+
+    for (const id of deletedIds) {
+      operationTypeMap.delete({ id })
+    }
+
+    // 筛选出来新增的和修改的
+    const changedChildren = newChildren.filter(({ id }) => !deletedIdsSet.has(id))
+
+    changedChildren.forEach((childItem, index) => {
+      // 新增
+      if (!originChildrenSet.has(childItem.id)) {
+        operationTypeMap.insert({
+          parentId: id,
+          newNodeData: childItem,
+          position: 'after',
+          referTargetNodeId: changedChildren?.[index]?.id
+        })
+        return
+      }
+
+      // 递归修改
+      operationTypeMap.updateAttributes({ id: childItem.id, value: childItem })
+    })
   }
 }
 

--- a/packages/canvas/DesignCanvas/src/api/useCanvas.js
+++ b/packages/canvas/DesignCanvas/src/api/useCanvas.js
@@ -183,6 +183,9 @@ const clearCanvas = () => {
   })
 
   setSaved(false)
+
+  canvasApi.value?.clearSelect?.()
+  canvasApi.value?.updateRect?.()
 }
 
 const isBlock = () => pageState.isBlock
@@ -254,7 +257,6 @@ const getNode = (id, parent) => {
 }
 
 const operationTypeMap = {
-  // TODO:insert 场景，要支持递归 insert
   insert: (operation) => {
     const { parentId, newNodeData, position, referTargetNodeId } = operation
 
@@ -265,6 +267,10 @@ const operationTypeMap = {
     }
 
     parentNode.children = parentNode.children || []
+
+    if (!newNodeData.id) {
+      newNodeData.id = utils.guid()
+    }
 
     if (referTargetNodeId) {
       const referenceNode = getNode(referTargetNodeId)
@@ -280,6 +286,12 @@ const operationTypeMap = {
 
       setNode(newNodeData, parentNode)
 
+      // 递归构建 nodeMap
+      if (Array.isArray(newNodeData?.children) && newNodeData.children.length) {
+        const newNode = getNode(newNodeData.id)
+        generateNodesMap(newNodeData.children, newNode)
+      }
+
       return {
         current: newNodeData,
         previous: undefined
@@ -289,6 +301,12 @@ const operationTypeMap = {
     if (position === 'after') {
       parentNode.children.push(newNodeData)
       setNode(newNodeData, parentNode)
+
+      // 递归构建 nodeMap
+      if (Array.isArray(newNodeData?.children) && newNodeData.children.length) {
+        const newNode = getNode(newNodeData.id)
+        generateNodesMap(newNodeData.children, newNode)
+      }
     }
 
     return {
@@ -296,7 +314,6 @@ const operationTypeMap = {
       previous: undefined
     }
   },
-  // TODO: 递归 delete
   delete: (operation) => {
     const { id } = operation
     const targetNode = getNode(id, true)
@@ -412,7 +429,7 @@ const operationTypeMap = {
 
 const lastUpdateType = ref('')
 
-const operateNode = (operation) => {
+const operateNode = async (operation) => {
   if (!operationTypeMap[operation.type]) {
     return
   }
@@ -422,6 +439,10 @@ const operateNode = (operation) => {
   lastUpdateType.value = operation.type
 
   publish({ topic: 'schemaChange', data: { operation } })
+
+  setTimeout(() => {
+    canvasApi.value.updateRect?.()
+  }, 0)
 }
 
 // 获取传入的 schema 与最新 schema 的 diff

--- a/packages/canvas/DesignCanvas/src/api/useCanvas.js
+++ b/packages/canvas/DesignCanvas/src/api/useCanvas.js
@@ -440,9 +440,11 @@ const operateNode = async (operation) => {
 
   publish({ topic: 'schemaChange', data: { operation } })
 
-  setTimeout(() => {
-    canvasApi.value.updateRect?.()
-  }, 0)
+  if (operation.type !== 'insert') {
+    setTimeout(() => {
+      canvasApi.value.updateRect?.()
+    }, 0)
+  }
 }
 
 // 获取传入的 schema 与最新 schema 的 diff

--- a/packages/canvas/DesignCanvas/src/api/useCanvas.js
+++ b/packages/canvas/DesignCanvas/src/api/useCanvas.js
@@ -138,8 +138,6 @@ const resetCanvasState = async (state = {}) => {
     generateNodesMap(pageState.pageSchema.children, pageState.pageSchema)
   }
 
-  await canvasApi.value?.setSchema(pageState.pageSchema)
-
   const diffPatch = jsondiffpatchInstance.diff(previousSchema, pageState.pageSchema)
 
   publish({ topic: 'schemaImport', data: { current: pageState.pageSchema, previous: previousSchema, diffPatch } })

--- a/packages/canvas/DesignCanvas/src/api/useCanvas.js
+++ b/packages/canvas/DesignCanvas/src/api/useCanvas.js
@@ -362,10 +362,14 @@ const operationTypeMap = {
       node = pageState.pageSchema
     }
 
+    if (!node.props) {
+      node.props = {}
+    }
+
     if (overwrite) {
       node.props = value.props
     } else {
-      Object.assign(node, value || {})
+      Object.assign(node.props, value?.props || {})
     }
 
     return {

--- a/packages/canvas/DesignCanvas/src/api/useCanvas.js
+++ b/packages/canvas/DesignCanvas/src/api/useCanvas.js
@@ -354,7 +354,7 @@ const operationTypeMap = {
   },
   changeProps: (operation) => {
     const { id, value, option: changeOption } = operation
-    const { node } = getNode(id, true)
+    const { node } = getNode(id, true) || {}
     const previous = deepClone(node)
     const { overwrite = false } = changeOption || {}
 

--- a/packages/canvas/DesignCanvas/src/api/useCanvas.js
+++ b/packages/canvas/DesignCanvas/src/api/useCanvas.js
@@ -12,10 +12,13 @@
 
 /* eslint-disable no-new-func */
 import { reactive, ref } from 'vue'
-import { constants } from '@opentiny/tiny-engine-utils'
-import { useHistory, getMetaApi } from '@opentiny/tiny-engine-meta-register'
+import * as jsondiffpatch from 'jsondiffpatch'
+import DiffMatchPatch from 'diff-match-patch'
+import { constants, utils } from '@opentiny/tiny-engine-utils'
+import { useHistory, getMetaApi, useMessage } from '@opentiny/tiny-engine-meta-register'
 
 const { COMPONENT_NAME } = constants
+const { deepClone } = utils
 
 const defaultPageState = {
   currentVm: null,
@@ -53,6 +56,7 @@ const defaultSchema = {
 
 const canvasApi = ref({})
 const isCanvasApiReady = ref(false)
+const nodesMap = ref(new Map())
 
 const initCanvasApi = (newCanvasApi) => {
   canvasApi.value = newCanvasApi
@@ -60,9 +64,56 @@ const initCanvasApi = (newCanvasApi) => {
 }
 
 const pageState = reactive({ ...defaultPageState, loading: true })
+const rootSchema = ref([
+  {
+    id: 0,
+    componentName: 'div',
+    props: pageState.pageSchema?.props || {},
+    children: pageState.pageSchema?.children || []
+  }
+])
+
+const generateNodesMap = (nodes, parent) => {
+  nodes.forEach((nodeItem) => {
+    if (!nodeItem.id) {
+      nodeItem.id = utils.guid()
+    }
+
+    nodesMap.value.set(nodeItem.id, {
+      node: nodeItem,
+      parent
+    })
+
+    if (Array.isArray(nodeItem.children) && nodeItem.children.length) {
+      generateNodesMap(nodeItem.children, nodeItem)
+    }
+  })
+}
+
 // 重置画布数据
 const resetCanvasState = async (state = {}) => {
   Object.assign(pageState, defaultPageState, state)
+
+  nodesMap.value.clear()
+
+  if (pageState.pageSchema) {
+    if (!pageState.pageSchema.children) {
+      pageState.pageSchema.children = []
+    }
+
+    rootSchema.value = [
+      {
+        id: 0,
+        componentName: 'div',
+        props: pageState.pageSchema.props || {},
+        children: pageState.pageSchema.children
+      }
+    ]
+
+    nodesMap.value.set(0, { node: rootSchema.value, parent: pageState.pageSchema })
+
+    generateNodesMap(pageState.pageSchema.children, pageState.pageSchema)
+  }
 
   await canvasApi.value?.setSchema(pageState.pageSchema)
 }
@@ -151,6 +202,179 @@ const clearCurrentState = () => {
 }
 const getCurrentPage = () => pageState.currentPage
 
+const getNodeById = (id) => {
+  return nodesMap.value.get(id)?.node
+}
+
+const getNodeWithParentById = (id) => {
+  return nodesMap.value.get(id)
+}
+
+const delNode = (id) => {
+  nodesMap.value.delete(id)
+}
+
+const clearNodes = () => {
+  nodesMap.value.clear()
+}
+
+const setNode = (schema, parent) => {
+  schema.id = schema.id || utils.guid()
+
+  nodesMap.value.set(schema.id, { node: schema, parent })
+}
+
+const getNode = (id, parent) => {
+  return parent ? nodesMap.value.get(id) : nodesMap.value.get(id)?.node
+}
+
+// const SIMPLE_TYPE = ['bigint', 'boolean', 'function', 'number', 'string', 'symbol', 'undefined']
+
+// const getType = (obj) => {
+//   const type = typeof obj
+
+//   if (SIMPLE_TYPE.includes(type)) {
+//     return type
+//   }
+
+//   if (!obj) {
+//     return 'null'
+//   }
+
+//   return Object.prototype.toString.call(obj)
+// }
+
+const jsondiffpatchInstance = jsondiffpatch.create({
+  objectHash: function (obj, index) {
+    return obj.fileName || obj.id || `$$index:${index}`
+  },
+  arrays: {
+    detectMove: true,
+    includeValueOnMove: false
+  },
+  textDiff: {
+    diffMatchPatch: DiffMatchPatch,
+    minLength: 60
+  },
+  // eslint-disable-next-line no-unused-vars
+  propertyFilter: function (name, context) {
+    return name.slice(0, 1) !== '$'
+  },
+  cloneDiffValues: false
+})
+
+const optionTypeMap = {
+  insert: (option) => {
+    const { parentId, newNodeData, position, referTargetNodeId } = option
+
+    const parentNode = getNode(parentId) || pageState.pageSchema
+
+    if (!parentNode) {
+      return {}
+    }
+
+    parentNode.children = parentNode.children || []
+
+    if (referTargetNodeId) {
+      const referenceNode = getNode(referTargetNodeId)
+      let index = parentNode.children.indexOf(referenceNode)
+
+      if (index === -1) {
+        index = 0
+      }
+
+      index = position === 'before' ? index : index + 1
+
+      parentNode.children.splice(index, 0, newNodeData)
+
+      setNode(newNodeData, parentNode)
+
+      return {
+        current: newNodeData,
+        previous: undefined
+      }
+    }
+
+    if (position === 'after') {
+      parentNode.children.push(newNodeData)
+      setNode(newNodeData, parentNode)
+    }
+
+    return {
+      current: newNodeData,
+      previous: undefined
+    }
+  },
+  delete: (option) => {
+    const { id } = option
+    let targetNode = getNode(id, true)
+    let { parent, node } = targetNode
+
+    const index = parent.children.indexOf(node)
+
+    if (index > -1) {
+      parent.children.splice(index, 1)
+      nodesMap.value.delete(node.id)
+    }
+
+    return {
+      current: undefined,
+      previous: node
+    }
+  },
+  changeProps: (option) => {
+    const { id, value, option: changeOption } = option
+    const { node, parent } = getNode(id, true)
+    const previous = deepClone(node)
+
+    const { overwrite = false } = changeOption || {}
+
+    if (!node) {
+      return
+    }
+
+    if (overwrite) {
+      setNode({ id, ...value }, parent)
+    } else {
+      Object.assign(node, value || {})
+    }
+
+    return {
+      current: node,
+      previous
+    }
+  }
+}
+
+const lastUpdateType = ref('')
+const { publish } = useMessage()
+
+const operateNode = (option) => {
+  if (!optionTypeMap[option.type]) {
+    return
+  }
+
+  const previousSchema = JSON.parse(JSON.stringify(pageState.pageSchema))
+
+  const { previous, current } = optionTypeMap[option.type](option)
+
+  const diffPatch = jsondiffpatchInstance.diff(previousSchema, pageState.pageSchema)
+
+  lastUpdateType.value = option.type
+
+  publish({ topic: 'schemaChange', data: { current: deepClone(current), previous, option, diffPatch } })
+}
+
+const getSchemaDiff = (schema) => {
+  return jsondiffpatchInstance.diff(schema, pageState.pageSchema)
+}
+
+const patchLatestSchema = (schema) => {
+  const diff = jsondiffpatchInstance.diff(schema, pageState.pageSchema)
+
+  jsondiffpatchInstance.patch(schema, diff)
+}
+
 export default function () {
   return {
     pageState,
@@ -169,6 +393,17 @@ export default function () {
     getCurrentPage,
     initCanvasApi,
     canvasApi,
-    isCanvasApiReady
+    isCanvasApiReady,
+    getNodeById,
+    getNodeWithParentById,
+    delNode,
+    clearNodes,
+    setNode,
+    getNode,
+    operateNode,
+    lastUpdateType,
+    jsondiffpatchInstance,
+    getSchemaDiff,
+    patchLatestSchema
   }
 }

--- a/packages/canvas/DesignCanvas/src/api/useCanvas.js
+++ b/packages/canvas/DesignCanvas/src/api/useCanvas.js
@@ -469,6 +469,7 @@ const operateNode = async (operation) => {
   publish({ topic: 'schemaChange', data: { operation } })
 
   if (operation.type !== 'insert') {
+    // 这里 setTimeout 延时是需要等画布更新渲染完成，然后再更新，才能得到正确的组件 offset
     setTimeout(() => {
       canvasApi.value.updateRect?.()
     }, 0)
@@ -481,8 +482,8 @@ const getSchemaDiff = (schema) => {
 }
 
 const patchLatestSchema = (schema) => {
-  // 这里 pageSchema 需要反序列化一下，不然 patch 的时候，会 patch 成同一个引用，造成画布无法更新
-  const diff = jsondiffpatchInstance.diff(schema, JSON.parse(JSON.stringify(pageState.pageSchema)))
+  // 这里 pageSchema 需要 deepClone，不然 patch 的时候，会 patch 成同一个引用，造成画布无法更新
+  const diff = jsondiffpatchInstance.diff(schema, deepClone(pageState.pageSchema))
 
   if (diff) {
     jsondiffpatchInstance.patch(schema, diff)

--- a/packages/canvas/container/src/CanvasContainer.vue
+++ b/packages/canvas/container/src/CanvasContainer.vue
@@ -115,10 +115,11 @@ export default {
         const win = iframe.value.contentWindow
         win.thirdPartyDeps = useMaterial().materialState.thirdPartyDeps
 
-        const { subscribe } = useMessage()
+        const { subscribe, unsubscribe } = useMessage()
         const { getSchemaDiff, patchLatestSchema } = useCanvas()
 
         iframe.value.contentWindow.host = {
+          unsubscribe,
           subscribe,
           getSchemaDiff,
           patchLatestSchema

--- a/packages/canvas/container/src/CanvasContainer.vue
+++ b/packages/canvas/container/src/CanvasContainer.vue
@@ -29,9 +29,9 @@
 </template>
 
 <script>
-import { onMounted, ref, computed, onUnmounted } from 'vue'
+import { onMounted, ref, computed, onUnmounted, watch, watchEffect } from 'vue'
 import { iframeMonitoring } from '@opentiny/tiny-engine-common/js/monitor'
-import { useTranslate, useCanvas, useMaterial, useMessage } from '@opentiny/tiny-engine-meta-register'
+import { useTranslate, useCanvas, useMaterial, useMessage, useResource } from '@opentiny/tiny-engine-meta-register'
 import { NODE_UID, NODE_LOOP, DESIGN_MODE } from '../../common'
 import { registerHostkeyEvent, removeHostkeyEvent } from './keyboard'
 import CanvasMenu, { closeMenu, openMenu } from './components/CanvasMenu.vue'
@@ -116,13 +116,18 @@ export default {
         win.thirdPartyDeps = useMaterial().materialState.thirdPartyDeps
 
         const { subscribe, unsubscribe } = useMessage()
-        const { getSchemaDiff, patchLatestSchema } = useCanvas()
+        const { getSchemaDiff, patchLatestSchema, getSchema } = useCanvas()
+        const { appSchemaState } = useResource()
 
         iframe.value.contentWindow.host = {
           unsubscribe,
           subscribe,
           getSchemaDiff,
-          patchLatestSchema
+          patchLatestSchema,
+          watch,
+          watchEffect,
+          getSchema,
+          appSchema: appSchemaState
         }
       }
     }

--- a/packages/canvas/container/src/CanvasContainer.vue
+++ b/packages/canvas/container/src/CanvasContainer.vue
@@ -31,7 +31,7 @@
 <script>
 import { onMounted, ref, computed, onUnmounted } from 'vue'
 import { iframeMonitoring } from '@opentiny/tiny-engine-common/js/monitor'
-import { useTranslate, useCanvas, useMaterial } from '@opentiny/tiny-engine-meta-register'
+import { useTranslate, useCanvas, useMaterial, useMessage } from '@opentiny/tiny-engine-meta-register'
 import { NODE_UID, NODE_LOOP, DESIGN_MODE } from '../../common'
 import { registerHostkeyEvent, removeHostkeyEvent } from './keyboard'
 import CanvasMenu, { closeMenu, openMenu } from './components/CanvasMenu.vue'
@@ -114,6 +114,15 @@ export default {
       if (iframe.value) {
         const win = iframe.value.contentWindow
         win.thirdPartyDeps = useMaterial().materialState.thirdPartyDeps
+
+        const { subscribe } = useMessage()
+        const { getSchemaDiff, patchLatestSchema } = useCanvas()
+
+        iframe.value.contentWindow.host = {
+          subscribe,
+          getSchemaDiff,
+          patchLatestSchema
+        }
       }
     }
 

--- a/packages/canvas/container/src/CanvasContainer.vue
+++ b/packages/canvas/container/src/CanvasContainer.vue
@@ -116,7 +116,7 @@ export default {
         win.thirdPartyDeps = useMaterial().materialState.thirdPartyDeps
 
         const { subscribe, unsubscribe } = useMessage()
-        const { getSchemaDiff, patchLatestSchema, getSchema } = useCanvas()
+        const { getSchemaDiff, patchLatestSchema, getSchema, getNode } = useCanvas()
         const { appSchemaState } = useResource()
 
         iframe.value.contentWindow.host = {
@@ -127,7 +127,11 @@ export default {
           watch,
           watchEffect,
           getSchema,
-          appSchema: appSchemaState
+          appSchema: appSchemaState,
+          schemaUtils: {
+            getSchema,
+            getNode
+          }
         }
       }
     }

--- a/packages/canvas/container/src/components/CanvasAction.vue
+++ b/packages/canvas/container/src/components/CanvasAction.vue
@@ -124,11 +124,10 @@ import {
   updateRect,
   copyNode,
   getRenderer,
-  getSchema,
   dragStart,
   getCurrentElement
 } from '../container'
-import { useLayout, useMaterial } from '@opentiny/tiny-engine-meta-register'
+import { useLayout, useMaterial, useCanvas } from '@opentiny/tiny-engine-meta-register'
 import { Popover } from '@opentiny/vue'
 import shortCutPopover from './shortCutPopover.vue'
 
@@ -236,7 +235,7 @@ export default {
       return !props.resize && parent && parent?.type !== 'JSSlot'
     })
 
-    const showToParent = computed(() => getCurrent().parent !== getSchema())
+    const showToParent = computed(() => getCurrent().parent !== useCanvas().getSchema())
 
     const isModal = computed(() => {
       const config = useMaterial().getMaterial(props.selectState.componentName)

--- a/packages/canvas/container/src/container.js
+++ b/packages/canvas/container/src/container.js
@@ -488,6 +488,7 @@ const setHoverRect = (element, data) => {
   const configure = getConfigure(componentName)
   const rect = getRect(element)
   const { left, height, top, width } = rect
+  const { getSchema, getNodeWithParentById } = useCanvas()
 
   hoverState.configure = configure
 
@@ -499,7 +500,7 @@ const setHoverRect = (element, data) => {
 
     // 如果拖拽经过的元素是body或者是带有容器属性的盒子，并且在元素内部插入,则需要特殊处理
     if ((isBodyEl(element) || configure?.isContainer) && rectType === POSITION.IN) {
-      const { node } = isBodyEl(element) ? { node: getSchema() } : useCanvas().getNodeWithParentById(id) || {}
+      const { node } = isBodyEl(element) ? { node: getSchema() } : getNodeWithParentById(id) || {}
       const children = node?.children || []
       if (children.length > 0) {
         // 如果容器盒子有子节点，则以最后一个子节点为拖拽参照物
@@ -727,9 +728,10 @@ export const onMouseUp = () => {
   const absolute = canvasState.type === 'absolute'
   const sourceId = data?.id
   const lineId = lineState.id
+  const { getNodeWithParentById, getSchema } = useCanvas()
 
   if (draging && !forbidden) {
-    const { parent, node } = useCanvas().getNodeWithParentById(lineId) || {} // target
+    const { parent, node } = getNodeWithParentById(lineId) || {} // target
 
     const insertData = toRaw(data)
     const targetNode = { parent, node, data: { ...insertData, children: insertData.children || [] } }
@@ -900,7 +902,6 @@ export const canvasApi = {
   setUtils,
   updateUtils,
   deleteUtils,
-  getSchema,
   setI18n,
   getCanvasType,
   setCanvasType,
@@ -921,10 +922,11 @@ export const canvasApi = {
 }
 
 export const initCanvas = ({ renderer, iframe, emit, controller }) => {
+  const { getSchema, getPageSchema } = useCanvas()
   const currentSchema = getSchema()
 
   // 在点击刷新按钮的情况下继续保留最新的schema.json
-  const schema = currentSchema ? currentSchema : useCanvas().getPageSchema()
+  const schema = currentSchema ? currentSchema : getPageSchema()
 
   canvasState.iframe = iframe
   canvasState.emit = emit

--- a/packages/canvas/container/src/container.js
+++ b/packages/canvas/container/src/container.js
@@ -75,9 +75,6 @@ export const setDesignMode = (mode) => getRenderer()?.setDesignMode(mode)
 
 export const getGlobalState = () => getRenderer().getGlobalState()
 
-// export const getNode = (id, parent) => getRenderer()?.getNode(id, parent)
-
-// export const getSchema = () => getRenderer()?.getSchema()
 export const getSchema = () => useCanvas().getPageSchema()
 
 export const getContext = () => {
@@ -264,16 +261,9 @@ const inserAfter = ({ parent, node, data }) => {
     position: 'after',
     referTargetNodeId: node.id
   })
-
-  // const parentChildren = parent.children
-  // const index = parentChildren.indexOf(node)
-  // parent.children.splice(index + 1, 0, data)
 }
 
 const insertBefore = ({ parent, node, data }) => {
-  // const parentChildren = parent.children
-  // const index = parentChildren.indexOf(node)
-  // parent.children.splice(index, 0, data)
   if (!data.id) {
     data.id = utils.guid()
   }
@@ -298,37 +288,9 @@ const insertInner = ({ node, data }, position) => {
     newNodeData: data,
     position: [POSITION.TOP, POSITION.LEFT].includes(position) ? 'before' : 'after'
   })
-  // node.children = node.children || []
-
-  // if (position === POSITION.TOP || position === POSITION.LEFT) {
-  //   node.children.unshift(data)
-  // } else {
-  //   node.children.push(data)
-  // }
 }
 
 export const removeNode = (id) => {
-  // const parentChildren = parent.children || parent.value
-  // const index = parentChildren.indexOf(node)
-
-  // if (index > -1) {
-  //   parentChildren.splice(index, 1)
-  // } else {
-  //   const templates = parentChildren.filter(({ componentName }) => componentName === 'Template')
-
-  //   templates.forEach((template) => {
-  //     const { children } = template
-
-  //     if (children.length) {
-  //       children.splice(children.indexOf(node), 1)
-  //     }
-
-  //     if (!children.length) {
-  //       parentChildren.splice(parentChildren.indexOf(template), 1)
-  //     }
-  //   })
-  // }
-
   useCanvas().operateNode({
     type: 'delete',
     id
@@ -691,7 +653,7 @@ export const selectNode = async (id, type) => {
     const loopId = type.split('=')[1]
     canvasState.loopId = loopId
   }
-  // const { node, parent } = getNode(id, true) || {}
+
   const { node, parent } = useCanvas().getNodeWithParentById(id) || {}
   let element = querySelectById(id, type)
 
@@ -717,7 +679,6 @@ export const hoverNode = (id, data) => {
 
 export const insertNode = (node, position = POSITION.IN, select = true) => {
   if (!node.parent) {
-    // insertInner({ node: canvasState.schema, data: node.data }, position)
     insertInner({ node: useCanvas().pageState.pageSchema, data: node.data }, position)
   } else {
     switch (position) {
@@ -753,7 +714,7 @@ export const copyNode = (id) => {
   if (!id) {
     return
   }
-  // const { node, parent } = getNode(id, true)
+
   const { node, parent } = useCanvas().getNodeWithParentById(id)
 
   inserAfter({ parent, node, data: copyObject(node) })
@@ -769,7 +730,6 @@ export const onMouseUp = () => {
 
   if (draging && !forbidden) {
     const { parent, node } = useCanvas().getNodeWithParentById(lineId) || {} // target
-    // const targetNode = { parent, node, data: toRaw(data) }
 
     const insertData = toRaw(data)
     const targetNode = { parent, node, data: { ...insertData, children: insertData.children || [] } }

--- a/packages/canvas/container/src/container.js
+++ b/packages/canvas/container/src/container.js
@@ -32,8 +32,6 @@ export const POSITION = Object.freeze({
   IN: 'in'
 })
 
-const { getNodeWithParentId, pageState, getPageSchema, getNode, operateNode } = useCanvas()
-
 const initialDragState = {
   keydown: false,
   draging: false,
@@ -80,7 +78,7 @@ export const getGlobalState = () => getRenderer().getGlobalState()
 // export const getNode = (id, parent) => getRenderer()?.getNode(id, parent)
 
 // export const getSchema = () => getRenderer()?.getSchema()
-export const getSchema = () => getPageSchema()
+export const getSchema = () => useCanvas().getPageSchema()
 
 export const getContext = () => {
   return getRenderer().getContext()
@@ -259,7 +257,7 @@ const inserAfter = ({ parent, node, data }) => {
     data.id = utils.guid()
   }
 
-  operateNode({
+  useCanvas().operateNode({
     type: 'insert',
     parentId: parent.id,
     newNodeData: data,
@@ -280,7 +278,7 @@ const insertBefore = ({ parent, node, data }) => {
     data.id = utils.guid()
   }
 
-  operateNode({
+  useCanvas().operateNode({
     type: 'insert',
     parentId: parent.id,
     newNodeData: data,
@@ -294,7 +292,7 @@ const insertInner = ({ node, data }, position) => {
     data.id = utils.guid()
   }
 
-  operateNode({
+  useCanvas().operateNode({
     type: 'insert',
     parentId: node.id,
     newNodeData: data,
@@ -331,7 +329,7 @@ export const removeNode = (id) => {
   //   })
   // }
 
-  operateNode({
+  useCanvas().operateNode({
     type: 'delete',
     id
   })
@@ -470,9 +468,9 @@ const isAncestor = (ancestor, descendant) => {
 
   while (descendantId) {
     // const { parent } = getNode(descendantId, true) || {}
-    const { parent } = getNodeWithParentId(descendantId) || {}
+    const { parent } = useCanvas().getNodeWithParentById(descendantId) || {}
 
-    if (parent.id === ancestorId) {
+    if (parent?.id === ancestorId) {
       return true
     }
 
@@ -539,7 +537,7 @@ const setHoverRect = (element, data) => {
 
     // 如果拖拽经过的元素是body或者是带有容器属性的盒子，并且在元素内部插入,则需要特殊处理
     if ((isBodyEl(element) || configure?.isContainer) && rectType === POSITION.IN) {
-      const { node } = isBodyEl(element) ? { node: getSchema() } : getNodeWithParentId(id) || {}
+      const { node } = isBodyEl(element) ? { node: getSchema() } : useCanvas().getNodeWithParentById(id) || {}
       const children = node?.children || []
       if (children.length > 0) {
         // 如果容器盒子有子节点，则以最后一个子节点为拖拽参照物
@@ -694,7 +692,7 @@ export const selectNode = async (id, type) => {
     canvasState.loopId = loopId
   }
   // const { node, parent } = getNode(id, true) || {}
-  const { node, parent } = getNodeWithParentId(id) || {}
+  const { node, parent } = useCanvas().getNodeWithParentById(id) || {}
   let element = querySelectById(id, type)
 
   if (element) {
@@ -720,7 +718,7 @@ export const hoverNode = (id, data) => {
 export const insertNode = (node, position = POSITION.IN, select = true) => {
   if (!node.parent) {
     // insertInner({ node: canvasState.schema, data: node.data }, position)
-    insertInner({ node: pageState.pageSchema, data: node.data }, position)
+    insertInner({ node: useCanvas().pageState.pageSchema, data: node.data }, position)
   } else {
     switch (position) {
       case POSITION.TOP:
@@ -756,7 +754,7 @@ export const copyNode = (id) => {
     return
   }
   // const { node, parent } = getNode(id, true)
-  const { node, parent } = getNodeWithParentId(id)
+  const { node, parent } = useCanvas().getNodeWithParentById(id)
 
   inserAfter({ parent, node, data: copyObject(node) })
   getController().addHistory()
@@ -770,7 +768,7 @@ export const onMouseUp = () => {
   const lineId = lineState.id
 
   if (draging && !forbidden) {
-    const { parent, node } = getNodeWithParentId(lineId) || {} // target
+    const { parent, node } = useCanvas().getNodeWithParentById(lineId) || {} // target
     // const targetNode = { parent, node, data: toRaw(data) }
 
     const insertData = toRaw(data)
@@ -862,7 +860,7 @@ export const setGlobalState = (state) => {
 }
 
 export const getNodePath = (id, nodes = []) => {
-  const { parent, node } = getNodeWithParentId(id) || {}
+  const { parent, node } = useCanvas().getNodeWithParentById(id) || {}
 
   node && nodes.unshift({ name: node.componentName, node: id })
 
@@ -934,7 +932,9 @@ export const canvasApi = {
   setPageCss,
   addScript,
   addStyle,
-  getNode,
+  getNode: () => {
+    return useCanvas().getNode()
+  },
   getCurrent,
   setSchema,
   setUtils,

--- a/packages/canvas/container/src/container.js
+++ b/packages/canvas/container/src/container.js
@@ -19,7 +19,7 @@ import {
   NODE_TAG,
   NODE_LOOP
 } from '../../common'
-import { useCanvas, useLayout, useResource, useTranslate, useMaterial } from '@opentiny/tiny-engine-meta-register'
+import { useCanvas, useLayout, useTranslate, useMaterial } from '@opentiny/tiny-engine-meta-register'
 import { utils } from '@opentiny/tiny-engine-utils'
 import { isVsCodeEnv } from '@opentiny/tiny-engine-common/js/environments'
 import Builtin from '../../render/src/builtin/builtin.json' //TODO 画布内外应该分开
@@ -72,8 +72,6 @@ export const getCurrent = () => {
 export const getDesignMode = () => getRenderer()?.getDesignMode()
 
 export const setDesignMode = (mode) => getRenderer()?.setDesignMode(mode)
-
-export const getGlobalState = () => getRenderer().getGlobalState()
 
 export const getSchema = () => useCanvas().getPageSchema()
 
@@ -770,31 +768,6 @@ export const setLocales = (messages, merge) => {
   })
 }
 
-export const setUtils = (utils, clear, isForceRefresh) => {
-  getRenderer().setUtils(utils, clear, isForceRefresh)
-}
-
-export const updateUtils = (utils) => {
-  getRenderer().updateUtils(utils)
-}
-
-export const deleteUtils = (utils) => {
-  getRenderer().deleteUtils(utils)
-}
-
-export const setGlobalState = (state) => {
-  useResource().resState.globalState = state
-  getRenderer().setGlobalState(state)
-}
-
-export const setSchema = async (schema) => {
-  clearHover()
-  clearSelect()
-  canvasState.schema = await getRenderer()?.setSchema(schema)
-
-  return canvasState.schema
-}
-
 export const setConfigure = (configure) => {
   getRenderer().setConfigure(configure)
 }
@@ -840,35 +813,17 @@ export const canvasApi = {
   addScript,
   addStyle,
   getCurrent,
-  setSchema,
-  setUtils,
-  updateUtils,
-  deleteUtils,
   setI18n,
   getCanvasType,
   setCanvasType,
-  setGlobalState,
-  getGlobalState,
   getDesignMode,
   setDesignMode,
   getDocument,
   canvasDispatch,
-  Builtin,
-  setDataSourceMap: (...args) => {
-    return canvasState.renderer.setDataSourceMap(...args)
-  },
-  getDataSourceMap: (...args) => {
-    return canvasState.renderer.getDataSourceMap(...args)
-  }
+  Builtin
 }
 
 export const initCanvas = ({ renderer, iframe, emit, controller }) => {
-  const { getSchema, getPageSchema } = useCanvas()
-  const currentSchema = getSchema()
-
-  // 在点击刷新按钮的情况下继续保留最新的schema.json
-  const schema = currentSchema ? currentSchema : getPageSchema()
-
   canvasState.iframe = iframe
   canvasState.emit = emit
   // 存放画布外层传进来的插件api
@@ -883,11 +838,6 @@ export const initCanvas = ({ renderer, iframe, emit, controller }) => {
     senterMessage({ type: 'i18nReady', value: true }, '*')
   }
 
-  setGlobalState(useResource().resState.globalState)
-  renderer.setDataSourceMap(useResource().resState.dataSource)
-  // 设置画布全局的utils工具类上下文环境
-  setUtils(useResource().resState.utils)
-  setSchema(schema)
   setConfigure(useMaterial().getConfigureMap())
   canvasDispatch('updateDependencies', { detail: useMaterial().materialState.thirdPartyDeps })
   canvasState.loading = false

--- a/packages/canvas/container/src/container.js
+++ b/packages/canvas/container/src/container.js
@@ -20,6 +20,7 @@ import {
   NODE_LOOP
 } from '../../common'
 import { useCanvas, useLayout, useResource, useTranslate, useMaterial } from '@opentiny/tiny-engine-meta-register'
+import { utils } from '@opentiny/tiny-engine-utils'
 import { isVsCodeEnv } from '@opentiny/tiny-engine-common/js/environments'
 import Builtin from '../../render/src/builtin/builtin.json' //TODO 画布内外应该分开
 
@@ -30,6 +31,8 @@ export const POSITION = Object.freeze({
   RIGHT: 'right',
   IN: 'in'
 })
+
+const { getNodeWithParentId, pageState, getPageSchema, getNode, operateNode } = useCanvas()
 
 const initialDragState = {
   keydown: false,
@@ -74,9 +77,10 @@ export const setDesignMode = (mode) => getRenderer()?.setDesignMode(mode)
 
 export const getGlobalState = () => getRenderer().getGlobalState()
 
-export const getNode = (id, parent) => getRenderer()?.getNode(id, parent)
+// export const getNode = (id, parent) => getRenderer()?.getNode(id, parent)
 
-export const getSchema = () => getRenderer()?.getSchema()
+// export const getSchema = () => getRenderer()?.getSchema()
+export const getSchema = () => getPageSchema()
 
 export const getContext = () => {
   return getRenderer().getContext()
@@ -251,48 +255,86 @@ const getRect = (element) => {
 }
 
 const inserAfter = ({ parent, node, data }) => {
-  const parentChildren = parent.children
-  const index = parentChildren.indexOf(node)
-  parent.children.splice(index + 1, 0, data)
+  if (!data.id) {
+    data.id = utils.guid()
+  }
+
+  operateNode({
+    type: 'insert',
+    parentId: parent.id,
+    newNodeData: data,
+    position: 'after',
+    referTargetNodeId: node.id
+  })
+
+  // const parentChildren = parent.children
+  // const index = parentChildren.indexOf(node)
+  // parent.children.splice(index + 1, 0, data)
 }
 
 const insertBefore = ({ parent, node, data }) => {
-  const parentChildren = parent.children
-  const index = parentChildren.indexOf(node)
-  parent.children.splice(index, 0, data)
+  // const parentChildren = parent.children
+  // const index = parentChildren.indexOf(node)
+  // parent.children.splice(index, 0, data)
+  if (!data.id) {
+    data.id = utils.guid()
+  }
+
+  operateNode({
+    type: 'insert',
+    parentId: parent.id,
+    newNodeData: data,
+    position: 'before',
+    referTargetNodeId: node.id
+  })
 }
 
 const insertInner = ({ node, data }, position) => {
-  node.children = node.children || []
-
-  if (position === POSITION.TOP || position === POSITION.LEFT) {
-    node.children.unshift(data)
-  } else {
-    node.children.push(data)
+  if (!data.id) {
+    data.id = utils.guid()
   }
+
+  operateNode({
+    type: 'insert',
+    parentId: node.id,
+    newNodeData: data,
+    position: [POSITION.TOP, POSITION.LEFT].includes(position) ? 'before' : 'after'
+  })
+  // node.children = node.children || []
+
+  // if (position === POSITION.TOP || position === POSITION.LEFT) {
+  //   node.children.unshift(data)
+  // } else {
+  //   node.children.push(data)
+  // }
 }
 
-export const removeNode = ({ parent, node }) => {
-  const parentChildren = parent.children || parent.value
-  const index = parentChildren.indexOf(node)
+export const removeNode = (id) => {
+  // const parentChildren = parent.children || parent.value
+  // const index = parentChildren.indexOf(node)
 
-  if (index > -1) {
-    parentChildren.splice(index, 1)
-  } else {
-    const templates = parentChildren.filter(({ componentName }) => componentName === 'Template')
+  // if (index > -1) {
+  //   parentChildren.splice(index, 1)
+  // } else {
+  //   const templates = parentChildren.filter(({ componentName }) => componentName === 'Template')
 
-    templates.forEach((template) => {
-      const { children } = template
+  //   templates.forEach((template) => {
+  //     const { children } = template
 
-      if (children.length) {
-        children.splice(children.indexOf(node), 1)
-      }
+  //     if (children.length) {
+  //       children.splice(children.indexOf(node), 1)
+  //     }
 
-      if (!children.length) {
-        parentChildren.splice(parentChildren.indexOf(template), 1)
-      }
-    })
-  }
+  //     if (!children.length) {
+  //       parentChildren.splice(parentChildren.indexOf(template), 1)
+  //     }
+  //   })
+  // }
+
+  operateNode({
+    type: 'delete',
+    id
+  })
 }
 
 export const removeNodeById = (id) => {
@@ -300,7 +342,8 @@ export const removeNodeById = (id) => {
     return
   }
 
-  removeNode(getNode(id, true))
+  // removeNode(getNode(id, true))
+  removeNode(id)
   clearSelect()
   getController().addHistory()
   canvasState.emit('remove')
@@ -426,13 +469,14 @@ const isAncestor = (ancestor, descendant) => {
   let descendantId = typeof descendant === 'string' ? descendant : descendant.id
 
   while (descendantId) {
-    const { parent } = getNode(descendantId, true) || {}
+    // const { parent } = getNode(descendantId, true) || {}
+    const { parent } = getNodeWithParentId(descendantId) || {}
 
     if (parent.id === ancestorId) {
       return true
     }
 
-    descendantId = parent.id
+    descendantId = parent?.id
   }
 
   return false
@@ -495,7 +539,7 @@ const setHoverRect = (element, data) => {
 
     // 如果拖拽经过的元素是body或者是带有容器属性的盒子，并且在元素内部插入,则需要特殊处理
     if ((isBodyEl(element) || configure?.isContainer) && rectType === POSITION.IN) {
-      const { node } = isBodyEl(element) ? { node: getSchema() } : getNode(id, true) || {}
+      const { node } = isBodyEl(element) ? { node: getSchema() } : getNodeWithParentId(id) || {}
       const children = node?.children || []
       if (children.length > 0) {
         // 如果容器盒子有子节点，则以最后一个子节点为拖拽参照物
@@ -649,7 +693,8 @@ export const selectNode = async (id, type) => {
     const loopId = type.split('=')[1]
     canvasState.loopId = loopId
   }
-  const { node, parent } = getNode(id, true) || {}
+  // const { node, parent } = getNode(id, true) || {}
+  const { node, parent } = getNodeWithParentId(id) || {}
   let element = querySelectById(id, type)
 
   if (element) {
@@ -662,7 +707,7 @@ export const selectNode = async (id, type) => {
 
   await scrollToNode(element)
   setSelectRect(element)
-  canvasState.emit('selected', node, parent, type)
+  canvasState.emit('selected', node, parent, type, id)
 
   return node
 }
@@ -674,7 +719,8 @@ export const hoverNode = (id, data) => {
 
 export const insertNode = (node, position = POSITION.IN, select = true) => {
   if (!node.parent) {
-    insertInner({ node: canvasState.schema, data: node.data }, position)
+    // insertInner({ node: canvasState.schema, data: node.data }, position)
+    insertInner({ node: pageState.pageSchema, data: node.data }, position)
   } else {
     switch (position) {
       case POSITION.TOP:
@@ -709,7 +755,8 @@ export const copyNode = (id) => {
   if (!id) {
     return
   }
-  const { node, parent } = getNode(id, true)
+  // const { node, parent } = getNode(id, true)
+  const { node, parent } = getNodeWithParentId(id)
 
   inserAfter({ parent, node, data: copyObject(node) })
   getController().addHistory()
@@ -723,13 +770,16 @@ export const onMouseUp = () => {
   const lineId = lineState.id
 
   if (draging && !forbidden) {
-    const { parent, node } = getNode(lineId, true) || {} // target
-    const targetNode = { parent, node, data: toRaw(data) }
+    const { parent, node } = getNodeWithParentId(lineId) || {} // target
+    // const targetNode = { parent, node, data: toRaw(data) }
+
+    const insertData = toRaw(data)
+    const targetNode = { parent, node, data: { ...insertData, children: insertData.children || [] } }
 
     if (sourceId) {
       // 内部拖拽
       if (sourceId !== lineId && !absolute) {
-        removeNode(getNode(sourceId, true))
+        removeNode(sourceId)
         insertNode(targetNode, position)
       }
     } else {
@@ -812,7 +862,7 @@ export const setGlobalState = (state) => {
 }
 
 export const getNodePath = (id, nodes = []) => {
-  const { parent, node } = getNode(id, true) || {}
+  const { parent, node } = getNodeWithParentId(id) || {}
 
   node && nodes.unshift({ name: node.componentName, node: id })
 

--- a/packages/canvas/container/src/container.js
+++ b/packages/canvas/container/src/container.js
@@ -648,9 +648,10 @@ export const selectNode = async (id, type) => {
   }
 
   const { node, parent } = useCanvas().getNodeWithParentById(id) || {}
+
   let element = querySelectById(id, type)
 
-  if (element) {
+  if (element && node) {
     const { rootSelector } = getConfigure(node.componentName)
     element = rootSelector ? element.querySelector(rootSelector) : element
   }

--- a/packages/canvas/container/src/container.js
+++ b/packages/canvas/container/src/container.js
@@ -77,10 +77,6 @@ export const getGlobalState = () => getRenderer().getGlobalState()
 
 export const getSchema = () => useCanvas().getPageSchema()
 
-export const getContext = () => {
-  return getRenderer().getContext()
-}
-
 // 记录拖拽状态
 export const dragState = reactive({
   ...initialDragState
@@ -302,7 +298,6 @@ export const removeNodeById = (id) => {
     return
   }
 
-  // removeNode(getNode(id, true))
   removeNode(id)
   clearSelect()
   getController().addHistory()
@@ -429,7 +424,6 @@ const isAncestor = (ancestor, descendant) => {
   let descendantId = typeof descendant === 'string' ? descendant : descendant.id
 
   while (descendantId) {
-    // const { parent } = getNode(descendantId, true) || {}
     const { parent } = useCanvas().getNodeWithParentById(descendantId) || {}
 
     if (parent?.id === ancestorId) {
@@ -758,26 +752,6 @@ export const onMouseUp = () => {
   dragEnd()
 }
 
-export const setPageCss = (css = '') => {
-  const id = 'page-css'
-  const document = getDocument()
-  let element = document.getElementById(id)
-  const head = document.querySelector('head')
-
-  document.body.setAttribute('style', '')
-
-  if (!element) {
-    element = document.createElement('style')
-    element.setAttribute('type', 'text/css')
-    element.setAttribute('id', id)
-
-    element.innerHTML = css
-    head.appendChild(element)
-  } else {
-    element.innerHTML = css
-  }
-}
-
 export const addStyle = (href) => appendStyle(href, getDocument())
 
 export const addScript = (src) => appendScript(src, getDocument())
@@ -796,10 +770,6 @@ export const setLocales = (messages, merge) => {
   })
 }
 
-export const setState = (state) => {
-  getRenderer().setState(state)
-}
-
 export const setUtils = (utils, clear, isForceRefresh) => {
   getRenderer().setUtils(utils, clear, isForceRefresh)
 }
@@ -812,27 +782,9 @@ export const deleteUtils = (utils) => {
   getRenderer().deleteUtils(utils)
 }
 
-export const deleteState = (variable) => {
-  getRenderer().deleteState(variable)
-}
-
 export const setGlobalState = (state) => {
   useResource().resState.globalState = state
   getRenderer().setGlobalState(state)
-}
-
-export const getNodePath = (id, nodes = []) => {
-  const { parent, node } = useCanvas().getNodeWithParentById(id) || {}
-
-  node && nodes.unshift({ name: node.componentName, node: id })
-
-  if (parent) {
-    parent && getNodePath(parent.id, nodes)
-  } else {
-    nodes.unshift({ name: 'BODY', node: id })
-  }
-
-  return nodes
 }
 
 export const setSchema = async (schema) => {
@@ -846,8 +798,6 @@ export const setSchema = async (schema) => {
 export const setConfigure = (configure) => {
   getRenderer().setConfigure(configure)
 }
-
-export const setProps = (data) => getRenderer()?.setProps(data)
 
 export const setI18n = (data) => {
   const messages = data || useTranslate().getData()
@@ -878,12 +828,8 @@ export const canvasDispatch = (name, data, doc = getDocument()) => {
 export const canvasApi = {
   dragStart,
   updateRect,
-  getContext,
-  getNodePath,
   dragMove,
   setLocales,
-  setState,
-  deleteState,
   getRenderer,
   clearSelect,
   selectNode,
@@ -891,12 +837,8 @@ export const canvasApi = {
   insertNode,
   removeNode,
   addComponent,
-  setPageCss,
   addScript,
   addStyle,
-  getNode: () => {
-    return useCanvas().getNode()
-  },
   getCurrent,
   setSchema,
   setUtils,
@@ -905,7 +847,6 @@ export const canvasApi = {
   setI18n,
   getCanvasType,
   setCanvasType,
-  setProps,
   setGlobalState,
   getGlobalState,
   getDesignMode,

--- a/packages/canvas/container/src/keyboard.js
+++ b/packages/canvas/container/src/keyboard.js
@@ -14,7 +14,6 @@ import {
   getCurrent,
   insertNode,
   selectNode,
-  getSchema,
   POSITION,
   removeNodeById,
   allowInsert,
@@ -22,7 +21,7 @@ import {
   clearHover,
   hoverState
 } from './container'
-import { useHistory } from '@opentiny/tiny-engine-meta-register'
+import { useHistory, useCanvas } from '@opentiny/tiny-engine-meta-register'
 import { copyObject } from '../../common'
 import { getClipboardSchema, setClipboardSchema } from './utils'
 
@@ -63,7 +62,7 @@ const handlerArrow = (keyCode) => {
   if (schema) {
     index = parent.children.indexOf(schema)
   } else {
-    schema = getSchema()
+    schema = useCanvas().getSchema()
   }
 
   let obj = {

--- a/packages/canvas/package.json
+++ b/packages/canvas/package.json
@@ -44,7 +44,9 @@
     "@opentiny/tiny-engine-webcomponent-core": "workspace:*",
     "@vue/babel-plugin-jsx": "1.1.1",
     "@vue/shared": "^3.3.4",
-    "@vueuse/core": "^9.6.0"
+    "@vueuse/core": "^9.6.0",
+    "diff-match-patch": "^1.0.5",
+    "jsondiffpatch": "^0.6.0"
   },
   "devDependencies": {
     "@opentiny/tiny-engine-vite-plugin-meta-comments": "workspace:*",

--- a/packages/canvas/render/src/RenderMain.js
+++ b/packages/canvas/render/src/RenderMain.js
@@ -54,12 +54,25 @@ watchEffect(() => {
   })
 })
 
+const getDeletedKeys = (objA, objB) => {
+  const keyA = Object.keys(objA)
+  const keyB = new Set(Object.keys(objB))
+
+  return keyA.filter((item) => !keyB.has(item))
+}
+
 const getUtils = () => utils
 
-const setUtils = (data, clear, isForceRefresh) => {
-  if (clear) {
-    reset(utils)
+const setUtils = (data) => {
+  // 筛选出来已经被删除的 key
+  const newKeys = new Set(data.map(({ name }) => name))
+  const currentKeys = Object.keys(utils)
+  const deletedUtilsKeys = currentKeys.filter((item) => !newKeys.has(item))
+
+  for (const key of deletedUtilsKeys) {
+    delete utils[key]
   }
+
   const utilsCollection = {}
   // 目前画布还不具备远程加载utils工具类的功能，目前只能加载TinyVue组件库中的组件工具
   data?.forEach((item) => {
@@ -83,32 +96,8 @@ const setUtils = (data, clear, isForceRefresh) => {
   Object.assign(utils, utilsCollection)
 
   // 因为工具类并不具有响应式行为，所以需要通过修改key来强制刷新画布
-  if (isForceRefresh) {
-    refreshKey.value++
-  }
+  refreshKey.value++
 }
-
-const updateUtils = (data) => {
-  setUtils(data, false, true)
-}
-
-const deleteUtils = (data) => {
-  data?.forEach((item) => {
-    if (utils[item.name]) {
-      delete utils[item.name]
-    }
-  })
-  setUtils([], false, true)
-}
-
-const setBridge = (data, clear) => {
-  clear && reset(bridge)
-  Object.assign(bridge, data)
-}
-
-const getBridge = () => bridge
-
-// const getMethods = () => methods
 
 const setMethods = (data = {}, clear) => {
   clear && reset(methods)
@@ -123,10 +112,6 @@ const setMethods = (data = {}, clear) => {
   )
   setContext(methods)
 }
-
-// const deleteState = (variable) => {
-//   delete state[variable]
-// }
 
 const generateAccessor = (type, accessor, property) => {
   const accessorFn = generateFunction(accessor[type].value, context)
@@ -162,13 +147,6 @@ const generateStateAccessors = (type, accessor, key) => {
       }
     })
   )
-}
-
-const getDeletedKeys = (objA, objB) => {
-  const keyA = Object.keys(objA)
-  const keyB = new Set(Object.keys(objB))
-
-  return keyA.filter((item) => !keyB.has(item))
 }
 
 const setState = (data) => {
@@ -219,10 +197,6 @@ const setDataSourceMap = (list) => {
 
     return dMap
   }, {})
-}
-
-const getGlobalState = () => {
-  return globalState.value
 }
 
 const setGlobalState = (data = []) => {
@@ -390,12 +364,19 @@ export default {
 
     const { locale } = inject(I18nInjectionKey).global
     const { data } = useBroadcastChannel({ name: BROADCAST_CHANNEL.CanvasLang })
-    const { post } = useBroadcastChannel({ name: BROADCAST_CHANNEL.SchemaLength })
 
     window.host.subscribe({
       topic: 'schemaChange',
       subscriber: 'canvasRenderer',
       callback: throttleUpdateSchema
+    })
+
+    window.host.subscribe({
+      topic: 'schemaImport',
+      subscriber: 'canvasRenderer',
+      callback: () => {
+        setSchema(window.host.getSchema())
+      }
     })
 
     onUnmounted(() => {
@@ -408,13 +389,6 @@ export default {
     watch(data, () => {
       locale.value = data.value
     })
-
-    watch(
-      () => schema?.children?.length,
-      (length) => {
-        post(length)
-      }
-    )
 
     // 这里监听schema.methods，为了保证methods上下文环境始终为最新
     watch(
@@ -443,7 +417,38 @@ export default {
         deep: true
       }
     )
+
+    window.host.watch(
+      () => window.host.appSchema?.utils,
+      (data) => {
+        setUtils(data)
+      },
+      {
+        immediate: true
+      }
+    )
+
+    window.host.watch(
+      () => window.host.appSchema?.dataSource,
+      (data) => {
+        setDataSourceMap(data)
+      },
+      {
+        immediate: true
+      }
+    )
+
+    window.host.watch(
+      () => window.host.appSchema?.globalState,
+      (data) => {
+        setGlobalState(data)
+      },
+      {
+        immediate: true
+      }
+    )
   },
+
   render() {
     return getRenderer().call(this)
   }
@@ -452,23 +457,16 @@ export default {
 export const api = {
   // 用于 lowcode.js 获取 utils 工具类
   getUtils,
-  setUtils,
-  updateUtils,
-  deleteUtils,
-  getBridge,
-  setBridge,
   getDataSourceMap,
-  setDataSourceMap,
-  getGlobalState,
-  setGlobalState,
 
   // setState 需要把 collection 的引用解开
   setState,
 
+  // 用于调用区块获取、注册、以及 CanvasCollection 的相关逻辑调用
   setController,
   // 设置物料
   setConfigure,
-  setSchema,
+
   // 用于大纲树临时性隐藏
   setCondition,
   getRenderer,

--- a/packages/canvas/render/src/RenderMain.js
+++ b/packages/canvas/render/src/RenderMain.js
@@ -197,6 +197,10 @@ const setDataSourceMap = (list) => {
 
     return dMap
   }, {})
+
+  Object.defineProperty(context, 'dataSourceMap', {
+    get: getDataSourceMap
+  })
 }
 
 const setGlobalState = (data = []) => {

--- a/packages/canvas/render/src/RenderMain.js
+++ b/packages/canvas/render/src/RenderMain.js
@@ -14,7 +14,7 @@ import { h, provide, inject, nextTick, shallowReactive, reactive, ref, watch, wa
 import { I18nInjectionKey } from 'vue-i18n'
 import TinyVue from '@opentiny/vue'
 import * as TinyVueIcon from '@opentiny/vue-icon'
-import { useBroadcastChannel } from '@vueuse/core'
+import { useBroadcastChannel, useThrottleFn } from '@vueuse/core'
 import { constants, utils as commonUtils } from '@opentiny/tiny-engine-utils'
 import renderer, { parseData, setConfigure, setController, globalNotify, isStateAccessor } from './render'
 import {
@@ -388,29 +388,9 @@ const setRenderer = (fn) => {
   canvasRenderer = fn
 }
 
-let lastUpdateTime = 0
-let timeoutRef = null
-
-// TODO: 简单节流，需要优化
-const throttleUpdateSchema = () => {
-  let curTime = Date.now()
-
-  if (curTime - lastUpdateTime >= 100) {
-    clearTimeout(timeoutRef)
-    lastUpdateTime = curTime
-    window.host.patchLatestSchema(schema)
-
-    return
-  }
-
-  timeoutRef = setTimeout(() => {
-    clearTimeout(timeoutRef)
-
-    lastUpdateTime = curTime
-
-    window.host.patchLatestSchema(schema)
-  }, 100)
-}
+const throttleUpdateSchema = useThrottleFn(() => {
+  window.host.patchLatestSchema(schema)
+}, 100)
 
 export default {
   setup() {
@@ -422,9 +402,7 @@ export default {
 
     window.host.subscribe({
       topic: 'schemaChange',
-      callback: () => {
-        throttleUpdateSchema()
-      }
+      callback: throttleUpdateSchema
     })
 
     watch(data, () => {

--- a/packages/canvas/render/src/RenderMain.js
+++ b/packages/canvas/render/src/RenderMain.js
@@ -391,6 +391,7 @@ const setRenderer = (fn) => {
 let lastUpdateTime = 0
 let timeoutRef = null
 
+// TODO: 简单节流，需要优化
 const throttleUpdateSchema = () => {
   let curTime = Date.now()
 

--- a/packages/canvas/render/src/RenderMain.js
+++ b/packages/canvas/render/src/RenderMain.js
@@ -268,8 +268,6 @@ const initProps = (properties = []) => {
   return accessorFunctions
 }
 
-const getSchema = () => schema
-
 const setPagecss = (css = '') => {
   const id = 'page-css'
   let element = document.getElementById(id)
@@ -455,7 +453,6 @@ export const api = {
   setMethods,
   setController,
   setConfigure,
-  getSchema,
   setSchema,
   getState,
   deleteState,

--- a/packages/canvas/render/src/RenderMain.js
+++ b/packages/canvas/render/src/RenderMain.js
@@ -10,7 +10,7 @@
  *
  */
 
-import { h, provide, inject, nextTick, shallowReactive, reactive, ref, watch, watchEffect } from 'vue'
+import { h, provide, inject, nextTick, shallowReactive, reactive, ref, watch, watchEffect, onUnmounted } from 'vue'
 import { I18nInjectionKey } from 'vue-i18n'
 import TinyVue from '@opentiny/vue'
 import * as TinyVueIcon from '@opentiny/vue-icon'
@@ -388,9 +388,13 @@ const setRenderer = (fn) => {
   canvasRenderer = fn
 }
 
-const throttleUpdateSchema = useThrottleFn(() => {
-  window.host.patchLatestSchema(schema)
-}, 100)
+const throttleUpdateSchema = useThrottleFn(
+  () => {
+    window.host.patchLatestSchema(schema)
+  },
+  100,
+  true
+)
 
 export default {
   setup() {
@@ -402,6 +406,7 @@ export default {
 
     window.host.subscribe({
       topic: 'schemaChange',
+      subscriber: 'canvasRenderer',
       callback: throttleUpdateSchema
     })
 
@@ -426,6 +431,13 @@ export default {
         deep: true
       }
     )
+
+    onUnmounted(() => {
+      window.host.unsubscribe({
+        topic: 'schemaChange',
+        subscriber: 'canvasRenderer'
+      })
+    })
   },
   render() {
     return getRenderer().call(this)

--- a/packages/canvas/render/src/RenderMain.js
+++ b/packages/canvas/render/src/RenderMain.js
@@ -383,13 +383,6 @@ export default {
       }
     })
 
-    onUnmounted(() => {
-      window.host.unsubscribe({
-        topic: 'schemaChange',
-        subscriber: 'canvasRenderer'
-      })
-    })
-
     watch(data, () => {
       locale.value = data.value
     })
@@ -422,35 +415,54 @@ export default {
       }
     )
 
-    window.host.watch(
+    const utilsWatchCanceler = window.host.watch(
       () => window.host.appSchema?.utils,
       (data) => {
         setUtils(data)
       },
       {
-        immediate: true
+        immediate: true,
+        deep: true
       }
     )
 
-    window.host.watch(
+    const dataSourceWatchCanceler = window.host.watch(
       () => window.host.appSchema?.dataSource,
       (data) => {
         setDataSourceMap(data)
       },
       {
-        immediate: true
+        immediate: true,
+        deep: true
       }
     )
 
-    window.host.watch(
+    const globalStateWatchCanceler = window.host.watch(
       () => window.host.appSchema?.globalState,
       (data) => {
         setGlobalState(data)
       },
       {
-        immediate: true
+        immediate: true,
+        deep: true
       }
     )
+
+    onUnmounted(() => {
+      window.host.unsubscribe({
+        topic: 'schemaChange',
+        subscriber: 'canvasRenderer'
+      })
+
+      window.host.unsubscribe({
+        topic: 'schemaImport',
+        subscriber: 'canvasRenderer'
+      })
+
+      utilsWatchCanceler()
+      dataSourceWatchCanceler()
+      globalStateWatchCanceler()
+    })
   },
 
   render() {

--- a/packages/canvas/render/src/RenderMain.js
+++ b/packages/canvas/render/src/RenderMain.js
@@ -64,6 +64,10 @@ const getDeletedKeys = (objA, objB) => {
 const getUtils = () => utils
 
 const setUtils = (data) => {
+  if (!Array.isArray(data)) {
+    return
+  }
+
   // 筛选出来已经被删除的 key
   const newKeys = new Set(data.map(({ name }) => name))
   const currentKeys = Object.keys(utils)
@@ -150,6 +154,10 @@ const generateStateAccessors = (type, accessor, key) => {
 }
 
 const setState = (data) => {
+  if (typeof data !== 'object' || data === null) {
+    return
+  }
+
   const deletedKeys = getDeletedKeys(state, data)
 
   // 同步删除的 key

--- a/packages/canvas/render/src/RenderMain.js
+++ b/packages/canvas/render/src/RenderMain.js
@@ -459,9 +459,6 @@ export const api = {
   getUtils,
   getDataSourceMap,
 
-  // setState 需要把 collection 的引用解开
-  setState,
-
   // 用于调用区块获取、注册、以及 CanvasCollection 的相关逻辑调用
   setController,
   // 设置物料

--- a/packages/canvas/render/src/RenderMain.js
+++ b/packages/canvas/render/src/RenderMain.js
@@ -17,7 +17,7 @@ import * as TinyVueIcon from '@opentiny/vue-icon'
 import { useBroadcastChannel, useThrottleFn } from '@vueuse/core'
 import { constants, utils as commonUtils } from '@opentiny/tiny-engine-utils'
 import renderer, { parseData, setConfigure, setController, globalNotify, isStateAccessor } from './render'
-import { clearNodes, setContext, getContext, setCondition, context, getDesignMode, setDesignMode } from './context'
+import { setContext, getContext, setCondition, context, getDesignMode, setDesignMode } from './context'
 import CanvasEmpty from './CanvasEmpty.vue'
 
 const { BROADCAST_CHANNEL } = constants
@@ -293,7 +293,7 @@ const setSchema = async (data) => {
 
   // 这里setState（会触发画布渲染），是因为状态管理里面的变量会用到props、utils、bridge、stores、methods
   setState(newSchema.state, true)
-  clearNodes()
+
   await nextTick()
   setPageCss(data.css)
   Object.assign(schema, newSchema)

--- a/packages/canvas/render/src/RenderMain.js
+++ b/packages/canvas/render/src/RenderMain.js
@@ -17,20 +17,7 @@ import * as TinyVueIcon from '@opentiny/vue-icon'
 import { useBroadcastChannel, useThrottleFn } from '@vueuse/core'
 import { constants, utils as commonUtils } from '@opentiny/tiny-engine-utils'
 import renderer, { parseData, setConfigure, setController, globalNotify, isStateAccessor } from './render'
-import {
-  getNode as getNodeById,
-  clearNodes,
-  getRoot,
-  setContext,
-  getContext,
-  setCondition,
-  getCondition,
-  getConditions,
-  context,
-  setNode,
-  getDesignMode,
-  setDesignMode
-} from './context'
+import { clearNodes, setContext, getContext, setCondition, context, getDesignMode, setDesignMode } from './context'
 import CanvasEmpty from './CanvasEmpty.vue'
 
 const { BROADCAST_CHANNEL } = constants
@@ -121,7 +108,7 @@ const setBridge = (data, clear) => {
 
 const getBridge = () => bridge
 
-const getMethods = () => methods
+// const getMethods = () => methods
 
 const setMethods = (data = {}, clear) => {
   clear && reset(methods)
@@ -137,11 +124,9 @@ const setMethods = (data = {}, clear) => {
   setContext(methods)
 }
 
-const getState = () => state
-
-const deleteState = (variable) => {
-  delete state[variable]
-}
+// const deleteState = (variable) => {
+//   delete state[variable]
+// }
 
 const generateAccessor = (type, accessor, property) => {
   const accessorFn = generateFunction(accessor[type].value, context)
@@ -179,10 +164,19 @@ const generateStateAccessors = (type, accessor, key) => {
   )
 }
 
-const setState = (data, clear) => {
-  clear && reset(state)
-  if (!schema.state) {
-    schema.state = data
+const getDeletedKeys = (objA, objB) => {
+  const keyA = Object.keys(objA)
+  const keyB = new Set(Object.keys(objB))
+
+  return keyA.filter((item) => !keyB.has(item))
+}
+
+const setState = (data) => {
+  const deletedKeys = getDeletedKeys(state, data)
+
+  // 同步删除的 key
+  for (const key of deletedKeys) {
+    delete state[key]
   }
 
   Object.assign(state, parseData(data, {}, getContext()) || {})
@@ -240,8 +234,6 @@ const setProps = (data, clear) => {
   Object.assign(props, data)
 }
 
-const getProps = () => props
-
 const initProps = (properties = []) => {
   const props = {}
   const accessorFunctions = []
@@ -268,7 +260,7 @@ const initProps = (properties = []) => {
   return accessorFunctions
 }
 
-const setPagecss = (css = '') => {
+const setPageCss = (css = '') => {
   const id = 'page-css'
   let element = document.getElementById(id)
   const head = document.querySelector('head')
@@ -329,7 +321,7 @@ const setSchema = async (data) => {
   setState(newSchema.state, true)
   clearNodes()
   await nextTick()
-  setPagecss(data.css)
+  setPageCss(data.css)
   Object.assign(schema, newSchema)
 
   // 当上下文环境设置完成之后再去处理区块属性访问器的watchEffect
@@ -353,8 +345,6 @@ const setSchema = async (data) => {
 
   return schema
 }
-
-const getNode = (id, parent) => (id ? getNodeById(id, parent) : schema)
 
 let canvasRenderer = null
 
@@ -408,6 +398,13 @@ export default {
       callback: throttleUpdateSchema
     })
 
+    onUnmounted(() => {
+      window.host.unsubscribe({
+        topic: 'schemaChange',
+        subscriber: 'canvasRenderer'
+      })
+    })
+
     watch(data, () => {
       locale.value = data.value
     })
@@ -430,12 +427,22 @@ export default {
       }
     )
 
-    onUnmounted(() => {
-      window.host.unsubscribe({
-        topic: 'schemaChange',
-        subscriber: 'canvasRenderer'
-      })
-    })
+    watch(
+      () => schema.css,
+      (value) => {
+        setPageCss(value)
+      }
+    )
+
+    watch(
+      () => schema.state,
+      (value) => {
+        setState(value)
+      },
+      {
+        deep: true
+      }
+    )
   },
   render() {
     return getRenderer().call(this)
@@ -443,34 +450,27 @@ export default {
 }
 
 export const api = {
+  // 用于 lowcode.js 获取 utils 工具类
   getUtils,
   setUtils,
   updateUtils,
   deleteUtils,
   getBridge,
   setBridge,
-  getMethods,
-  setMethods,
-  setController,
-  setConfigure,
-  setSchema,
-  getState,
-  deleteState,
-  setState,
-  getProps,
-  setProps,
-  getContext,
-  getNode,
-  getRoot,
-  setPagecss,
-  setCondition,
-  getCondition,
-  getConditions,
-  getGlobalState,
   getDataSourceMap,
   setDataSourceMap,
+  getGlobalState,
   setGlobalState,
-  setNode,
+
+  // setState 需要把 collection 的引用解开
+  setState,
+
+  setController,
+  // 设置物料
+  setConfigure,
+  setSchema,
+  // 用于大纲树临时性隐藏
+  setCondition,
   getRenderer,
   setRenderer,
   getDesignMode,

--- a/packages/canvas/render/src/RenderMain.js
+++ b/packages/canvas/render/src/RenderMain.js
@@ -363,6 +363,7 @@ let canvasRenderer = null
 const defaultRenderer = function () {
   // 渲染画布增加根节点，与出码和预览保持一致
   const rootChildrenSchema = {
+    id: 0,
     componentName: 'div',
     // 手动添加一个唯一的属性，后续在画布选中此节点时方便处理额外的逻辑。由于没有修改schema，不会影响出码
     props: { ...schema.props, 'data-id': 'root-container' },
@@ -387,6 +388,29 @@ const setRenderer = (fn) => {
   canvasRenderer = fn
 }
 
+let lastUpdateTime = 0
+let timeoutRef = null
+
+const throttleUpdateSchema = () => {
+  let curTime = Date.now()
+
+  if (curTime - lastUpdateTime >= 100) {
+    clearTimeout(timeoutRef)
+    lastUpdateTime = curTime
+    window.host.patchLatestSchema(schema)
+
+    return
+  }
+
+  timeoutRef = setTimeout(() => {
+    clearTimeout(timeoutRef)
+
+    lastUpdateTime = curTime
+
+    window.host.patchLatestSchema(schema)
+  }, 100)
+}
+
 export default {
   setup() {
     provide('rootSchema', schema)
@@ -394,6 +418,13 @@ export default {
     const { locale } = inject(I18nInjectionKey).global
     const { data } = useBroadcastChannel({ name: BROADCAST_CHANNEL.CanvasLang })
     const { post } = useBroadcastChannel({ name: BROADCAST_CHANNEL.SchemaLength })
+
+    window.host.subscribe({
+      topic: 'schemaChange',
+      callback: () => {
+        throttleUpdateSchema()
+      }
+    })
 
     watch(data, () => {
       locale.value = data.value

--- a/packages/canvas/render/src/builtin/CanvasCollection.js
+++ b/packages/canvas/render/src/builtin/CanvasCollection.js
@@ -119,12 +119,19 @@ const askShouldImportData = ({ node, sourceRef, updateKey }) => {
     .confirm({
       message: '检测到表格存在配置的数据，是否需要引入？',
       exec() {
-        const sourceColumns = sourceRef.value?.data?.columns?.map(({ title, field }) => ({ title, field })) || []
-        // 这里需要找到对应列，然后进行列合并
-        node.props.columns = generateAssignColumns(sourceColumns, node.props.columns)
+        try {
+          const sourceColumns = sourceRef.value?.data?.columns?.map(({ title, field }) => ({ title, field })) || []
+          // 这里需要找到对应列，然后进行列合并
+          node.props.columns = generateAssignColumns(sourceColumns, node.props.columns)
 
-        publish({ topic: 'schemaChange', data: {} })
-        updateKey.value++
+          publish({ topic: 'schemaChange', data: {} })
+          updateKey.value++
+        } catch (error) {
+          getController().useNotify({
+            type: 'error',
+            message: '引入配置数据失败'
+          })
+        }
       },
       cancel() {
         node.props.columns = [...(sourceRef.value.data?.columns || [])]

--- a/packages/canvas/render/src/builtin/CanvasCollection.js
+++ b/packages/canvas/render/src/builtin/CanvasCollection.js
@@ -111,7 +111,7 @@ const generateAssignColumns = (newColumns, oldColumns) => {
   return newColumns
 }
 
-const askShouldImportData = ({ node, sourceRef }) => {
+const askShouldImportData = ({ node, sourceRef, updateKey }) => {
   const { publish } = getController().useMessage()
 
   getController()
@@ -124,6 +124,7 @@ const askShouldImportData = ({ node, sourceRef }) => {
         node.props.columns = generateAssignColumns(sourceColumns, node.props.columns)
 
         publish({ topic: 'schemaChange', data: {} })
+        updateKey.value++
       },
       cancel() {
         node.props.columns = [...(sourceRef.value.data?.columns || [])]
@@ -133,8 +134,8 @@ const askShouldImportData = ({ node, sourceRef }) => {
     })
 }
 
-const updateNodeHandler = ({ node, sourceRef, pageSchema, sourceName, methodName }) => {
-  if (!node || !node.props) {
+const updateNodeHandler = ({ node, sourceRef, pageSchema, sourceName, methodName, updateKey }) => {
+  if (!node || !node.props || !sourceName) {
     return
   }
 
@@ -142,7 +143,7 @@ const updateNodeHandler = ({ node, sourceRef, pageSchema, sourceName, methodName
   delete node?.props?.data
 
   if (node.props.columns.length) {
-    askShouldImportData({ node, sourceRef })
+    askShouldImportData({ node, sourceRef, updateKey })
   } else {
     node.props.columns = [...(sourceRef.value.data?.columns || [])]
   }
@@ -181,7 +182,7 @@ this.dataSourceMap.${sourceName}.load().then((res) => {
 }
 
 const extraHandlerMap = {
-  TinyGrid: ({ node, sourceRef, schemaId, pageSchema }) => {
+  TinyGrid: ({ node, sourceRef, schemaId, pageSchema, updateKey }) => {
     const sourceName = sourceRef.value?.name
     const methodName = `${NAME_PREFIX.table}${schemaId}`
 
@@ -190,7 +191,7 @@ const extraHandlerMap = {
       value: `{ api: this.${methodName} }`
     }
 
-    const updateNode = () => updateNodeHandler({ node, sourceRef, pageSchema, sourceName, methodName })
+    const updateNode = () => updateNodeHandler({ node, sourceRef, pageSchema, sourceName, methodName, updateKey })
 
     const clearBindVar = () => {
       // 当数据源组件children字段为空时，及时清空创建的methods
@@ -277,7 +278,7 @@ const extraHandlerMap = {
   }
 }
 
-export const getHandler = ({ node, sourceRef, schemaId, pageSchema }) =>
+export const getHandler = ({ node, sourceRef, schemaId, pageSchema, updateKey }) =>
   extraHandlerMap[node.componentName]
-    ? extraHandlerMap[node.componentName]({ node, sourceRef, schemaId, pageSchema })
+    ? extraHandlerMap[node.componentName]({ node, sourceRef, schemaId, pageSchema, updateKey })
     : defaultHandlerTemplate({ node, sourceRef, schemaId, pageSchema })

--- a/packages/canvas/render/src/builtin/CanvasCollection.js
+++ b/packages/canvas/render/src/builtin/CanvasCollection.js
@@ -9,8 +9,8 @@
  * A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
  *
  */
-import * as ast from '@opentiny/tiny-engine-common/js/ast'
-import { useModal, useMaterial, useMessage } from '@opentiny/tiny-engine-meta-register'
+
+import { getController } from '../render'
 
 const NAME_PREFIX = {
   loop: 'loop',
@@ -43,7 +43,7 @@ const genRemoteMethodToLifeSetup = (variableName, sourceRef, pageSchema) => {
 const removeState = (pageSchema, variableName) => {
   delete pageSchema.state[variableName]
 
-  const { parse, traverse, generate } = ast
+  const { parse, traverse, generate } = getController().ast
   const setupFn = pageSchema.lifeCycles?.setup?.value
 
   try {
@@ -73,7 +73,7 @@ const defaultHandlerTemplate = ({ node, sourceRef, schemaId, pageSchema }) => {
   const genVarName = (schemaId) => `${NAME_PREFIX.loop}${schemaId}`
 
   const updateNode = () => {
-    const { configure } = useMaterial().getMaterial(node?.componentName)
+    const { configure } = getController().getMaterial(node?.componentName)
 
     if (!configure?.loop) {
       return
@@ -112,23 +112,25 @@ const generateAssignColumns = (newColumns, oldColumns) => {
 }
 
 const askShouldImportData = ({ node, sourceRef }) => {
-  const { publish } = useMessage()
+  const { publish } = getController().useMessage()
 
-  useModal().confirm({
-    message: '检测到表格存在配置的数据，是否需要引入？',
-    exec() {
-      const sourceColumns = sourceRef.value?.data?.columns?.map(({ title, field }) => ({ title, field })) || []
-      // 这里需要找到对应列，然后进行列合并
-      node.props.columns = generateAssignColumns(sourceColumns, node.props.columns)
+  getController()
+    .useModal()
+    .confirm({
+      message: '检测到表格存在配置的数据，是否需要引入？',
+      exec() {
+        const sourceColumns = sourceRef.value?.data?.columns?.map(({ title, field }) => ({ title, field })) || []
+        // 这里需要找到对应列，然后进行列合并
+        node.props.columns = generateAssignColumns(sourceColumns, node.props.columns)
 
-      publish({ topic: 'schemaChange', data: {} })
-    },
-    cancel() {
-      node.props.columns = [...(sourceRef.value.data?.columns || [])]
+        publish({ topic: 'schemaChange', data: {} })
+      },
+      cancel() {
+        node.props.columns = [...(sourceRef.value.data?.columns || [])]
 
-      publish({ topic: 'schemaChange', data: {} })
-    }
-  })
+        publish({ topic: 'schemaChange', data: {} })
+      }
+    })
 }
 
 const updateNodeHandler = ({ node, sourceRef, pageSchema, sourceName, methodName }) => {

--- a/packages/canvas/render/src/builtin/CanvasCollection.vue
+++ b/packages/canvas/render/src/builtin/CanvasCollection.vue
@@ -1,106 +1,24 @@
 <template>
   <component :is="tag" v-bind="$attrs">
     <slot>
-      <canvas-placeholder>{{ source?.name || '未选择数据源' }}</canvas-placeholder>
+      <canvas-placeholder></canvas-placeholder>
     </slot>
   </component>
 </template>
 
 <script>
-import { ref, watch, computed, inject } from 'vue'
-import { getController } from '../render'
 import CanvasPlaceholder from './CanvasPlaceholder.vue'
-
-import { getHandler } from './CanvasCollection.js'
-
-export const fetchDataSourceDetail = (dataSourceId) =>
-  getController().request.get(`/app-center/api/sources/detail/${dataSourceId}`) // TODO: 强行耦合了
 
 export default {
   components: {
     CanvasPlaceholder
   },
   props: {
+    // TODO: 这里实际上没有提供配置的入口，可以考虑删除了(出码也没有定制)
     tag: {
       type: String,
       default: 'div'
-    },
-    schema: {
-      type: Object,
-      default: () => ({})
-    },
-    dataSource: [String, Array, Number]
-  },
-  setup(props) {
-    const source = ref(null)
-    const pageSchema = inject('rootSchema')
-
-    if (props.dataSource) {
-      fetchDataSourceDetail(props.dataSource).then((res) => {
-        source.value = res
-      })
     }
-
-    let handler
-
-    watch(
-      () => props.dataSource,
-      async (value) => {
-        if (value) {
-          source.value = await fetchDataSourceDetail(value)
-          if (props.schema?.children[0]) {
-            handler = getHandler({
-              sourceRef: source,
-              node: props.schema?.children[0],
-              schemaId: props.schema.id,
-              pageSchema
-            })
-          }
-          handler?.updateNode()
-        }
-      }
-    )
-
-    const isEmpty = computed(() => {
-      const { children } = props.schema || {}
-
-      return Array.isArray(children) ? !children.length : !children
-    })
-
-    watch(
-      () => isEmpty.value,
-      (value) => {
-        if (value) {
-          // 清除自动创建的state,method与setup逻辑
-          if (handler) {
-            handler.clearBindVar()
-          } else {
-            const schemaId = props.schema?.id
-
-            // 当页面初始化时handler是不存在的，所以需要通过数据源的schemaId（唯一性），去删除对应的方法
-            Object.keys(pageSchema.methods || {})?.some((item) => {
-              if (item.includes(schemaId)) {
-                delete pageSchema.methods[item]
-                return true
-              }
-              return false
-            })
-          }
-        } else {
-          if (props.schema?.children[0]) {
-            handler = getHandler({
-              sourceRef: source,
-              node: props.schema?.children[0],
-              schemaId: props.schema.id,
-              pageSchema
-            })
-            handler.updateNode()
-          }
-        }
-      }
-    )
-
-    return { source }
   }
 }
 </script>

--- a/packages/canvas/render/src/builtin/CanvasCollection.vue
+++ b/packages/canvas/render/src/builtin/CanvasCollection.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="tag" v-bind="$attrs">
+  <component :is="tag" v-bind="$attrs" :key="updateKey">
     <slot>
       <canvas-placeholder></canvas-placeholder>
     </slot>
@@ -33,6 +33,8 @@ export default {
   },
   setup(props) {
     const source = ref(null)
+    // 这里 key 的作用是：触发组件更新，这样就能触发 tiny-grid 表格组件重新触发 fetchData 方法，进而刷新数据显示到画布
+    const updateKey = ref(0)
 
     if (props.dataSource) {
       fetchDataSourceDetail(props.dataSource).then((res) => {
@@ -54,10 +56,12 @@ export default {
               sourceRef: source,
               node,
               schemaId: props.schema.id,
-              pageSchema: getSchema()
+              pageSchema: getSchema(),
+              updateKey
             })
           }
           handler?.updateNode()
+          updateKey.value++
         }
       }
     )
@@ -94,7 +98,8 @@ export default {
               sourceRef: source,
               node,
               schemaId: props.schema.id,
-              pageSchema
+              pageSchema,
+              updateKey
             })
             handler.updateNode()
           }
@@ -103,9 +108,10 @@ export default {
         const { publish } = getController().useMessage()
 
         publish({ topic: 'schemaChange', data: {} })
+        updateKey.value++
       }
     )
-    return { source }
+    return { source, updateKey }
   }
 }
 </script>

--- a/packages/canvas/render/src/builtin/CanvasCollection.vue
+++ b/packages/canvas/render/src/builtin/CanvasCollection.vue
@@ -7,7 +7,13 @@
 </template>
 
 <script>
+import { ref, watch, computed } from 'vue'
 import CanvasPlaceholder from './CanvasPlaceholder.vue'
+import { getController } from '../render'
+import { getHandler } from './CanvasCollection'
+
+export const fetchDataSourceDetail = (dataSourceId) =>
+  getController().request.get(`/app-center/api/sources/detail/${dataSourceId}`) // TODO: 强行耦合了
 
 export default {
   components: {
@@ -18,7 +24,88 @@ export default {
     tag: {
       type: String,
       default: 'div'
+    },
+    schema: {
+      type: Object,
+      default: () => ({})
+    },
+    dataSource: [String, Array, Number]
+  },
+  setup(props) {
+    const source = ref(null)
+
+    if (props.dataSource) {
+      fetchDataSourceDetail(props.dataSource).then((res) => {
+        source.value = res
+      })
     }
+
+    let handler
+    watch(
+      () => props.dataSource,
+      async (value) => {
+        if (value) {
+          source.value = await fetchDataSourceDetail(value)
+          const { getSchema, getNode } = window.host.schemaUtils
+          const node = getNode(props.schema?.children?.[0]?.id)
+
+          if (node) {
+            handler = getHandler({
+              sourceRef: source,
+              node,
+              schemaId: props.schema.id,
+              pageSchema: getSchema()
+            })
+          }
+          handler?.updateNode()
+        }
+      }
+    )
+    const isEmpty = computed(() => {
+      const { children } = props.schema || {}
+      return Array.isArray(children) ? !children.length : !children
+    })
+
+    watch(
+      () => isEmpty.value,
+      (value) => {
+        const { getSchema, getNode } = window.host.schemaUtils
+        const pageSchema = getSchema()
+
+        if (value) {
+          // 清除自动创建的state,method与setup逻辑
+          if (handler) {
+            handler.clearBindVar()
+          } else {
+            const schemaId = props.schema?.id
+            // 当页面初始化时handler是不存在的，所以需要通过数据源的schemaId（唯一性），去删除对应的方法
+            Object.keys(pageSchema.methods || {})?.some((item) => {
+              if (item.includes(schemaId)) {
+                delete pageSchema.methods[item]
+                return true
+              }
+              return false
+            })
+          }
+        } else {
+          const node = getNode(props.schema?.children?.[0]?.id)
+          if (node) {
+            handler = getHandler({
+              sourceRef: source,
+              node,
+              schemaId: props.schema.id,
+              pageSchema
+            })
+            handler.updateNode()
+          }
+        }
+
+        const { publish } = getController().useMessage()
+
+        publish({ topic: 'schemaChange', data: {} })
+      }
+    )
+    return { source }
   }
 }
 </script>

--- a/packages/canvas/render/src/context.js
+++ b/packages/canvas/render/src/context.js
@@ -11,35 +11,11 @@
  */
 
 import { shallowReactive } from 'vue'
-import { utils } from '@opentiny/tiny-engine-utils'
 
 export const context = shallowReactive({})
 
 // 从大纲树控制隐藏
 export const conditions = shallowReactive({})
-
-const nodes = {}
-
-export const setNode = (schema, parent) => {
-  schema.id = schema.id || utils.guid()
-  nodes[schema.id] = { node: schema, parent }
-}
-
-export const getNode = (id, parent) => {
-  return parent ? nodes[id] : nodes[id].node
-}
-
-export const delNode = (id) => delete nodes[id]
-
-export const clearNodes = () => {
-  Object.keys(nodes).forEach(delNode)
-}
-
-export const getRoot = (id) => {
-  const { parent } = getNode(id, true)
-
-  return parent?.id ? getRoot(parent.id) : parent
-}
 
 export const setContext = (ctx, clear) => {
   clear && Object.keys(context).forEach((key) => delete context[key])

--- a/packages/canvas/render/src/render.js
+++ b/packages/canvas/render/src/render.js
@@ -26,7 +26,7 @@ import {
 } from '@opentiny/tiny-engine-builtin-component'
 
 import { NODE_UID as DESIGN_UIDKEY, NODE_TAG as DESIGN_TAGKEY, NODE_LOOP as DESIGN_LOOPID } from '../../common'
-import { context, conditions, setNode, getDesignMode, DESIGN_MODE } from './context'
+import { context, conditions, getDesignMode, DESIGN_MODE } from './context'
 import {
   CanvasBox,
   CanvasCollection,
@@ -625,7 +625,7 @@ const injectPlaceHolder = (componentName, children) => {
   return children
 }
 
-const renderGroup = (children, scope, parent) => {
+const renderGroup = (children, scope) => {
   return children.map?.((schema) => {
     const { componentName, children, loop, loopArgs, condition, id } = schema
     const loopList = parseData(loop, scope)
@@ -637,8 +637,6 @@ const renderGroup = (children, scope, parent) => {
         item,
         loopArgs
       })
-
-      setNode(schema, parent)
 
       if (conditions[id] === false || !parseCondition(condition, mergeScope)) {
         return null
@@ -673,7 +671,7 @@ const getChildren = (schema, mergeScope) => {
       return renderDefault(renderChildren, mergeScope, schema)
     } else {
       return isGroup
-        ? renderGroup(renderChildren, mergeScope, schema)
+        ? renderGroup(renderChildren, mergeScope)
         : renderSlot(renderChildren, mergeScope, schema, isCustomElm)
     }
   } else {
@@ -723,9 +721,6 @@ export const renderer = {
         const slotData = blockSlotDataMap[blockName]?.[slotName] || {}
         mergeScope = mergeScope ? { ...mergeScope, ...slotData } : slotData
       }
-
-      // 给每个节点设置schema.id，并缓存起来
-      setNode(schema, parent)
 
       if (conditions[schema.id] === false || !parseCondition(condition, mergeScope)) {
         return null

--- a/packages/canvas/render/src/render.js
+++ b/packages/canvas/render/src/render.js
@@ -726,7 +726,13 @@ export const renderer = {
         return null
       }
 
-      return h(component, getBindProps(schema, mergeScope), getChildren(schema, mergeScope))
+      const children = getChildren(schema, mergeScope)
+
+      return h(
+        component,
+        getBindProps(schema, mergeScope),
+        Array.isArray(children) && !children.length ? null : children
+      )
     }
 
     return loopList?.length ? loopList.map(renderElement) : renderElement()

--- a/packages/canvas/render/src/render.js
+++ b/packages/canvas/render/src/render.js
@@ -667,16 +667,21 @@ const getChildren = (schema, mergeScope) => {
   const isGroup = checkGroup(componentName)
 
   if (Array.isArray(renderChildren)) {
+    // children 空的场景，不能返回空数组，因为有部分组件会误以为使用了自定义插槽，从而无法渲染默认插槽内容，比如 TinyTree 组件
+    if (!renderChildren.length) {
+      return null
+    }
+
     if (isNative || isCustomElm) {
       return renderDefault(renderChildren, mergeScope, schema)
-    } else {
-      return isGroup
-        ? renderGroup(renderChildren, mergeScope)
-        : renderSlot(renderChildren, mergeScope, schema, isCustomElm)
     }
-  } else {
-    return parseData(renderChildren, mergeScope)
+
+    return isGroup
+      ? renderGroup(renderChildren, mergeScope)
+      : renderSlot(renderChildren, mergeScope, schema, isCustomElm)
   }
+
+  return parseData(renderChildren, mergeScope)
 }
 
 export const renderer = {

--- a/packages/common/component/BlockDeployDialog.vue
+++ b/packages/common/component/BlockDeployDialog.vue
@@ -208,8 +208,7 @@ export default {
       }
       try {
         const pageSchema = JSON.parse(state.newCode)
-        const setSchema = useCanvas().canvasApi.value.setSchema
-        setSchema?.({ ...pageSchema, componentName: COMPONENT_NAME.Block })
+        useCanvas().importSchema({ ...pageSchema, componentName: COMPONENT_NAME.Block })
         close()
       } catch (err) {
         useNotify({

--- a/packages/common/component/BlockDeployDialog.vue
+++ b/packages/common/component/BlockDeployDialog.vue
@@ -175,7 +175,7 @@ export default {
         const remote = await api.getBlockById(block?.id)
         const originalObj = remote?.content || {}
         state.originalCode = JSON.stringify(originalObj, null, 2)
-        const getSchema = useCanvas().canvasApi.value.getSchema
+        const getSchema = useCanvas().getSchema
 
         // 转为普通对象，和线上代码顺序保持一致
         const pageSchema = getSchema?.() || {}

--- a/packages/common/component/BlockLinkEvent.vue
+++ b/packages/common/component/BlockLinkEvent.vue
@@ -38,7 +38,7 @@ export default {
     const { addBlockEvent, removeEventLink, getCurrentBlock, appendEventEmit } = useBlock()
     const { PLUGIN_NAME, activePlugin } = useLayout()
 
-    const { schema } = useCanvas().canvasApi.value?.getSchema?.() || {}
+    const { schema } = useCanvas()?.getSchema?.() || {}
     const events = schema?.events || []
     const eventsList = Object.entries(events).map(([key, value]) => {
       return {

--- a/packages/common/component/BlockLinkField.vue
+++ b/packages/common/component/BlockLinkField.vue
@@ -48,10 +48,10 @@ export default {
   },
   setup(props) {
     const { confirm } = useModal()
-    const { pageState, canvasApi } = useCanvas()
+    const { pageState, canvasApi, getSchema } = useCanvas()
     const { addBlockProperty, removePropertyLink, getCurrentBlock, editBlockProperty } = useBlock()
     const { PLUGIN_NAME, activePlugin } = useLayout()
-    const { schema } = canvasApi.value.getSchema?.() || {}
+    const { schema } = getSchema?.() || {}
 
     const state = reactive({
       newPropertyName: ''

--- a/packages/common/component/ConfigItem.vue
+++ b/packages/common/component/ConfigItem.vue
@@ -265,11 +265,11 @@ export default {
 
     const updateValue = (value) => {
       const { property, type } = props.property
-      const { setProp } = useProperties()
+      const { setProp, getSchema } = useProperties()
 
       // 是否双向绑定
       if (value?.type === SCHEMA_DATA_TYPE.JSExpression) {
-        const currentComponent = useProperties().getSchema().componentName
+        const currentComponent = getSchema().componentName
         const {
           schema: { events = {} }
         } = useMaterial().getMaterial(currentComponent)
@@ -282,13 +282,13 @@ export default {
         }
       }
 
+      const { operateNode, isSaved } = useCanvas()
+
       if (property === 'children') {
-        useProperties().getSchema().children = value
+        const schema = getSchema()
+        operateNode({ type: 'updateAttributes', id: schema.id, value: { children: value } })
       } else {
-        if (
-          !useCanvas().isSaved() &&
-          ![PAGE_STATUS.Guest, PAGE_STATUS.Occupy].includes(useLayout().layoutState.pageStatus.state)
-        ) {
+        if (!isSaved() && ![PAGE_STATUS.Guest, PAGE_STATUS.Occupy].includes(useLayout().layoutState.pageStatus.state)) {
           return
         }
 

--- a/packages/common/component/LifeCycles.vue
+++ b/packages/common/component/LifeCycles.vue
@@ -131,7 +131,7 @@ export default {
     }
 
     const syncLifeCycle = () => {
-      const currentSchema = useCanvas().canvasApi.value?.getSchema?.()
+      const currentSchema = useCanvas()?.getSchema?.()
       const pageContent = getPageContent()
       const { id, fileName } = pageContent
       if (id === currentSchema.id || fileName === currentSchema.fileName) {
@@ -154,8 +154,7 @@ export default {
 
     const openLifeCyclesPanel = (item) => {
       state.title = item
-      const bindLifeCycleSource =
-        props.bindLifeCycles?.[item] || useCanvas().canvasApi.value?.getSchema?.()?.lifeCycles?.[item]
+      const bindLifeCycleSource = props.bindLifeCycles?.[item] || useCanvas()?.getSchema?.()?.lifeCycles?.[item]
       state.editorValue =
         bindLifeCycleSource?.value ||
         `function ${item} (${item === 'setup' ? '{ props, state, watch, onMounted }' : ''}) {} `

--- a/packages/common/component/LifeCycles.vue
+++ b/packages/common/component/LifeCycles.vue
@@ -131,7 +131,7 @@ export default {
     }
 
     const syncLifeCycle = () => {
-      const currentSchema = useCanvas()?.getSchema?.()
+      const currentSchema = useCanvas().getSchema()
       const pageContent = getPageContent()
       const { id, fileName } = pageContent
       if (id === currentSchema.id || fileName === currentSchema.fileName) {
@@ -154,7 +154,7 @@ export default {
 
     const openLifeCyclesPanel = (item) => {
       state.title = item
-      const bindLifeCycleSource = props.bindLifeCycles?.[item] || useCanvas()?.getSchema?.()?.lifeCycles?.[item]
+      const bindLifeCycleSource = props.bindLifeCycles?.[item] || useCanvas().getSchema()?.lifeCycles?.[item]
       state.editorValue =
         bindLifeCycleSource?.value ||
         `function ${item} (${item === 'setup' ? '{ props, state, watch, onMounted }' : ''}) {} `

--- a/packages/common/component/MetaListItems.vue
+++ b/packages/common/component/MetaListItems.vue
@@ -103,7 +103,7 @@ export default {
   },
   setup(props, { emit }) {
     const listItemOption = computed(() => props)
-    const { resState } = useResource()
+    const { appSchemaState } = useResource()
 
     const changeItem = (params) => {
       const optionsList = [...props.optionsList]
@@ -159,7 +159,7 @@ export default {
         if (item[props.textField]) {
           if (item[props.textField].i18nKey) {
             let i18nKey = item[props.textField].i18nKey
-            text = resState.langs[i18nKey][resState.currentLang]
+            text = appSchemaState.langs[i18nKey][appSchemaState.currentLang]
           } else {
             text = item[props.textField]
           }

--- a/packages/common/js/canvas.js
+++ b/packages/common/js/canvas.js
@@ -16,7 +16,7 @@ import { useResource, getMetaApi, META_SERVICE } from '@opentiny/tiny-engine-met
 export const getCanvasStatus = (data) => {
   const globalState = getMetaApi(META_SERVICE.GlobalService).getState()
   // 写死ID 待删除
-  let isDemo = useResource().resState.isDemo
+  let isDemo = useResource().appSchemaState.isDemo
   const { resetPasswordToken } = globalState.userInfo
 
   if (isDemo && [PAGE_STATUS.Developer, PAGE_STATUS.SuperAdmin].includes(resetPasswordToken)) {

--- a/packages/common/js/completion.js
+++ b/packages/common/js/completion.js
@@ -71,7 +71,7 @@ const getSnippetsSuggestions = (monaco, range, wordContent) =>
     .filter(({ insertText }) => insertText.indexOf(wordContent) === 0)
 
 const getUserWords = () => {
-  const { bridge = [], dataSource = [], utils = [], globalState = [] } = useResource().resState
+  const { bridge = [], dataSource = [], utils = [], globalState = [] } = useResource().appSchemaState
 
   return {
     state: {

--- a/packages/configurator/src/collection-configurator/CollectionConfigurator.vue
+++ b/packages/configurator/src/collection-configurator/CollectionConfigurator.vue
@@ -4,22 +4,30 @@
       <tiny-option v-for="item in options" :key="item.id" :label="item.name" :value="item.id"> </tiny-option>
     </tiny-select>
     <tiny-tooltip class="item" effect="dark" content="刷新数据源" placement="top">
-      <icon-conment-refresh @click="refreshData"></icon-conment-refresh>
+      <icon-common-refresh @click="refreshData"></icon-common-refresh>
     </tiny-tooltip>
   </div>
 </template>
 
 <script lang="jsx">
-import { useModal, getMetaApi, META_SERVICE } from '@opentiny/tiny-engine-meta-register'
+import { nextTick, ref, onMounted, watch, computed } from 'vue'
 import { Option, Select, Tooltip } from '@opentiny/vue'
-import { IconConmentRefresh } from '@opentiny/vue-icon'
-import { nextTick, ref } from 'vue'
+import { iconConmentRefresh as iconCommonRefresh } from '@opentiny/vue-icon'
+import {
+  useModal,
+  getMetaApi,
+  META_SERVICE,
+  useCanvas,
+  useProperties,
+  useMessage
+} from '@opentiny/tiny-engine-meta-register'
+import { getHandler } from './collection'
 
 export default {
   components: {
     TinySelect: Select,
     TinyOption: Option,
-    IconConmentRefresh: IconConmentRefresh(),
+    IconCommonRefresh: iconCommonRefresh(),
     TinyTooltip: Tooltip
   },
   props: {
@@ -28,6 +36,7 @@ export default {
   setup(props, { emit }) {
     const options = ref([])
     const selected = ref(Array.isArray(props.modelValue) ? props.modelValue[0] : props.modelValue)
+    const { publish } = useMessage()
 
     const sourceChange = (value) => {
       if (props.modelValue) {
@@ -47,9 +56,13 @@ export default {
 
     const fetchDataSourceList = (appId) => getMetaApi(META_SERVICE.Http).get(`/app-center/api/sources/list/${appId}`)
 
-    const appId = getMetaApi(META_SERVICE.GlobalService).getBaseInfo().id
-    fetchDataSourceList(appId).then((data) => {
-      options.value = data
+    onMounted(() => {
+      const appId = getMetaApi(META_SERVICE.GlobalService).getBaseInfo().id
+
+      // 获取数据源列表
+      fetchDataSourceList(appId).then((data) => {
+        options.value = data
+      })
     })
 
     const refreshData = () => {
@@ -69,6 +82,85 @@ export default {
         }
       })
     }
+
+    const source = ref(null)
+
+    const fetchDataSourceDetail = (dataSourceId) =>
+      getMetaApi(META_SERVICE.Http).get(`/app-center/api/sources/detail/${dataSourceId}`)
+
+    let handler = null
+
+    watch(
+      () => props.modelValue,
+      async (value) => {
+        if (value) {
+          source.value = await fetchDataSourceDetail(value)
+
+          const pageSchema = useCanvas().getPageSchema()
+          const currentSchema = useProperties().getSchema()
+
+          if (currentSchema?.children[0]) {
+            handler = getHandler({
+              sourceRef: source,
+              node: currentSchema?.children[0],
+              schemaId: currentSchema.id,
+              pageSchema
+            })
+          }
+
+          handler?.updateNode()
+
+          publish({ topic: 'schemaChange', data: {} })
+        }
+      },
+      {
+        deep: true
+      }
+    )
+
+    const isEmpty = computed(() => {
+      const { children } = useProperties().getSchema() || {}
+
+      return Array.isArray(children) ? !children.length : !children
+    })
+
+    watch(
+      () => isEmpty.value,
+      (value) => {
+        const pageSchema = useCanvas().getPageSchema()
+        const currentSchema = useProperties().getSchema()
+
+        if (value) {
+          // 清除自动创建的state,method与setup逻辑
+          if (handler) {
+            handler.clearBindVar()
+          } else {
+            const schemaId = currentSchema?.id
+
+            // 当页面初始化时handler是不存在的，所以需要通过数据源的schemaId（唯一性），去删除对应的方法
+            Object.keys(pageSchema.methods || {})?.some((item) => {
+              if (item.includes(schemaId)) {
+                delete pageSchema.methods[item]
+                return true
+              }
+              return false
+            })
+          }
+        } else {
+          if (currentSchema?.children[0]) {
+            handler = getHandler({
+              sourceRef: source,
+              node: currentSchema?.children[0],
+              schemaId: currentSchema.id,
+              pageSchema
+            })
+            handler.updateNode()
+          }
+        }
+
+        publish({ topic: 'schemaChange', data: {} })
+      }
+    )
 
     return {
       options,

--- a/packages/configurator/src/collection-configurator/CollectionConfigurator.vue
+++ b/packages/configurator/src/collection-configurator/CollectionConfigurator.vue
@@ -10,18 +10,10 @@
 </template>
 
 <script lang="jsx">
-import { nextTick, ref, onMounted, watch, computed } from 'vue'
+import { nextTick, ref } from 'vue'
 import { Option, Select, Tooltip } from '@opentiny/vue'
 import { iconConmentRefresh as iconCommonRefresh } from '@opentiny/vue-icon'
-import {
-  useModal,
-  getMetaApi,
-  META_SERVICE,
-  useCanvas,
-  useProperties,
-  useMessage
-} from '@opentiny/tiny-engine-meta-register'
-import { getHandler } from './collection'
+import { useModal, getMetaApi, META_SERVICE } from '@opentiny/tiny-engine-meta-register'
 
 export default {
   components: {
@@ -36,7 +28,6 @@ export default {
   setup(props, { emit }) {
     const options = ref([])
     const selected = ref(Array.isArray(props.modelValue) ? props.modelValue[0] : props.modelValue)
-    const { publish } = useMessage()
 
     const sourceChange = (value) => {
       if (props.modelValue) {
@@ -56,13 +47,11 @@ export default {
 
     const fetchDataSourceList = (appId) => getMetaApi(META_SERVICE.Http).get(`/app-center/api/sources/list/${appId}`)
 
-    onMounted(() => {
-      const appId = getMetaApi(META_SERVICE.GlobalService).getBaseInfo().id
+    const appId = getMetaApi(META_SERVICE.GlobalService).getBaseInfo().id
 
-      // 获取数据源列表
-      fetchDataSourceList(appId).then((data) => {
-        options.value = data
-      })
+    // 获取数据源列表
+    fetchDataSourceList(appId).then((data) => {
+      options.value = data
     })
 
     const refreshData = () => {
@@ -82,85 +71,6 @@ export default {
         }
       })
     }
-
-    const source = ref(null)
-
-    const fetchDataSourceDetail = (dataSourceId) =>
-      getMetaApi(META_SERVICE.Http).get(`/app-center/api/sources/detail/${dataSourceId}`)
-
-    let handler = null
-
-    watch(
-      () => props.modelValue,
-      async (value) => {
-        if (value) {
-          source.value = await fetchDataSourceDetail(value)
-
-          const pageSchema = useCanvas().getPageSchema()
-          const currentSchema = useProperties().getSchema()
-
-          if (currentSchema?.children[0]) {
-            handler = getHandler({
-              sourceRef: source,
-              node: currentSchema?.children[0],
-              schemaId: currentSchema.id,
-              pageSchema
-            })
-          }
-
-          handler?.updateNode()
-
-          publish({ topic: 'schemaChange', data: {} })
-        }
-      },
-      {
-        deep: true
-      }
-    )
-
-    const isEmpty = computed(() => {
-      const { children } = useProperties().getSchema() || {}
-
-      return Array.isArray(children) ? !children.length : !children
-    })
-
-    watch(
-      () => isEmpty.value,
-      (value) => {
-        const pageSchema = useCanvas().getPageSchema()
-        const currentSchema = useProperties().getSchema()
-
-        if (value) {
-          // 清除自动创建的state,method与setup逻辑
-          if (handler) {
-            handler.clearBindVar()
-          } else {
-            const schemaId = currentSchema?.id
-
-            // 当页面初始化时handler是不存在的，所以需要通过数据源的schemaId（唯一性），去删除对应的方法
-            Object.keys(pageSchema.methods || {})?.some((item) => {
-              if (item.includes(schemaId)) {
-                delete pageSchema.methods[item]
-                return true
-              }
-              return false
-            })
-          }
-        } else {
-          if (currentSchema?.children[0]) {
-            handler = getHandler({
-              sourceRef: source,
-              node: currentSchema?.children[0],
-              schemaId: currentSchema.id,
-              pageSchema
-            })
-            handler.updateNode()
-          }
-        }
-
-        publish({ topic: 'schemaChange', data: {} })
-      }
-    )
 
     return {
       options,

--- a/packages/configurator/src/collection-configurator/collection.js
+++ b/packages/configurator/src/collection-configurator/collection.js
@@ -9,7 +9,6 @@
  * A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
  *
  */
-// import { api } from '../RenderMain'
 import * as ast from '@opentiny/tiny-engine-common/js/ast'
 import { useModal, useMaterial, useMessage } from '@opentiny/tiny-engine-meta-register'
 
@@ -63,8 +62,6 @@ const removeState = (pageSchema, variableName) => {
 }
 
 const setStateWithSourceRef = (pageSchema, variableName, sourceRef, data) => {
-  // TODO: 更新 state
-  // api.setState({ [variableName]: data })
   pageSchema.state[variableName] = data
 
   if (sourceRef.value.data?.option?.isSync) {

--- a/packages/configurator/src/collection-configurator/collection.js
+++ b/packages/configurator/src/collection-configurator/collection.js
@@ -9,10 +9,9 @@
  * A PARTICULAR PURPOSE. SEE THE APPLICABLE LICENSES FOR MORE DETAILS.
  *
  */
-
-import { getController } from '../render'
-import { api } from '../RenderMain'
-import { useModal } from '@opentiny/tiny-engine-meta-register'
+// import { api } from '../RenderMain'
+import * as ast from '@opentiny/tiny-engine-common/js/ast'
+import { useModal, useMaterial } from '@opentiny/tiny-engine-meta-register'
 
 const NAME_PREFIX = {
   loop: 'loop',
@@ -45,7 +44,7 @@ const genRemoteMethodToLifeSetup = (variableName, sourceRef, pageSchema) => {
 const removeState = (pageSchema, variableName) => {
   delete pageSchema.state[variableName]
 
-  const { parse, traverse, generate } = getController().ast
+  const { parse, traverse, generate } = ast
   const setupFn = pageSchema.lifeCycles?.setup?.value
 
   try {
@@ -64,7 +63,8 @@ const removeState = (pageSchema, variableName) => {
 }
 
 const setStateWithSourceRef = (pageSchema, variableName, sourceRef, data) => {
-  api.setState({ [variableName]: data })
+  // TODO: 更新 state
+  // api.setState({ [variableName]: data })
   pageSchema.state[variableName] = data
 
   if (sourceRef.value.data?.option?.isSync) {
@@ -76,7 +76,7 @@ const defaultHandlerTemplate = ({ node, sourceRef, schemaId, pageSchema }) => {
   const genVarName = (schemaId) => `${NAME_PREFIX.loop}${schemaId}`
 
   const updateNode = () => {
-    const { configure } = getController().getMaterial(node?.componentName)
+    const { configure } = useMaterial().getMaterial(node?.componentName)
 
     if (!configure?.loop) {
       return
@@ -104,7 +104,7 @@ const defaultHandlerTemplate = ({ node, sourceRef, schemaId, pageSchema }) => {
   }
 }
 
-const generateAssginColumns = (newColumns, oldColumns) => {
+const generateAssignColumns = (newColumns, oldColumns) => {
   newColumns.forEach((item) => {
     const targetColumn = oldColumns.find((value) => value.field === item.field)
     if (targetColumn) {
@@ -118,9 +118,9 @@ const askShouldImportData = ({ node, sourceRef }) => {
   useModal().confirm({
     message: '检测到表格存在配置的数据，是否需要引入？',
     exec() {
-      const sourceColums = sourceRef.value?.data?.columns?.map(({ title, field }) => ({ title, field })) || []
+      const sourceColumns = sourceRef.value?.data?.columns?.map(({ title, field }) => ({ title, field })) || []
       // 这里需要找到对应列，然后进行列合并
-      node.props.columns = generateAssginColumns(sourceColums, node.props.columns)
+      node.props.columns = generateAssignColumns(sourceColumns, node.props.columns)
     },
     cancel() {
       node.props.columns = [...(sourceRef.value.data?.columns || [])]

--- a/packages/configurator/src/collection-configurator/collection.js
+++ b/packages/configurator/src/collection-configurator/collection.js
@@ -11,7 +11,7 @@
  */
 // import { api } from '../RenderMain'
 import * as ast from '@opentiny/tiny-engine-common/js/ast'
-import { useModal, useMaterial } from '@opentiny/tiny-engine-meta-register'
+import { useModal, useMaterial, useMessage } from '@opentiny/tiny-engine-meta-register'
 
 const NAME_PREFIX = {
   loop: 'loop',
@@ -115,15 +115,21 @@ const generateAssignColumns = (newColumns, oldColumns) => {
 }
 
 const askShouldImportData = ({ node, sourceRef }) => {
+  const { publish } = useMessage()
+
   useModal().confirm({
     message: '检测到表格存在配置的数据，是否需要引入？',
     exec() {
       const sourceColumns = sourceRef.value?.data?.columns?.map(({ title, field }) => ({ title, field })) || []
       // 这里需要找到对应列，然后进行列合并
       node.props.columns = generateAssignColumns(sourceColumns, node.props.columns)
+
+      publish({ topic: 'schemaChange', data: {} })
     },
     cancel() {
       node.props.columns = [...(sourceRef.value.data?.columns || [])]
+
+      publish({ topic: 'schemaChange', data: {} })
     }
   })
 }

--- a/packages/configurator/src/container-configurator/ContainerConfigurator.vue
+++ b/packages/configurator/src/container-configurator/ContainerConfigurator.vue
@@ -129,7 +129,7 @@ export default {
       const { operateNode } = useCanvas()
       const id = value.id
 
-      operateNode({ type: 'changeProps', id, value: value.props })
+      operateNode({ type: 'changeProps', id, value: { props: value.props } })
     }
 
     return { children, addChildren, delChildren, dragEnd, onTitleUpdate }

--- a/packages/configurator/src/container-configurator/ContainerConfigurator.vue
+++ b/packages/configurator/src/container-configurator/ContainerConfigurator.vue
@@ -4,7 +4,7 @@
       <template #content="{ data }">
         <div class="item-text">
           <div class="tiny-input">
-            <input v-model="data.props.title" class="tiny-input__inner" />
+            <tiny-input v-model="data.props.title" @update:modelValue="onTitleUpdate(data)" />
           </div>
         </div>
       </template>
@@ -20,16 +20,18 @@
   </div>
 </template>
 <script>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
+import { Input } from '@opentiny/vue'
 import { MetaListItems } from '@opentiny/tiny-engine-common'
-import { useProperties, useMaterial, useHistory } from '@opentiny/tiny-engine-meta-register'
+import { useProperties, useMaterial, useHistory, useCanvas } from '@opentiny/tiny-engine-meta-register'
 import { utils } from '@opentiny/tiny-engine-utils'
 import { iconDel } from '@opentiny/vue-icon'
 
 export default {
   components: {
     MetaListItems,
-    IconDel: iconDel()
+    IconDel: iconDel(),
+    TinyInput: Input
   },
   setup() {
     const { children: schemaChildren, componentName } = useProperties().getSchema()
@@ -37,33 +39,62 @@ export default {
     const childComponentName =
       configureMap[componentName]?.nestingRule?.childWhitelist?.[0] || schemaChildren?.[0]?.componentName
 
-    schemaChildren.forEach((item) => {
-      if (!item.props) {
-        item.props = {
-          title: '选项卡',
-          name: ''
+    const updateChildrenToValid = () => {
+      const schema = useProperties().getSchema()
+      const schemaChildren = schema.children || []
+      let hasUpdate = false
+
+      const newChildren = schemaChildren.map((item) => {
+        if (!item.props) {
+          hasUpdate = true
+
+          item.props = {
+            title: '选项卡',
+            name: ''
+          }
         }
+
+        return item
+      })
+
+      const { operateNode } = useCanvas()
+
+      if (hasUpdate) {
+        operateNode({ type: 'updateAttributes', id: schema.id, value: { children: newChildren } })
       }
+    }
+
+    onMounted(() => {
+      updateChildrenToValid()
     })
 
     const children = ref(schemaChildren)
     const addChildren = () => {
       const name = utils.guid()
-
-      schemaChildren.push({
+      const schema = useProperties().getSchema()
+      const newNodeData = {
         componentName: childComponentName,
         props: {
           title: '选项卡',
           name
         },
         children: [{ componentName: 'div' }]
-      })
+      }
+
+      const { operateNode } = useCanvas()
+
+      operateNode({ type: 'insert', parentId: schema.id, newNodeData, position: 'after' })
+
       children.value = [...schemaChildren]
     }
 
     const delChildren = (data) => {
-      schemaChildren.splice(children.value.indexOf(data), 1)
+      const { operateNode } = useCanvas()
+
+      operateNode({ type: 'delete', id: data.id })
+
       children.value = [...schemaChildren]
+
       useHistory().addHistory()
     }
 
@@ -74,14 +105,34 @@ export default {
         return
       }
 
-      const list = schemaChildren
-      const spliceItem = list.splice(oldIndex, 1)
+      const schema = useProperties().getSchema()
+      const schemaChildren = schema.children
 
-      list.splice(newIndex, 0, ...spliceItem)
-      children.value = [...list]
+      const { operateNode } = useCanvas()
+
+      const newNodeData = schemaChildren[oldIndex]
+      const referTargetNodeId = schemaChildren[newIndex].id
+
+      operateNode({ type: 'delete', id: schemaChildren[oldIndex].id })
+      operateNode({
+        type: 'insert',
+        parentId: schema.id,
+        newNodeData,
+        position: newIndex < oldIndex ? 'before' : 'after',
+        referTargetNodeId
+      })
+
+      children.value = [...schemaChildren]
     }
 
-    return { children, addChildren, delChildren, dragEnd }
+    const onTitleUpdate = (value) => {
+      const { operateNode } = useCanvas()
+      const id = value.id
+
+      operateNode({ type: 'changeProps', id, value: value.props })
+    }
+
+    return { children, addChildren, delChildren, dragEnd, onTitleUpdate }
   }
 }
 </script>

--- a/packages/configurator/src/html-attributes-configurator/HtmlAttributesConfigurator.vue
+++ b/packages/configurator/src/html-attributes-configurator/HtmlAttributesConfigurator.vue
@@ -48,7 +48,7 @@
 </template>
 <script>
 import { reactive, ref, watchEffect } from 'vue'
-import { useProperties, useMaterial } from '@opentiny/tiny-engine-meta-register'
+import { useProperties, useMaterial, useCanvas } from '@opentiny/tiny-engine-meta-register'
 import { IconDel, IconEdit, IconClose, IconPlus } from '@opentiny/vue-icon'
 import { Form, FormItem, Input, Button, Popover, Tooltip } from '@opentiny/vue'
 import { utils } from '@opentiny/tiny-engine-utils'
@@ -95,12 +95,26 @@ export default {
       })
 
       for (const [key, value] of Object.entries(useProperties().getSchema()?.props)) {
-        !properties.includes(key) &&
+        const isExcludedKey = properties.includes(key)
+
+        if (isExcludedKey) {
+          continue
+        }
+
+        const index = attrs.value.findIndex(({ data: { key: attrKey } }) => attrKey === key)
+
+        if (index === -1) {
           attrs.value.push({
             text: `${key} = '${value}'`,
             data: { key, value },
             id: utils.guid()
           })
+        } else {
+          Object.assign(attrs.value[index], {
+            text: `${key} = '${value}'`,
+            data: { key, value }
+          })
+        }
       }
     })
 
@@ -110,7 +124,10 @@ export default {
 
     const updateSchema = () => {
       const mergeProps = {}
-      const { props } = useProperties().getSchema()
+      const { operateNode } = useCanvas()
+      const { getSchema } = useProperties()
+      const { props } = getSchema()
+
       for (const [key, value] of Object.entries(props)) {
         if (properties.includes(key)) {
           mergeProps[key] = value
@@ -121,7 +138,9 @@ export default {
         mergeProps[attr.data.key] = attr.data.value
       })
 
-      useProperties().getSchema().props = mergeProps
+      const schema = useProperties().getSchema()
+
+      operateNode({ type: 'updateAttributes', id: schema.id, value: { props: mergeProps } })
     }
 
     const save = () => {

--- a/packages/configurator/src/html-text-configurator/HtmlTextConfigurator.vue
+++ b/packages/configurator/src/html-text-configurator/HtmlTextConfigurator.vue
@@ -15,7 +15,7 @@
 </template>
 <script>
 import { reactive, computed } from 'vue'
-import { useProperties } from '@opentiny/tiny-engine-meta-register'
+import { useProperties, useCanvas } from '@opentiny/tiny-engine-meta-register'
 import InputConfigurator from '../input-configurator/InputConfigurator.vue'
 
 export default {
@@ -44,12 +44,20 @@ export default {
 
     const triggerType = (item, index) => {
       state.active = index
-      useProperties().getSchema().componentName = item.toLowerCase()
+      const { operateNode } = useCanvas()
+      const schema = useProperties().getSchema()
+
+      if (schema) {
+        operateNode({ type: 'updateAttributes', id: schema.id, value: { componentName: item.toLowerCase() } })
+      }
     }
 
     const change = (value) => {
-      if (useProperties().getSchema()) {
-        useProperties().getSchema().children = value
+      const { operateNode } = useCanvas()
+      const schema = useProperties().getSchema()
+
+      if (schema) {
+        operateNode({ type: 'updateAttributes', id: schema.id, value: { children: value } })
       }
     }
 

--- a/packages/configurator/src/js-slot-configurator/JsSlotConfigurator.vue
+++ b/packages/configurator/src/js-slot-configurator/JsSlotConfigurator.vue
@@ -14,7 +14,7 @@
         <div class="use-slot-item-content">
           <div class="use-slot-switch-wrap">
             <div :class="['e__switch', { 'e_is-checked': slot.bind }]">
-              <span class="e__switch-core" @click="toggleSlot(index, slot)"></span>
+              <span class="e__switch-core" @click="updateSlot(index, slot)"></span>
             </div>
           </div>
           <tiny-form-item
@@ -25,7 +25,7 @@
             <tiny-input
               v-model="slot.params"
               class="use-slot-params"
-              @change="validParams(paramsPropPath(index), slot)"
+              @change="validParams(slot, paramsPropPath(index))"
             ></tiny-input>
           </tiny-form-item>
         </div>
@@ -94,51 +94,7 @@ export default {
       }
     }
 
-    const updateSlotParams = (slotData) => {
-      emit('update:modelValue', slotData)
-
-      // 更新当前选中组件的根属性，不更新在jsslot中的数据非响应式
-      const [propsName] = path.split('.')
-      const schema = useProperties().getSchema()
-      schema.props[propsName] = JSON.parse(JSON.stringify(schema.props[propsName]))
-    }
-
-    const setSlotParams = ({ name, params = '' }) => {
-      if (!props.modelValue?.[name]) {
-        return
-      }
-
-      const slotData = { ...(props.modelValue || {}) }
-
-      if (params.length) {
-        slotData[name].params = params.split(',')
-      } else {
-        delete slotData[name].params
-      }
-
-      updateSlotParams(slotData)
-    }
-
-    const toggleSlot = (idx, { bind, name, params = '' }) => {
-      // 原本绑定的，解除绑定
-      if (bind) {
-        useModal().confirm({
-          title: '提示',
-          message: '关闭后插槽内的内容将被清空，是否继续？',
-          status: 'info',
-          exec: () => {
-            slotList.value[idx].bind = false
-            const { [name]: _deleted, ...rest } = { ...(props.modelValue || {}) }
-            updateSlotParams(rest)
-          }
-        })
-
-        return
-      }
-
-      // 未绑定的，新增绑定
-      slotList.value[idx].bind = true
-
+    const updateSlot = (idx, { bind, name, params = '' }, isToggleSlot = true) => {
       const slotInfo = {
         [name]: {
           type: 'JSSlot',
@@ -150,17 +106,71 @@ export default {
         }
       }
 
+      const slotData = { ...slotInfo, ...(props.modelValue || {}) }
+      const { setProp } = useProperties()
+      const { setNode, operateNode } = useCanvas()
+
       if (params.length) {
-        slotInfo[name].params = params.split(',')
+        slotData[name].params = params.split(',')
+      } else {
+        delete slotData[name].params
       }
 
-      updateSlotParams({ ...(props.modelValue || {}), ...slotInfo })
+      if (bind && isToggleSlot) {
+        useModal().confirm({
+          title: '提示',
+          message: '关闭后插槽内的内容将被清空，是否继续？',
+          status: 'info',
+          exec: () => {
+            slotList.value[idx].bind = false
+            operateNode({ type: 'delete', id: slotData[name].value[0].id })
+
+            delete slotData[name]
+            emit('update:modelValue', slotData)
+            const [propsName] = path.split('.')
+
+            const schema = useProperties().getSchema()
+
+            setProp(propsName, schema.props[propsName])
+          }
+        })
+      } else {
+        slotList.value[idx].bind = true
+      }
+
+      emit('update:modelValue', slotData)
+
+      // 更新当前选中组件的根属性，不根新在jsslot中的数据非响应式
+      const [propsName] = path.split('.')
+      const schema = useProperties().getSchema()
+
+      for (const data of Object.values(slotData)) {
+        if (data.value?.[0] && !data.value[0]?.id) {
+          // 手动设置节点
+          setNode(data.value[0], schema)
+        }
+      }
+
+      setProp(propsName, schema.props[propsName])
     }
 
-    const validParams = (paramsPath, slot) => {
+    const setParams = (slot) => {
+      if (slot.bind) {
+        const slotData = props.modelValue
+        const { params, name } = slot
+
+        if (params.length) {
+          slotData[name].params = params.split(',')
+        } else {
+          delete slotData[name].params
+        }
+      }
+    }
+
+    const validParams = (slot, paramsPath) => {
       slotRef.value.validateField([paramsPath], (error) => {
         if (!error) {
-          slot.bind && setSlotParams(slot)
+          setParams(slot)
         }
       })
     }
@@ -171,12 +181,13 @@ export default {
     })
 
     return {
-      toggleSlot,
+      updateSlot,
       slotList,
       paramsPropPath,
       slotRef,
       paramsStringValidator,
       validParams,
+      setParams,
       state,
       componentsMap
     }

--- a/packages/configurator/src/layout-grid-configurator/LayoutGridConfigurator.vue
+++ b/packages/configurator/src/layout-grid-configurator/LayoutGridConfigurator.vue
@@ -36,7 +36,7 @@
 <script>
 import { reactive, ref, computed } from 'vue'
 import { SplitPanes, Pane } from '@opentiny/tiny-engine-common'
-import { useProperties } from '@opentiny/tiny-engine-meta-register'
+import { useProperties, useCanvas } from '@opentiny/tiny-engine-meta-register'
 
 export default {
   components: {
@@ -195,6 +195,18 @@ export default {
       const spans = item.split(':')
       mode.value = item
 
+      const { operateNode } = useCanvas()
+      const schema = useProperties().getSchema()
+
+      if (!schema) {
+        // eslint-disable-next-line no-console
+        console.error('Error! There is no node selected. 错误！当前没有节点被选中。')
+
+        return
+      }
+
+      const cols = [...(schema?.children || [])]
+
       spans.forEach((span, index) => {
         if (cols[index]) {
           cols[index].props.span = span
@@ -217,7 +229,7 @@ export default {
         }
       })
 
-      cols.length = spans.length
+      operateNode({ type: 'updateAttributes', id: schema.id, value: { children: cols.slice(0, spans.length) } })
     }
 
     const modeClick = (index, item) => {

--- a/packages/configurator/src/related-editor-configurator/RelatedEditorConfigurator.vue
+++ b/packages/configurator/src/related-editor-configurator/RelatedEditorConfigurator.vue
@@ -90,7 +90,7 @@ export default {
       let newValue = value
 
       if (value?.type === CONSTANT.JSEXPRESSION) {
-        const pageSchema = useCanvas().canvasApi.value.getSchema()
+        const pageSchema = useCanvas().getSchema()
         const stateName = value?.value?.replace(CONSTANT.STATE, '')
         newValue = pageSchema?.state?.[stateName]
       }

--- a/packages/configurator/src/slot-configurator/SlotConfigurator.vue
+++ b/packages/configurator/src/slot-configurator/SlotConfigurator.vue
@@ -65,12 +65,7 @@ export default {
     })
     const toggleSlot = ({ name = 'default', params, bind }, i) => {
       const schema = useProperties().getSchema()
-
-      if (!schema.children) {
-        schema.children = []
-      }
-
-      const children = schema.children
+      const { operateNode } = useCanvas()
 
       if (!bind) {
         slotList.value[i].bind = !slotList.value[i].bind
@@ -90,7 +85,11 @@ export default {
           template.props.slot.params = params
         }
 
-        children.push(template)
+        operateNode({
+          type: 'updateAttributes',
+          id: schema.id,
+          value: { children: [...(schema.children || []), template] }
+        })
       } else {
         useModal().confirm({
           title: '提示',
@@ -99,11 +98,12 @@ export default {
           exec: () => {
             slotList.value[i].bind = !slotList.value[i].bind
 
-            const nodeIdex = children.findIndex(
+            const newChildren = schema.children.filter(
               ({ componentName, props }) =>
-                componentName === 'Template' && (props?.slot === name || props?.slot?.name === name)
+                componentName !== 'Template' || (props?.slot !== name && props?.slot?.name !== name)
             )
-            children.splice(nodeIdex, 1)
+
+            operateNode({ type: 'updateAttributes', id: schema.id, value: { children: [...newChildren] } })
           },
           cancel: () => {}
         })

--- a/packages/configurator/src/table-columns-configurator/TableColumnsConfigurator.vue
+++ b/packages/configurator/src/table-columns-configurator/TableColumnsConfigurator.vue
@@ -3,7 +3,6 @@
 </template>
 
 <script setup>
-import { nextTick } from 'vue'
 import { useProperties, useMaterial, useCanvas } from '@opentiny/tiny-engine-meta-register'
 import ArrayItemConfigurator from '../array-item-configurator/ArrayItemConfigurator.vue'
 
@@ -25,8 +24,6 @@ const updateColumns = (columns) => {
   })
 
   useCanvas().operateNode({ type: 'updateAttributes', id: useProperties().getSchema().id, value: { children } })
-
-  nextTick(useCanvas().canvasApi.value.updateRect)
 }
 
 updateColumns(props?.columns)

--- a/packages/configurator/src/table-columns-configurator/TableColumnsConfigurator.vue
+++ b/packages/configurator/src/table-columns-configurator/TableColumnsConfigurator.vue
@@ -24,7 +24,8 @@ const updateColumns = (columns) => {
     }
   })
 
-  useProperties().getSchema().children = children
+  useCanvas().operateNode({ type: 'updateAttributes', id: useProperties().getSchema().id, value: { children } })
+
   nextTick(useCanvas().canvasApi.value.updateRect)
 }
 

--- a/packages/configurator/src/variable-configurator/VariableConfigurator.vue
+++ b/packages/configurator/src/variable-configurator/VariableConfigurator.vue
@@ -151,13 +151,15 @@ const CONSTANTS = {
 }
 
 const getJsSlot = () => {
-  const { getNode, getCurrent } = useCanvas().canvasApi.value || {}
+  const { getCurrent } = useCanvas().canvasApi.value || {}
 
-  if (!getNode || !getCurrent) {
+  if (!getCurrent) {
     return [false, {}]
   }
 
-  const jsSlot = getNode(getCurrent()?.parent?.id, true)?.parent
+  const { getNodeWithParentId } = useCanvas()
+
+  const jsSlot = getNodeWithParentId(getCurrent()?.parent?.id, true)?.parent
 
   return [jsSlot?.type === 'JSSlot', jsSlot]
 }

--- a/packages/configurator/src/variable-configurator/VariableConfigurator.vue
+++ b/packages/configurator/src/variable-configurator/VariableConfigurator.vue
@@ -157,9 +157,9 @@ const getJsSlot = () => {
     return [false, {}]
   }
 
-  const { getNodeWithParentId } = useCanvas()
+  const { getNodeWithParentById } = useCanvas()
 
-  const jsSlot = getNodeWithParentId(getCurrent()?.parent?.id, true)?.parent
+  const jsSlot = getNodeWithParentById(getCurrent()?.parent?.id, true)?.parent
 
   return [jsSlot?.type === 'JSSlot', jsSlot]
 }
@@ -399,7 +399,7 @@ export default {
     const confirm = () => {
       let variableContent = state.isEditorEditMode ? editor.value?.getEditor().getValue() : state.variable
 
-      const { setSaved, canvasApi, getSchema } = useCanvas()
+      const { setSaved, getSchema, updateSchema } = useCanvas()
       // 如果新旧值不一样就显示未保存状态
       if (oldValue !== variableContent) {
         setSaved(false)
@@ -415,10 +415,7 @@ export default {
           const stateName = state.variable.replace(`${CONSTANTS.STATE}`, '')
           const staticData = state.variableContent.map(({ _id, ...other }) => other)
 
-          pageSchema.state[stateName] = staticData
-
-          // 设置画布上下文环境，让画布触发更新渲染
-          canvasApi.value.setState({ [stateName]: staticData })
+          updateSchema({ ...pageSchema.state, [stateName]: staticData })
 
           // 这里在setup生命周期函数内部处理用户真实环境中的数据源请求
           genRemoteMethodToLifeSetup(stateName, state.dataSouce, pageSchema)

--- a/packages/configurator/src/variable-configurator/VariableConfigurator.vue
+++ b/packages/configurator/src/variable-configurator/VariableConfigurator.vue
@@ -458,7 +458,7 @@ export default {
 
     const selectItem = (item) => {
       state.active = item.id
-      const { canvasApi, getSchema } = useCanvas()
+      const { getSchema } = useCanvas()
 
       if (item.id === 'function') {
         state.bindPrefix = CONSTANTS.THIS
@@ -523,7 +523,7 @@ export default {
         state.variables = params.reduce((variables, param) => ({ ...variables, [param]: param }), {})
       } else {
         state.bindPrefix = CONSTANTS.STATE
-        state.variables = canvasApi.value.getSchema()?.[item.id]
+        state.variables = getSchema()?.[item.id]
       }
     }
 

--- a/packages/configurator/src/variable-configurator/VariableConfigurator.vue
+++ b/packages/configurator/src/variable-configurator/VariableConfigurator.vue
@@ -467,7 +467,7 @@ export default {
       } else if (item.id === 'bridge' || item.id === 'utils') {
         state.bindPrefix = `${CONSTANTS.THIS}${item.id}.`
         const bridge = {}
-        useResource().resState[item.id]?.forEach((res) => {
+        useResource().appSchemaState[item.id]?.forEach((res) => {
           bridge[res.name] = `${item.id}.${res.content.exportName}`
         })
 
@@ -502,7 +502,7 @@ export default {
         state.bindPrefix = CONSTANTS.STORE
         state.variables = {}
 
-        const stores = canvasApi.value.getGlobalState()
+        const stores = useResource().appSchemaState.globalState
         stores.forEach(({ id, state: storeState = {}, getters = {} }) => {
           const loadProp = (prop) => {
             const propBinding = `${id}.${prop}`

--- a/packages/configurator/src/variable-configurator/VariableConfigurator.vue
+++ b/packages/configurator/src/variable-configurator/VariableConfigurator.vue
@@ -399,7 +399,7 @@ export default {
     const confirm = () => {
       let variableContent = state.isEditorEditMode ? editor.value?.getEditor().getValue() : state.variable
 
-      const { setSaved, canvasApi } = useCanvas()
+      const { setSaved, canvasApi, getSchema } = useCanvas()
       // 如果新旧值不一样就显示未保存状态
       if (oldValue !== variableContent) {
         setSaved(false)
@@ -411,7 +411,7 @@ export default {
 
       if (variableContent) {
         if (state.bindPrefix === CONSTANTS.DATASOUCEPREFIX) {
-          const pageSchema = canvasApi.value.getSchema()
+          const pageSchema = getSchema()
           const stateName = state.variable.replace(`${CONSTANTS.STATE}`, '')
           const staticData = state.variableContent.map(({ _id, ...other }) => other)
 
@@ -453,7 +453,7 @@ export default {
       state.isVisible = true
       state.variableName = bindKey.value
       state.variable = getInitVariable()
-      state.variables = useCanvas().canvasApi.value.getSchema()?.state || {}
+      state.variables = useCanvas().getSchema()?.state || {}
       state.bindPrefix = CONSTANTS.STATE
       state.variableContent = state.variables[bindKey.value]
       nextTick(() => window.dispatchEvent(new Event('resize')))
@@ -461,7 +461,7 @@ export default {
 
     const selectItem = (item) => {
       state.active = item.id
-      const { canvasApi } = useCanvas()
+      const { canvasApi, getSchema } = useCanvas()
 
       if (item.id === 'function') {
         state.bindPrefix = CONSTANTS.THIS
@@ -477,7 +477,7 @@ export default {
         state.variables = bridge
       } else if (item.id === 'props') {
         state.bindPrefix = CONSTANTS.PROPS
-        const properties = canvasApi.value.getSchema()?.schema?.properties
+        const properties = getSchema()?.schema?.properties
         const bindProperties = {}
         properties?.forEach(({ content }) => {
           content.forEach(({ property }) => {

--- a/packages/plugins/block/src/composable/useBlock.js
+++ b/packages/plugins/block/src/composable/useBlock.js
@@ -278,13 +278,13 @@ const getBlockPageSchema = (block) => {
 }
 
 const initBlock = async (block = {}, _langs = {}, isEdit) => {
-  const { resetBlockCanvasState, setSaved } = useCanvas()
+  const { resetBlockCanvasState, setSaved, getSchema } = useCanvas()
   const { setBreadcrumbBlock } = useBreadcrumb()
 
   // 把区块的schema传递给画布
   await resetBlockCanvasState({ pageSchema: getBlockPageSchema(block) })
   // 这一步操作很重要，让区块管理面板和画布共同维护同一份区块schema
-  block.content = useCanvas().canvasApi.value?.getSchema()
+  block.content = getSchema()
 
   setCurrentBlock(block)
   setBreadcrumbBlock([block[nameCn] || block.label], block.histories)

--- a/packages/plugins/bridge/src/js/resource.js
+++ b/packages/plugins/bridge/src/js/resource.js
@@ -181,6 +181,16 @@ export const saveResource = (data, callback, emit) => {
     requestUpdateReSource(data).then((result) => {
       if (result) {
         const index = useResource().appSchemaState[data.category].findIndex((item) => item.name === result.name)
+
+        if (index === -1) {
+          useNotify({
+            type: 'error',
+            message: '修改失败'
+          })
+
+          return
+        }
+
         useResource().appSchemaState[data.category][index] = result
 
         // 更新画布工具函数环境，保证渲染最新工具类返回值, 并触发画布的强制刷新
@@ -222,6 +232,16 @@ export const deleteData = (name, callback, emit) => {
   requestDeleteReSource(params).then((data) => {
     if (data) {
       const index = useResource().appSchemaState[state.type].findIndex((item) => item.name === data.name)
+
+      if (index === -1) {
+        useNotify({
+          type: 'error',
+          message: '删除失败'
+        })
+
+        return
+      }
+
       useResource().appSchemaState[state.type].splice(index, 1)
 
       generateBridgeUtil(getAppId())

--- a/packages/plugins/bridge/src/js/resource.js
+++ b/packages/plugins/bridge/src/js/resource.js
@@ -11,7 +11,7 @@
  */
 
 import { reactive } from 'vue'
-import { useResource, useNotify, useCanvas, getMetaApi, META_SERVICE } from '@opentiny/tiny-engine-meta-register'
+import { useResource, useNotify, getMetaApi, META_SERVICE } from '@opentiny/tiny-engine-meta-register'
 import { isVsCodeEnv } from '@opentiny/tiny-engine-common/js/environments'
 import {
   fetchResourceList,
@@ -176,17 +176,15 @@ const generateBridgeUtil = (...args) => {
 }
 
 export const saveResource = (data, callback, emit) => {
-  const { updateUtils } = useCanvas().canvasApi.value
-
   if (getActionType() === ACTION_TYPE.Edit) {
     data.id = state.resource.id
     requestUpdateReSource(data).then((result) => {
       if (result) {
-        const index = useResource().resState[data.category].findIndex((item) => item.name === result.name)
-        useResource().resState[data.category][index] = result
+        const index = useResource().appSchemaState[data.category].findIndex((item) => item.name === result.name)
+        useResource().appSchemaState[data.category][index] = result
 
         // 更新画布工具函数环境，保证渲染最新工具类返回值, 并触发画布的强制刷新
-        updateUtils([result])
+
         generateBridgeUtil(getAppId())
 
         useNotify({
@@ -202,10 +200,9 @@ export const saveResource = (data, callback, emit) => {
   } else {
     requestAddReSource(data).then((result) => {
       if (result) {
-        useResource().resState[data.category].push(result)
+        useResource().appSchemaState[data.category].push(result)
 
         // 更新画布工具函数环境，保证渲染最新工具类返回值, 并触发画布的强制刷新
-        updateUtils([result])
         generateBridgeUtil(getAppId())
         useNotify({
           type: 'success',
@@ -221,14 +218,12 @@ export const saveResource = (data, callback, emit) => {
 
 export const deleteData = (name, callback, emit) => {
   const params = `app=${getAppId()}&id=${state.resource?.id}`
-  const { deleteUtils } = useCanvas().canvasApi.value
 
   requestDeleteReSource(params).then((data) => {
     if (data) {
-      const index = useResource().resState[state.type].findIndex((item) => item.name === data.name)
-      useResource().resState[state.type].splice(index, 1)
+      const index = useResource().appSchemaState[state.type].findIndex((item) => item.name === data.name)
+      useResource().appSchemaState[state.type].splice(index, 1)
 
-      deleteUtils([data])
       generateBridgeUtil(getAppId())
       useNotify({
         type: 'success',

--- a/packages/plugins/datasource/src/DataSourceGlobalDataHandler.vue
+++ b/packages/plugins/datasource/src/DataSourceGlobalDataHandler.vue
@@ -49,9 +49,9 @@ export default {
     const { confirm } = useModal()
 
     const state = reactive({
-      dataHandlerValue: useResource().resState?.dataHandler?.value,
-      willFetchValue: useResource().resState.willFetch?.value,
-      errorHandlerValue: useResource().resState?.errorHandler?.value
+      dataHandlerValue: useResource().appSchemaState?.dataHandler?.value,
+      willFetchValue: useResource().appSchemaState.willFetch?.value,
+      errorHandlerValue: useResource().appSchemaState?.errorHandler?.value
     })
 
     const saveGlobalDataHandle = () => {
@@ -65,9 +65,9 @@ export default {
 
       requestGlobalDataHandler(id, { data_source_global: handler }).then((data) => {
         if (data) {
-          useResource().resState.dataHandler = { type: 'JSFunction', value: state.dataHandlerValue }
-          useResource().resState.willFetch = { type: 'JSFunction', value: state.willFetchValue }
-          useResource().resState.errorHandler = { type: 'JSFunction', value: state.errorHandlerValue }
+          useResource().appSchemaState.dataHandler = { type: 'JSFunction', value: state.dataHandlerValue }
+          useResource().appSchemaState.willFetch = { type: 'JSFunction', value: state.willFetchValue }
+          useResource().appSchemaState.errorHandler = { type: 'JSFunction', value: state.errorHandlerValue }
           confirm({
             title: '提示',
             message: '全局请求处理函数设置成功'

--- a/packages/plugins/datasource/src/DataSourceList.vue
+++ b/packages/plugins/datasource/src/DataSourceList.vue
@@ -34,6 +34,7 @@
   <data-source-record-list
     :data="state.currentData"
     @edit="openDataSourceForm(dataSourceList[activeIndex], activeIndex)"
+    @refresh="refresh()"
   ></data-source-record-list>
 </template>
 
@@ -111,7 +112,8 @@ export default {
       openRecordListPanel,
       openDataSourceForm,
       dataSourceList,
-      activeIndex
+      activeIndex,
+      refresh
     }
   }
 }

--- a/packages/plugins/datasource/src/DataSourceList.vue
+++ b/packages/plugins/datasource/src/DataSourceList.vue
@@ -39,7 +39,7 @@
 
 <script>
 import { onMounted, reactive, ref } from 'vue'
-import { useDataSource, useResource, useCanvas, getMetaApi, META_SERVICE } from '@opentiny/tiny-engine-meta-register'
+import { useDataSource, useResource, getMetaApi, META_SERVICE } from '@opentiny/tiny-engine-meta-register'
 import { close as closeRemotePanel } from './DataSourceRemotePanel.vue'
 import { close as closeDataSourceForm } from './DataSourceForm.vue'
 import DataSourceRecordList, { open as openRecordList } from './DataSourceRecordList.vue'
@@ -56,7 +56,8 @@ export const refresh = () => {
   const selectedId = getMetaApi(META_SERVICE.GlobalService).getBaseInfo().id || url.get('id')
   fetchDataSourceList(selectedId).then((data) => {
     dataSourceList.value = data
-    useCanvas().canvasApi.value.setDataSourceMap(data)
+
+    useResource().appSchemaState.dataSource = data
   })
 }
 
@@ -78,7 +79,7 @@ export default {
     const { dataSourceState, saveDataSource } = useDataSource()
 
     onMounted(() => {
-      dataSourceList.value = useResource().resState.dataSource
+      dataSourceList.value = useResource().appSchemaState.dataSource
     })
 
     // 打开新增数据面板

--- a/packages/plugins/datasource/src/DataSourceRecordList.vue
+++ b/packages/plugins/datasource/src/DataSourceRecordList.vue
@@ -419,7 +419,7 @@ export default {
         }
 
         const key = `datasource${capitalize(camelize(name))}`
-        const pageSchema = useCanvas().canvasApi.value.getSchema()
+        const pageSchema = useCanvas().getSchema()
 
         if (pageSchema.state[key]) {
           pageSchema.state[key] = data.map(({ _id, ...other }) => other)

--- a/packages/plugins/datasource/src/DataSourceRecordList.vue
+++ b/packages/plugins/datasource/src/DataSourceRecordList.vue
@@ -118,7 +118,7 @@ export default {
     }
   },
   emits: ['edit'],
-  setup(props) {
+  setup(props, { emit }) {
     const grid = ref(null)
     const { confirm } = useModal()
     const { toClipboard } = useClipboard()
@@ -288,6 +288,8 @@ export default {
       return getGridData({ page: state.pagerConfig, forceUseRemoteData }).then(({ result, page }) => {
         state.tableData = result
         state.pagerConfig.total = page.total
+        // 通知刷新mock数据到 appSchemaState
+        emit('refresh')
       })
     }
 

--- a/packages/plugins/datasource/src/js/datasource.js
+++ b/packages/plugins/datasource/src/js/datasource.js
@@ -54,16 +54,16 @@ const defaultWillFetch = createFn(DEFAULT_INTERCEPTOR.willFetch.value)
 const defaultErrorHandler = createFn(DEFAULT_INTERCEPTOR.errorHandler.value)
 
 export const getRequest = (config) => {
-  const globalDataHandle = useResource().resState.dataHandler
-    ? createFn(useResource().resState.dataHandler.value)
+  const globalDataHandle = useResource().appSchemaState.dataHandler
+    ? createFn(useResource().appSchemaState.dataHandler.value)
     : defaultDataHandler
 
-  const globalErrorHandler = useResource().resState.errorHandler
-    ? createFn(useResource().resState.errorHandler.value)
+  const globalErrorHandler = useResource().appSchemaState.errorHandler
+    ? createFn(useResource().appSchemaState.errorHandler.value)
     : defaultErrorHandler
 
-  const globalWillFetch = useResource().resState.willFetch
-    ? createFn(useResource().resState.willFetch.value)
+  const globalWillFetch = useResource().appSchemaState.willFetch
+    ? createFn(useResource().appSchemaState.willFetch.value)
     : defaultWillFetch
 
   const http = axios.create()

--- a/packages/plugins/i18n/src/composable/useTranslate.js
+++ b/packages/plugins/i18n/src/composable/useTranslate.js
@@ -116,10 +116,10 @@ const getI18nData = () => {
 }
 
 const getI18n = async ({ init, local }) => {
-  const { resState } = useResource()
+  const { appSchemaState } = useResource()
 
   if (local) {
-    const locales = resState?.langs?.locales || []
+    const locales = appSchemaState?.langs?.locales || []
     const messages = {}
     const langs = getLangs()
 
@@ -135,7 +135,7 @@ const getI18n = async ({ init, local }) => {
 
     return { locales, messages }
   } else {
-    const i18n = init ? resState.langs : await getI18nData
+    const i18n = init ? appSchemaState.langs : await getI18nData
 
     return i18n
   }

--- a/packages/plugins/i18n/src/composable/useTranslate.js
+++ b/packages/plugins/i18n/src/composable/useTranslate.js
@@ -135,7 +135,7 @@ const getI18n = async ({ init, local }) => {
 
     return { locales, messages }
   } else {
-    const i18n = init ? appSchemaState.langs : await getI18nData
+    const i18n = init ? appSchemaState.langs : await getI18nData()
 
     return i18n
   }

--- a/packages/plugins/materials/src/composable/useMaterial.js
+++ b/packages/plugins/materials/src/composable/useMaterial.js
@@ -371,7 +371,7 @@ const fetchMaterial = async () => {
 }
 
 /**
- * 获取区块保存的依赖信息，合并到resState.thirdPartyDeps
+ * 获取区块保存的依赖信息，合并到appSchemaState.thirdPartyDeps
  * @param {object} dependencies 区块保存的依赖信息
  */
 const getBlockDeps = (dependencies = {}) => {

--- a/packages/plugins/materials/src/composable/useResource.js
+++ b/packages/plugins/materials/src/composable/useResource.js
@@ -10,7 +10,7 @@
  *
  */
 
-import { reactive } from 'vue'
+import { reactive, toRaw } from 'vue'
 import { constants } from '@opentiny/tiny-engine-utils'
 import { getCanvasStatus } from '@opentiny/tiny-engine-common/js/canvas'
 import {
@@ -109,7 +109,7 @@ const initPageOrBlock = async () => {
     ) || {
       componentName: COMPONENT_NAME.Page
     }
-  initPage(pageInfo)
+  initPage(toRaw(pageInfo))
 }
 
 const handlePopStateEvent = async () => {

--- a/packages/plugins/materials/src/composable/useResource.js
+++ b/packages/plugins/materials/src/composable/useResource.js
@@ -28,7 +28,7 @@ import {
 
 const { COMPONENT_NAME, DEFAULT_INTERCEPTOR } = constants
 
-const resState = reactive({
+const appSchemaState = reactive({
   dataSource: [],
   pageTree: [],
   langs: {},
@@ -103,8 +103,8 @@ const initPageOrBlock = async () => {
   }
 
   // url 没有 pageid 或 blockid，到页面首页或第一页
-  const pageInfo = resState.pageTree.find((page) => page?.meta?.isHome) ||
-    resState.pageTree.find(
+  const pageInfo = appSchemaState.pageTree.find((page) => page?.meta?.isHome) ||
+    appSchemaState.pageTree.find(
       (page) => page.componentName === COMPONENT_NAME.Page && page?.meta?.group !== 'publicPages'
     ) || {
       componentName: COMPONENT_NAME.Page
@@ -121,22 +121,19 @@ const handlePopStateEvent = async () => {
   await useTranslate().initI18n({ host: id, hostType: type })
 }
 
-const fetchResource = async ({ isInit = true } = {}) => {
-  const { id, type } = getMetaApi(META_SERVICE.GlobalService).getBaseInfo()
-  useMessage().publish({ topic: 'app_id_changed', data: id })
+const fetchAppState = async () => {
+  const { id } = getMetaApi(META_SERVICE.GlobalService).getBaseInfo()
   const appData = await getMetaApi(META_SERVICE.Http).get(`/app-center/v1/api/apps/schema/${id}`)
-  resState.pageTree = appData.componentsTree
-  resState.dataSource = appData.dataSource?.list
-  resState.dataHandler = appData.dataSource?.dataHandler || DEFAULT_INTERCEPTOR.dataHandler
-  resState.willFetch = appData.dataSource?.willFetch || DEFAULT_INTERCEPTOR.willFetch
-  resState.errorHandler = appData.dataSource?.errorHandler || DEFAULT_INTERCEPTOR.errorHandler
+  appSchemaState.pageTree = appData.componentsTree
+  appSchemaState.dataSource = appData.dataSource?.list
+  appSchemaState.dataHandler = appData.dataSource?.dataHandler || DEFAULT_INTERCEPTOR.dataHandler
+  appSchemaState.willFetch = appData.dataSource?.willFetch || DEFAULT_INTERCEPTOR.willFetch
+  appSchemaState.errorHandler = appData.dataSource?.errorHandler || DEFAULT_INTERCEPTOR.errorHandler
 
-  resState.bridge = appData.bridge
-  resState.utils = appData.utils
-  resState.isDemo = appData.meta?.is_demo
-  resState.globalState = appData?.meta.global_state
-
-  useMaterial().initMaterial({ isInit, appData })
+  appSchemaState.bridge = appData.bridge
+  appSchemaState.utils = appData.utils
+  appSchemaState.isDemo = appData.meta?.is_demo
+  appSchemaState.globalState = appData?.meta.global_state
 
   // 词条语言为空时使用默认的语言
   const defaultLocales = [
@@ -146,10 +143,22 @@ const fetchResource = async ({ isInit = true } = {}) => {
   const locales = Object.keys(appData.i18n).length
     ? Object.keys(appData.i18n).map((key) => ({ lang: key, label: key }))
     : defaultLocales
-  resState.langs = {
+
+  appSchemaState.langs = {
     locales,
-    messages: appData.i18n
+    messages: appSchemaState.i18n
   }
+
+  return appData
+}
+
+const fetchResource = async ({ isInit = true } = {}) => {
+  const { id, type } = getMetaApi(META_SERVICE.GlobalService).getBaseInfo()
+  useMessage().publish({ topic: 'app_id_changed', data: id })
+
+  const appData = await fetchAppState()
+
+  useMaterial().initMaterial({ isInit, appData })
 
   try {
     await useMaterial().fetchMaterial()
@@ -166,9 +175,10 @@ const fetchResource = async ({ isInit = true } = {}) => {
 
 export default function () {
   return {
-    resState,
+    appSchemaState,
     fetchResource,
     initPageOrBlock,
-    handlePopStateEvent
+    handlePopStateEvent,
+    fetchAppState
   }
 }

--- a/packages/plugins/materials/src/composable/useResource.js
+++ b/packages/plugins/materials/src/composable/useResource.js
@@ -146,7 +146,7 @@ const fetchAppState = async () => {
 
   appSchemaState.langs = {
     locales,
-    messages: appSchemaState.i18n
+    messages: appData.i18n
   }
 
   return appData

--- a/packages/plugins/schema/package.json
+++ b/packages/plugins/schema/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@opentiny/tiny-engine-common": "workspace:*",
     "@opentiny/tiny-engine-meta-register": "workspace:*",
-    "@opentiny/tiny-engine-utils": "workspace:*"
+    "@opentiny/tiny-engine-utils": "workspace:*",
+    "@vueuse/core": "^9.6.0"
   },
   "devDependencies": {
     "@opentiny/tiny-engine-vite-plugin-meta-comments": "workspace:*",

--- a/packages/plugins/schema/src/Main.vue
+++ b/packages/plugins/schema/src/Main.vue
@@ -38,7 +38,7 @@
 import { nextTick, reactive, getCurrentInstance, onActivated, ref, onDeactivated } from 'vue'
 import { Popover, Button } from '@opentiny/vue'
 import { VueMonaco, CloseIcon } from '@opentiny/tiny-engine-common'
-import { useCanvas, useModal, useHistory, useNotify, useMessage } from '@opentiny/tiny-engine-meta-register'
+import { useCanvas, useModal, useNotify, useMessage } from '@opentiny/tiny-engine-meta-register'
 import { utils } from '@opentiny/tiny-engine-utils'
 import { iconDownloadLink } from '@opentiny/vue-icon'
 
@@ -101,8 +101,9 @@ export default {
         componentName: pageState.pageSchema.componentName
       }
 
-      useCanvas().initData(value, pageState.currentPage)
-      useHistory().addHistory()
+      useCanvas().importSchema(value)
+      // TODO: 历史堆栈
+      // useHistory().addHistory()
       state.pageData = ''
 
       nextTick(() => {

--- a/packages/plugins/schema/src/Main.vue
+++ b/packages/plugins/schema/src/Main.vue
@@ -41,6 +41,7 @@ import { VueMonaco, CloseIcon } from '@opentiny/tiny-engine-common'
 import { useCanvas, useModal, useNotify, useMessage } from '@opentiny/tiny-engine-meta-register'
 import { utils } from '@opentiny/tiny-engine-utils'
 import { iconDownloadLink } from '@opentiny/vue-icon'
+import { useThrottleFn } from '@vueuse/core'
 
 const { reactiveObj2String: obj2String, string2Obj } = utils
 
@@ -112,8 +113,11 @@ export default {
       })
     }
 
+    const throttleUpdateData = useThrottleFn(() => {
+      state.pageData = obj2String(pageState.pageSchema)
+    }, 100)
+
     onActivated(() => {
-      // pageState.pageSchema = useCanvas().canvasApi.value?.getSchema?.() || {}
       state.pageData = obj2String(pageState.pageSchema)
       nextTick(() => {
         window.dispatchEvent(new Event('resize'))
@@ -123,13 +127,7 @@ export default {
       subscribe({
         topic: 'schemaChange',
         subscriber: 'schema-plugin',
-        callback: () => {
-          // if (option.type !== 'changeProps') {
-          //   state.pageSchema = filterSchema(pageState.pageSchema)
-          // }
-          // TODO: 使用节流
-          state.pageData = obj2String(pageState.pageSchema)
-        }
+        callback: throttleUpdateData
       })
     })
 

--- a/packages/plugins/schema/src/Main.vue
+++ b/packages/plugins/schema/src/Main.vue
@@ -113,9 +113,13 @@ export default {
       })
     }
 
-    const throttleUpdateData = useThrottleFn(() => {
-      state.pageData = obj2String(pageState.pageSchema)
-    }, 100)
+    const throttleUpdateData = useThrottleFn(
+      () => {
+        state.pageData = obj2String(pageState.pageSchema)
+      },
+      100,
+      true
+    )
 
     onActivated(() => {
       state.pageData = obj2String(pageState.pageSchema)

--- a/packages/plugins/schema/src/Main.vue
+++ b/packages/plugins/schema/src/Main.vue
@@ -35,10 +35,10 @@
 </template>
 
 <script lang="jsx">
-import { nextTick, reactive, getCurrentInstance, onActivated, ref } from 'vue'
+import { nextTick, reactive, getCurrentInstance, onActivated, ref, onDeactivated } from 'vue'
 import { Popover, Button } from '@opentiny/vue'
 import { VueMonaco, CloseIcon } from '@opentiny/tiny-engine-common'
-import { useCanvas, useModal, useHistory, useNotify } from '@opentiny/tiny-engine-meta-register'
+import { useCanvas, useModal, useHistory, useNotify, useMessage } from '@opentiny/tiny-engine-meta-register'
 import { utils } from '@opentiny/tiny-engine-utils'
 import { iconDownloadLink } from '@opentiny/vue-icon'
 
@@ -59,6 +59,7 @@ export default {
     const state = reactive({
       pageData: obj2String(pageState.pageSchema)
     })
+    const { subscribe, unsubscribe } = useMessage()
 
     const isEdit = false
     const showRed = ref(true)
@@ -111,11 +112,30 @@ export default {
     }
 
     onActivated(() => {
-      pageState.pageSchema = useCanvas().canvasApi.value?.getSchema?.() || {}
+      // pageState.pageSchema = useCanvas().canvasApi.value?.getSchema?.() || {}
       state.pageData = obj2String(pageState.pageSchema)
       nextTick(() => {
         window.dispatchEvent(new Event('resize'))
         showRed.value = state.pageData === app.refs.container.getEditor().getValue()
+      })
+
+      subscribe({
+        topic: 'schemaChange',
+        subscriber: 'schema-plugin',
+        callback: () => {
+          // if (option.type !== 'changeProps') {
+          //   state.pageSchema = filterSchema(pageState.pageSchema)
+          // }
+          // TODO: 使用节流
+          state.pageData = obj2String(pageState.pageSchema)
+        }
+      })
+    })
+
+    onDeactivated(() => {
+      unsubscribe({
+        topic: 'schemaChange',
+        subscriber: 'schema-plugin'
       })
     })
 

--- a/packages/plugins/script/src/js/method.js
+++ b/packages/plugins/script/src/js/method.js
@@ -76,14 +76,12 @@ export const saveMethod = ({ name, content }) => {
 
   const methods = getMethods()
 
-  if (!methods[name]) {
-    methods[name] = {
-      type: SCHEMA_DATA_TYPE.JSFunction,
-      value: ''
-    }
+  const methodItem = {
+    type: SCHEMA_DATA_TYPE.JSFunction,
+    value: content
   }
 
-  methods[name].value = content
+  useCanvas().updateSchema({ methods: { ...methods, [name]: methodItem } })
 }
 
 const saveMethods = () => {
@@ -103,7 +101,7 @@ const saveMethods = () => {
 
   const editorContent = monaco.value.getEditor().getValue()
   const ast = string2Ast(editorContent)
-  useCanvas().getSchema().methods = {}
+  const newMethods = {}
 
   ast.program.body.forEach((declaration, index) => {
     const name = declaration?.id?.name
@@ -118,8 +116,15 @@ const saveMethods = () => {
 
     const content = formatString(ast2String(declaration).trim(), 'javascript')
 
-    saveMethod({ name, content })
+    if (name) {
+      newMethods[name] = {
+        type: SCHEMA_DATA_TYPE.JSFunction,
+        value: content
+      }
+    }
   })
+
+  useCanvas().updateSchema({ methods: newMethods })
   useCanvas().setSaved(false)
   state.isChanged = false
   useNotify({

--- a/packages/plugins/script/src/js/method.js
+++ b/packages/plugins/script/src/js/method.js
@@ -33,7 +33,7 @@ const monaco = ref(null)
 let scriptAst = null
 
 export const getMethods = () => {
-  const pageSchema = useCanvas().canvasApi.value.getSchema?.() || {}
+  const pageSchema = useCanvas().getSchema?.() || {}
 
   pageSchema.methods = pageSchema?.methods || {}
   return pageSchema.methods
@@ -103,7 +103,7 @@ const saveMethods = () => {
 
   const editorContent = monaco.value.getEditor().getValue()
   const ast = string2Ast(editorContent)
-  useCanvas().canvasApi.value.getSchema().methods = {}
+  useCanvas().getSchema().methods = {}
 
   ast.program.body.forEach((declaration, index) => {
     const name = declaration?.id?.name

--- a/packages/plugins/state/src/DataSourceList.vue
+++ b/packages/plugins/state/src/DataSourceList.vue
@@ -68,7 +68,7 @@ export default {
     }
 
     const removeStoreConfirm = (key) => {
-      const appPages = useResource().resState.pageTree.filter(
+      const appPages = useResource().appSchemaState.pageTree.filter(
         (page) => page.componentName === COMPONENT_NAME.Page && page?.meta?.group !== 'publicPages'
       )
       const expression = `stores.${key}`

--- a/packages/plugins/state/src/Main.vue
+++ b/packages/plugins/state/src/Main.vue
@@ -191,7 +191,6 @@ export default {
 
     const confirm = () => {
       const { name } = state.createData
-      const { setGlobalState } = useCanvas().canvasApi.value
       const { getSchema, updateSchema } = useCanvas()
 
       if (!name || errorMessage.value) {
@@ -248,7 +247,7 @@ export default {
         const { id } = getMetaApi(META_SERVICE.GlobalService).getBaseInfo()
         updateGlobalState(id, { global_state: storeList }).then((res) => {
           isPanelShow.value = false
-          setGlobalState(res.global_state || [])
+          useResource().appSchemaState.globalState = res.global_state || []
         })
       }
       openCommon()
@@ -296,8 +295,7 @@ export default {
     }
 
     const setGlobalStateToDataSource = () => {
-      const { getGlobalState } = useCanvas().canvasApi.value
-      const globalState = getGlobalState()
+      const globalState = useResource().appSchemaState.globalState
 
       if (!globalState) {
         state.dataSource = {}
@@ -305,20 +303,19 @@ export default {
         return
       }
 
-      state.dataSource = getGlobalState().reduce((acc, store) => ({ ...acc, [store.id]: store }), {})
+      state.dataSource = globalState.reduce((acc, store) => ({ ...acc, [store.id]: store }), {})
     }
 
     const removeStore = (key) => {
-      const storeListt = [...useResource().resState.globalState] || []
-      const index = storeListt.findIndex((store) => store.id === key)
-      const { setGlobalState } = useCanvas().canvasApi.value
+      const storeList = [...useResource().appSchemaState.globalState] || []
+      const index = storeList.findIndex((store) => store.id === key)
 
       if (index !== -1) {
         const { id } = getMetaApi(META_SERVICE.GlobalService).getBaseInfo()
 
-        storeListt.splice(index, 1)
-        updateGlobalState(id, { global_state: storeListt }).then((res) => {
-          setGlobalState(res.global_state)
+        storeList.splice(index, 1)
+        updateGlobalState(id, { global_state: storeList }).then((res) => {
+          useResource().appSchemaState.globalState = res.global_state || []
           setGlobalStateToDataSource()
         })
 

--- a/packages/plugins/state/src/Main.vue
+++ b/packages/plugins/state/src/Main.vue
@@ -163,7 +163,7 @@ export default {
     }
 
     const add = (name, variable) => {
-      const { getSchema } = useCanvas().canvasApi.value
+      const { getSchema } = useCanvas()
 
       if (getSchema()) {
         if (updateKey.value !== name && flag.value === OPTION_TYPE.UPDATE) {
@@ -261,7 +261,8 @@ export default {
     }
 
     const remove = (key) => {
-      const { deleteState, getSchema } = useCanvas().canvasApi.value
+      const { deleteState } = useCanvas().canvasApi.value
+      const { getSchema } = useCanvas()
 
       delete state.dataSource[key]
       // 删除变量也需要同步触发画布渲染
@@ -328,7 +329,7 @@ export default {
     }
 
     const initDataSource = (tabsName = activeName.value) => {
-      const { getSchema } = useCanvas().canvasApi.value
+      const { getSchema } = useCanvas()
 
       if (tabsName === STATE.GLOBAL_STATE) {
         setGlobalStateToDataSource()

--- a/packages/plugins/state/src/Main.vue
+++ b/packages/plugins/state/src/Main.vue
@@ -191,7 +191,8 @@ export default {
 
     const confirm = () => {
       const { name } = state.createData
-      const { setState, setGlobalState } = useCanvas().canvasApi.value
+      const { setGlobalState } = useCanvas().canvasApi.value
+      const { getSchema, updateSchema } = useCanvas()
 
       if (!name || errorMessage.value) {
         notifySaveError('变量名未填写或名称不符合规范，请按照提示修改后重试。')
@@ -214,8 +215,9 @@ export default {
         isPanelShow.value = false
         setSaved(false)
 
-        // 触发画布渲染
-        setState({ [name]: variable })
+        const schema = getSchema()
+        updateSchema({ state: { ...(schema.state || {}), [name]: variable } })
+
         useHistory().addHistory()
       } else {
         const validateResult = validateMonacoEditorData(storeRef.value.getEditor(), 'state字段', { required: true })
@@ -261,12 +263,13 @@ export default {
     }
 
     const remove = (key) => {
-      const { deleteState } = useCanvas().canvasApi.value
-      const { getSchema } = useCanvas()
+      const { getSchema, updateSchema } = useCanvas()
 
       delete state.dataSource[key]
-      // 删除变量也需要同步触发画布渲染
-      deleteState(key)
+
+      const schema = getSchema()
+      let { lifeCycles } = schema
+      const { [key]: deletedKey, ...restState } = schema.state
 
       if (key.startsWith('datasource')) {
         const pageSchema = getSchema()
@@ -279,8 +282,10 @@ export default {
          */
         const pattern = new RegExp(`([\\s\\n]*\\/\\*\\* ${start} \\*\\/[\\s\\S]*\\/\\*\\* ${end} \\*\\/)`)
 
-        pageSchema.lifeCycles.setup.value = pageSchema.lifeCycles.setup.value.replace(pattern, '')
+        lifeCycles.setup.value = pageSchema.lifeCycles.setup.value.replace(pattern, '')
       }
+
+      updateSchema({ state: restState, lifeCycles })
 
       // 如果删除的是当前编辑的状态变量，则需要关闭二级面板
       if (state.createData.name === key) {
@@ -336,7 +341,6 @@ export default {
       } else {
         const pageSchema = getSchema() || {}
 
-        pageSchema.state = pageSchema?.state || {}
         state.dataSource = pageSchema.state
       }
     }

--- a/packages/plugins/state/src/Main.vue
+++ b/packages/plugins/state/src/Main.vue
@@ -338,7 +338,7 @@ export default {
       } else {
         const pageSchema = getSchema() || {}
 
-        state.dataSource = pageSchema.state
+        state.dataSource = pageSchema.state || {}
       }
     }
 

--- a/packages/plugins/tree/src/Main.vue
+++ b/packages/plugins/tree/src/Main.vue
@@ -49,12 +49,12 @@
 </template>
 
 <script>
-import { reactive, watch, ref, onActivated, computed } from 'vue'
+import { reactive, watch, ref, computed } from 'vue'
 import { Grid, GridColumn } from '@opentiny/vue'
 import { PluginPanel, SvgButton } from '@opentiny/tiny-engine-common'
 import { constants } from '@opentiny/tiny-engine-utils'
 import { IconChevronDown, iconEyeopen, iconEyeclose } from '@opentiny/vue-icon'
-import { useCanvas, useMaterial, useLayout } from '@opentiny/tiny-engine-meta-register'
+import { useCanvas, useMaterial, useLayout, useMessage } from '@opentiny/tiny-engine-meta-register'
 import { extend } from '@opentiny/vue-renderless/common/object'
 import { typeOf } from '@opentiny/vue-renderless/common/type'
 
@@ -118,10 +118,22 @@ export default {
       }
     })
 
-    onActivated(() => {
-      const { getSchema } = useCanvas().canvasApi.value
-      state.pageSchema = filterSchema(getSchema())
+    const { subscribe } = useMessage()
+
+    subscribe({
+      topic: 'schemaChange',
+      subscriber: 'node-tree',
+      callback: ({ option }) => {
+        if (option.type !== 'changeProps') {
+          state.pageSchema = filterSchema(pageState.pageSchema)
+        }
+      }
     })
+
+    // onActivated(() => {
+    //   const { getSchema } = useCanvas().canvasApi.value
+    //   state.pageSchema = filterSchema(getSchema())
+    // })
 
     watch(
       () => pageState.currentSchema,

--- a/packages/plugins/tree/src/Main.vue
+++ b/packages/plugins/tree/src/Main.vue
@@ -144,7 +144,7 @@ export default {
     watch(
       () => pageState.currentSchema,
       () => {
-        const { getSchema } = useCanvas().canvasApi.value
+        const { getSchema } = useCanvas()
         state.pageSchema = filterSchema(getSchema())
       }
     )

--- a/packages/plugins/tree/src/Main.vue
+++ b/packages/plugins/tree/src/Main.vue
@@ -127,7 +127,7 @@ export default {
         topic: 'schemaChange',
         subscriber: 'node-tree',
         callback: ({ operation }) => {
-          if (operation.type !== 'changeProps') {
+          if (operation?.type !== 'changeProps') {
             state.pageSchema = filterSchema(pageState.pageSchema)
           }
         }

--- a/packages/plugins/tree/src/Main.vue
+++ b/packages/plugins/tree/src/Main.vue
@@ -121,7 +121,6 @@ export default {
     const { subscribe, unsubscribe } = useMessage()
 
     onActivated(() => {
-      // const { getSchema } = useCanvas().canvasApi.value
       state.pageSchema = filterSchema(pageState.pageSchema)
 
       subscribe({

--- a/packages/plugins/tree/src/Main.vue
+++ b/packages/plugins/tree/src/Main.vue
@@ -127,8 +127,8 @@ export default {
       subscribe({
         topic: 'schemaChange',
         subscriber: 'node-tree',
-        callback: ({ option }) => {
-          if (option.type !== 'changeProps') {
+        callback: ({ operation }) => {
+          if (operation.type !== 'changeProps') {
             state.pageSchema = filterSchema(pageState.pageSchema)
           }
         }

--- a/packages/plugins/tree/src/Main.vue
+++ b/packages/plugins/tree/src/Main.vue
@@ -49,7 +49,7 @@
 </template>
 
 <script>
-import { reactive, watch, ref, computed } from 'vue'
+import { reactive, watch, ref, computed, onActivated, onDeactivated } from 'vue'
 import { Grid, GridColumn } from '@opentiny/vue'
 import { PluginPanel, SvgButton } from '@opentiny/tiny-engine-common'
 import { constants } from '@opentiny/tiny-engine-utils'
@@ -118,22 +118,29 @@ export default {
       }
     })
 
-    const { subscribe } = useMessage()
+    const { subscribe, unsubscribe } = useMessage()
 
-    subscribe({
-      topic: 'schemaChange',
-      subscriber: 'node-tree',
-      callback: ({ option }) => {
-        if (option.type !== 'changeProps') {
-          state.pageSchema = filterSchema(pageState.pageSchema)
+    onActivated(() => {
+      // const { getSchema } = useCanvas().canvasApi.value
+      state.pageSchema = filterSchema(pageState.pageSchema)
+
+      subscribe({
+        topic: 'schemaChange',
+        subscriber: 'node-tree',
+        callback: ({ option }) => {
+          if (option.type !== 'changeProps') {
+            state.pageSchema = filterSchema(pageState.pageSchema)
+          }
         }
-      }
+      })
     })
 
-    // onActivated(() => {
-    //   const { getSchema } = useCanvas().canvasApi.value
-    //   state.pageSchema = filterSchema(getSchema())
-    // })
+    onDeactivated(() => {
+      unsubscribe({
+        topic: 'schemaChange',
+        subscriber: 'node-tree'
+      })
+    })
 
     watch(
       () => pageState.currentSchema,

--- a/packages/register/src/common.js
+++ b/packages/register/src/common.js
@@ -159,7 +159,7 @@ export const preprocessRegistry = (registry) => {
     })
 }
 
-const maxDepth = 100
+const maxDepth = 25
 
 export const generateRegistry = (registry, depth = 1) => {
   if (depth > maxDepth) {

--- a/packages/register/src/common.js
+++ b/packages/register/src/common.js
@@ -177,7 +177,6 @@ export const generateRegistry = (registry, depth = 1) => {
         // TODO: 其他类型配置处理
       }
 
-      // console.log('value', value)
       generateRegistry(value, depth + 1)
     }
   })

--- a/packages/register/src/common.js
+++ b/packages/register/src/common.js
@@ -159,7 +159,13 @@ export const preprocessRegistry = (registry) => {
     })
 }
 
-export const generateRegistry = (registry) => {
+const maxDepth = 100
+
+export const generateRegistry = (registry, depth = 1) => {
+  if (depth > maxDepth) {
+    return
+  }
+
   Object.entries(registry).forEach(([key, value]) => {
     if (typeof value === 'object' && value) {
       const { id } = value
@@ -171,7 +177,8 @@ export const generateRegistry = (registry) => {
         // TODO: 其他类型配置处理
       }
 
-      generateRegistry(value)
+      // console.log('value', value)
+      generateRegistry(value, depth + 1)
     }
   })
 }

--- a/packages/register/src/common.js
+++ b/packages/register/src/common.js
@@ -159,13 +159,7 @@ export const preprocessRegistry = (registry) => {
     })
 }
 
-const maxDepth = 25
-
-export const generateRegistry = (registry, depth = 1) => {
-  if (depth > maxDepth) {
-    return
-  }
-
+export const generateRegistry = (registry) => {
   Object.entries(registry).forEach(([key, value]) => {
     if (typeof value === 'object' && value) {
       const { id } = value
@@ -177,7 +171,7 @@ export const generateRegistry = (registry, depth = 1) => {
         // TODO: 其他类型配置处理
       }
 
-      generateRegistry(value, depth + 1)
+      generateRegistry(value)
     }
   })
 }

--- a/packages/settings/events/src/components/AdvanceConfig.vue
+++ b/packages/settings/events/src/components/AdvanceConfig.vue
@@ -173,16 +173,20 @@ export default {
     }
 
     const setConfig = (value) => {
-      const { getSchema, setProp } = useProperties()
+      const { getSchema } = useProperties()
       const schema = getSchema()
+
       if (!schema) {
         return
       }
 
+      const { operateNode } = useCanvas()
+
       if (value === false || value?.type) {
-        setProp('condition', value)
+        operateNode({ type: 'updateAttributes', id: schema.id, value: { condition: value } })
       } else {
-        setProp('condition', '')
+        const { condition: _schemaCondition, children, ...rest } = schema
+        operateNode({ type: 'updateAttributes', id: schema.id, value: { ...rest }, overwrite: true })
       }
 
       useCanvas().canvasApi.value.updateRect()

--- a/packages/settings/events/src/components/AdvanceConfig.vue
+++ b/packages/settings/events/src/components/AdvanceConfig.vue
@@ -127,33 +127,35 @@ export default {
 
     const setLoopKey = (value = '') => {
       value = value.replace(/\s*/g, '')
-      const schema = useProperties().getSchema()
+      const { getSchema, setProp } = useProperties()
+      const schema = getSchema()
 
       if (!schema) {
         return
       }
 
       const isNumber = Number(value).toString() !== 'NaN'
-
-      schema.props = schema.props || {}
-      const props = schema.props
+      let newPropsKey = schema.props.key
 
       if (value && !isNumber) {
-        props.key = {
+        newPropsKey = {
           type: PROP_DATA_TYPE.JSEXPRESSION,
           value
         }
       }
+
       if (!value) {
         if (state.isLoop) {
-          props.key = {
+          newPropsKey = {
             type: PROP_DATA_TYPE.JSEXPRESSION,
             value: getIndexName()
           }
         } else {
-          delete props.key
+          newPropsKey = ''
         }
       }
+
+      setProp('key', newPropsKey)
     }
 
     watch([() => state.isLoop, () => state.loopIndex], () => {
@@ -171,14 +173,16 @@ export default {
     }
 
     const setConfig = (value) => {
-      if (!useProperties().getSchema()) {
+      const { getSchema, setProp } = useProperties()
+      const schema = getSchema()
+      if (!schema) {
         return
       }
 
       if (value === false || value?.type) {
-        useProperties().getSchema().condition = value
+        setProp('condition', value)
       } else {
-        delete useProperties().getSchema().condition
+        setProp('condition', '')
       }
 
       useCanvas().canvasApi.value.updateRect()
@@ -186,21 +190,34 @@ export default {
     }
 
     const setLoopIndex = (value) => {
-      if (useProperties().getSchema().loopArgs) {
-        useProperties().getSchema().loopArgs[1] = value || DEFAULT_LOOP_NAME.INDEX
+      const schema = useProperties().getSchema()
+      let loopArgs = schema.loopArgs
+      const { operateNode } = useCanvas()
+
+      if (loopArgs) {
+        loopArgs[1] = value || DEFAULT_LOOP_NAME.INDEX
       } else {
-        useProperties().getSchema().loopArgs = [DEFAULT_LOOP_NAME.ITEM, value]
+        loopArgs = [DEFAULT_LOOP_NAME.ITEM, value]
       }
+
+      operateNode({ type: 'updateAttributes', id: schema.id, value: { loopArgs } })
     }
 
     const setLoop = (value) => {
+      const { operateNode } = useCanvas()
+      const { getSchema } = useProperties()
+      const schema = getSchema()
+
       if (value) {
-        useProperties().getSchema().loop = value?.type ? value : string2Obj(value)
+        const newLoop = value?.type ? value : string2Obj(value)
+
+        operateNode({ type: 'updateAttributes', id: schema.id, value: { loop: newLoop } })
         setLoopIndex(DEFAULT_LOOP_NAME.INDEX)
       } else {
         setLoopKey()
-        delete useProperties().getSchema().loop
-        delete useProperties().getSchema().loopArgs
+        const { loop: _loop, loopArgs: _loopArgs, children: _children, ...rest } = schema
+
+        operateNode({ type: 'updateAttributes', id: schema.id, value: rest, overwrite: true })
       }
 
       // 触发更新state
@@ -208,11 +225,17 @@ export default {
     }
 
     const setLoopItem = (value) => {
-      if (useProperties().getSchema().loopArgs) {
-        useProperties().getSchema().loopArgs[0] = value || DEFAULT_LOOP_NAME.ITEM
+      const schema = useProperties().getSchema()
+      let loopArgs = schema.loopArgs
+      const { operateNode } = useCanvas()
+
+      if (loopArgs) {
+        loopArgs[0] = value || DEFAULT_LOOP_NAME.ITEM
       } else {
-        useProperties().getSchema().loopArgs = [value, DEFAULT_LOOP_NAME.INDEX]
+        loopArgs = [value, DEFAULT_LOOP_NAME.INDEX]
       }
+
+      operateNode({ type: 'updateAttributes', id: schema.id, value: { loopArgs } })
     }
 
     return {

--- a/packages/settings/props/src/components/Empty.vue
+++ b/packages/settings/props/src/components/Empty.vue
@@ -3,11 +3,8 @@
 </template>
 
 <script>
-import { ref, watchEffect } from 'vue'
-import { useBroadcastChannel } from '@vueuse/core'
-import { constants } from '@opentiny/tiny-engine-utils'
-
-const { BROADCAST_CHANNEL } = constants
+import { ref, watch } from 'vue'
+import { useCanvas } from '@opentiny/tiny-engine-meta-register'
 
 const EMPTY_COMPONENT = '您还未拖拽组件至画布中'
 const EMPTY_SELECTION = '请在画布中选择组件'
@@ -21,11 +18,14 @@ export default {
   },
   setup() {
     const tipsDesc = ref(EMPTY_COMPONENT)
-    const { data: schemaLength } = useBroadcastChannel({ name: BROADCAST_CHANNEL.SchemaLength })
+    const { getSchema } = useCanvas()
 
-    watchEffect(() => {
-      tipsDesc.value = schemaLength.value ? EMPTY_SELECTION : EMPTY_COMPONENT
-    })
+    watch(
+      () => getSchema()?.children?.length,
+      (len) => {
+        tipsDesc.value = len ? EMPTY_SELECTION : EMPTY_COMPONENT
+      }
+    )
 
     return {
       tipsDesc

--- a/packages/settings/props/src/components/modal/ModalContent.vue
+++ b/packages/settings/props/src/components/modal/ModalContent.vue
@@ -45,7 +45,7 @@ export default {
     }
   },
   setup(props) {
-    const { resState } = useResource()
+    const { appSchemaState } = useResource()
 
     const propertyList = computed(() => {
       const properties = JSON.parse(JSON.stringify(props.properties))
@@ -65,9 +65,9 @@ export default {
 
       if (props.values.title && props.values.title.i18nKey) {
         const i18nKey = props.values.title.i18nKey
-        title = resState.langs[i18nKey]
-          ? resState.langs[i18nKey][resState.currentLang]
-          : props.values.title[resState.currentLang]
+        title = appSchemaState.langs[i18nKey]
+          ? appSchemaState.langs[i18nKey][appSchemaState.currentLang]
+          : props.values.title[appSchemaState.currentLang]
       } else {
         title = props.values.title
       }

--- a/packages/settings/props/src/composable/useProperties.js
+++ b/packages/settings/props/src/composable/useProperties.js
@@ -121,15 +121,32 @@ const setProp = (name, value, type) => {
 
   properties.schema.props = properties.schema.props || {}
 
+  const newProps = { ...(properties.schema.props || {}) }
+
+  let overwrite = false
+
   if ((value === '' && type !== 'String') || value === undefined || value === null) {
-    delete properties.schema.props[name]
+    // delete properties.schema.props[name]
+    delete newProps[name]
+    overwrite = true
   } else {
-    properties.schema.props[name] = value
+    // properties.schema.props[name] = value
+    newProps[name] = value
   }
 
+  useCanvas().operateNode({
+    type: 'changeProps',
+    id: properties.schema.id,
+    value: { props: newProps },
+    option: { overwrite }
+  })
+
   // 没有父级，或者不在节点上面，要更新内容。就用setState
-  const { getNode, setState, updateRect } = useCanvas().canvasApi.value || {}
-  getNode(properties.schema.id, true)?.parent || setState(useCanvas().getPageSchema().state)
+  const { setState, updateRect } = useCanvas().canvasApi.value || {}
+  const { getNodeWithParentById } = useCanvas()
+
+  getNodeWithParentById(properties.schema.id)?.parent || setState(useCanvas().getPageSchema().state)
+  // getNode(properties.schema.id, true)?.parent || setState(useCanvas().getPageSchema().state)
   propsUpdateKey.value++
 
   // 更新根节点props不用updateRect
@@ -145,8 +162,19 @@ const getProp = (key) => {
 }
 
 const delProp = (name) => {
-  const props = properties.schema.props || {}
-  delete props[name]
+  // const props = properties.schema.props || {}
+  // delete props[name]
+
+  const newProps = { ...(properties.schema.props || {}) }
+
+  delete newProps[name]
+
+  useCanvas().operateNode({
+    type: 'changeProps',
+    id: properties.schema.id,
+    value: { props: newProps },
+    option: { overwrite: true }
+  })
   propsUpdateKey.value++
 }
 

--- a/packages/settings/props/src/composable/useProperties.js
+++ b/packages/settings/props/src/composable/useProperties.js
@@ -139,11 +139,11 @@ const setProp = (name, value, type) => {
     option: { overwrite }
   })
 
-  // 没有父级，或者不在节点上面，要更新内容。就用setState
-  const { setState, updateRect } = useCanvas().canvasApi.value || {}
-  const { getNodeWithParentById } = useCanvas()
+  const { updateRect } = useCanvas().canvasApi.value || {}
 
-  getNodeWithParentById(properties.schema.id)?.parent || setState(useCanvas().getPageSchema().state)
+  // 没有父级，或者不在节点上面，要更新内容。就用setState
+  // TODO: 确认相关场景还有没有用，没用删除
+  // getNodeWithParentById(properties.schema.id)?.parent || setState(useCanvas().getPageSchema().state)
   propsUpdateKey.value++
 
   // 更新根节点props不用updateRect

--- a/packages/settings/props/src/composable/useProperties.js
+++ b/packages/settings/props/src/composable/useProperties.js
@@ -10,7 +10,7 @@
  *
  */
 
-import { toRaw, nextTick, shallowReactive, ref } from 'vue'
+import { toRaw, shallowReactive, ref } from 'vue'
 import { constants } from '@opentiny/tiny-engine-utils'
 import { useCanvas, useMaterial, useTranslate } from '@opentiny/tiny-engine-meta-register'
 
@@ -139,19 +139,7 @@ const setProp = (name, value, type) => {
     option: { overwrite }
   })
 
-  const { updateRect } = useCanvas().canvasApi.value || {}
-
-  // 没有父级，或者不在节点上面，要更新内容。就用setState
-  // TODO: 确认相关场景还有没有用，没用删除
-  // getNodeWithParentById(properties.schema.id)?.parent || setState(useCanvas().getPageSchema().state)
   propsUpdateKey.value++
-
-  // 更新根节点props不用updateRect
-  if (!properties.schema.id) {
-    return
-  }
-
-  nextTick(updateRect)
 }
 
 const getProp = (key) => {

--- a/packages/settings/props/src/composable/useProperties.js
+++ b/packages/settings/props/src/composable/useProperties.js
@@ -126,11 +126,9 @@ const setProp = (name, value, type) => {
   let overwrite = false
 
   if ((value === '' && type !== 'String') || value === undefined || value === null) {
-    // delete properties.schema.props[name]
     delete newProps[name]
     overwrite = true
   } else {
-    // properties.schema.props[name] = value
     newProps[name] = value
   }
 
@@ -146,7 +144,6 @@ const setProp = (name, value, type) => {
   const { getNodeWithParentById } = useCanvas()
 
   getNodeWithParentById(properties.schema.id)?.parent || setState(useCanvas().getPageSchema().state)
-  // getNode(properties.schema.id, true)?.parent || setState(useCanvas().getPageSchema().state)
   propsUpdateKey.value++
 
   // 更新根节点props不用updateRect

--- a/packages/settings/props/src/composable/useProperties.js
+++ b/packages/settings/props/src/composable/useProperties.js
@@ -159,9 +159,6 @@ const getProp = (key) => {
 }
 
 const delProp = (name) => {
-  // const props = properties.schema.props || {}
-  // delete props[name]
-
   const newProps = { ...(properties.schema.props || {}) }
 
   delete newProps[name]

--- a/packages/settings/styles/src/Main.vue
+++ b/packages/settings/styles/src/Main.vue
@@ -127,7 +127,7 @@ export default {
     // 获取当前节点 style 对象
     const { state, updateStyle } = useStyle() // updateStyle
     const { addHistory } = useHistory()
-    const { getSchema } = useProperties()
+    const { getSchema, setProp } = useProperties()
 
     const handoverGroup = (actives) => {
       if (props.isCollapsed) {
@@ -135,26 +135,30 @@ export default {
       }
     }
 
+    const updateStyleToSchema = (value) => {
+      const schema = getSchema()
+
+      if (schema) {
+        setProp('style', value)
+
+        return
+      }
+
+      const { getSchema: getCanvasPageSchema, updateSchema } = useCanvas()
+      const pageSchema = getCanvasPageSchema()
+
+      // TODO: 当 style 为空时，支持移除 style key
+      updateSchema({ props: { ...(pageSchema.props || {}), style: value } })
+    }
+
     // 保存编辑器内容，并回写到 schema
     const save = ({ content }) => {
       const { updateRect } = useCanvas().canvasApi.value
-      const { getSchema: getCanvasPageSchema } = useCanvas()
-      const pageSchema = getCanvasPageSchema()
-      const schema = getSchema() || pageSchema
       const styleString = styleStrRemoveRoot(content)
-      const currentSchema = getCurrentSchema() || pageSchema
 
       state.styleContent = content
-      schema.props = schema.props || {}
-      schema.props.style = styleString
 
-      currentSchema.props = currentSchema.props || {}
-
-      if (styleString) {
-        currentSchema.props.style = styleString
-      } else {
-        delete currentSchema.props.style
-      }
+      updateStyleToSchema(styleString)
 
       addHistory()
       updateRect()
@@ -162,20 +166,14 @@ export default {
 
     const setConfig = (value) => {
       const { updateRect } = useCanvas().canvasApi.value
-      const { getSchema: getCanvasPageSchema } = useCanvas()
-      const pageSchema = getCanvasPageSchema()
-      const currentSchema = getCurrentSchema() || pageSchema
-      const schema = getSchema() || pageSchema
 
       if (value !== '') {
-        schema.props.style = value
-        currentSchema.props.style = value
+        updateStyleToSchema(value)
         state.propertiesList = `已绑定：${value.value}`
         state.lineStyleDisable = false
         addHistory()
       } else {
-        schema.props.style = ''
-        currentSchema.props.style = ''
+        updateStyleToSchema('')
         state.propertiesList = '编辑行内样式'
         state.lineStyleDisable = true
         addHistory()

--- a/packages/settings/styles/src/Main.vue
+++ b/packages/settings/styles/src/Main.vue
@@ -137,7 +137,8 @@ export default {
 
     // 保存编辑器内容，并回写到 schema
     const save = ({ content }) => {
-      const { getSchema: getCanvasPageSchema, updateRect } = useCanvas().canvasApi.value
+      const { updateRect } = useCanvas().canvasApi.value
+      const { getSchema: getCanvasPageSchema } = useCanvas()
       const pageSchema = getCanvasPageSchema()
       const schema = getSchema() || pageSchema
       const styleString = styleStrRemoveRoot(content)
@@ -160,7 +161,8 @@ export default {
     }
 
     const setConfig = (value) => {
-      const { getSchema: getCanvasPageSchema, updateRect } = useCanvas().canvasApi.value
+      const { updateRect } = useCanvas().canvasApi.value
+      const { getSchema: getCanvasPageSchema } = useCanvas()
       const pageSchema = getCanvasPageSchema()
       const currentSchema = getCurrentSchema() || pageSchema
       const schema = getSchema() || pageSchema

--- a/packages/settings/styles/src/components/classNamesContainer/index.vue
+++ b/packages/settings/styles/src/components/classNamesContainer/index.vue
@@ -111,7 +111,7 @@ import { formatString } from '@opentiny/tiny-engine-common/js/ast'
 import useStyle, { updateGlobalStyleStr } from '../../js/useStyle'
 import { stringify, getSelectorArr } from '../../js/parser'
 
-const { getSchema, propsUpdateKey } = useProperties()
+const { getSchema, propsUpdateKey, setProp } = useProperties()
 
 const stateOptions = [
   { label: 'None', value: '' },
@@ -171,14 +171,19 @@ watch(
 )
 
 const setSelectorProps = (type, value) => {
-  const { getSchema: getCanvasPageSchema } = useCanvas()
-  const schema = getSchema() || getCanvasPageSchema()
+  const schema = getSchema()
 
-  if (!schema.props) {
-    schema.props = {}
+  if (schema) {
+    setProp(type, value)
+    propsUpdateKey.value++
+
+    return
   }
 
-  schema.props[type] = value
+  const { getSchema: getCanvasPageSchema, updateSchema } = useCanvas()
+  const pageSchema = getCanvasPageSchema()
+
+  updateSchema({ props: { ...(pageSchema.props || {}), [type]: value } })
   propsUpdateKey.value++
 }
 

--- a/packages/settings/styles/src/components/classNamesContainer/index.vue
+++ b/packages/settings/styles/src/components/classNamesContainer/index.vue
@@ -171,7 +171,7 @@ watch(
 )
 
 const setSelectorProps = (type, value) => {
-  const { getSchema: getCanvasPageSchema } = useCanvas().canvasApi.value
+  const { getSchema: getCanvasPageSchema } = useCanvas()
   const schema = getSchema() || getCanvasPageSchema()
 
   if (!schema.props) {
@@ -184,7 +184,7 @@ const setSelectorProps = (type, value) => {
 
 // 编辑 className 新增、删除、或修改
 const editClassName = (curClassName, optionType = OPTION_TYPE.ADD, oldSelector = '') => {
-  const { getSchema: getCanvasPageSchema } = useCanvas().canvasApi.value
+  const { getSchema: getCanvasPageSchema } = useCanvas()
   const schema = getSchema() || getCanvasPageSchema()
   let type = ''
 
@@ -443,7 +443,8 @@ const save = ({ content }) => {
   const cssString = formatString(content.replace(/"/g, "'"), 'css')
   const { getPageSchema } = useCanvas()
   const { addHistory } = useHistory()
-  const { updateRect, setPageCss, getSchema: getCanvasPageSchema } = useCanvas().canvasApi.value
+  const { updateRect, setPageCss } = useCanvas().canvasApi.value
+  const { getSchema: getCanvasPageSchema } = useCanvas()
   getPageSchema().css = cssString
   getCanvasPageSchema().css = cssString
   setPageCss(cssString)

--- a/packages/settings/styles/src/components/classNamesContainer/index.vue
+++ b/packages/settings/styles/src/components/classNamesContainer/index.vue
@@ -441,13 +441,11 @@ watchEffect(() => {
 
 const save = ({ content }) => {
   const cssString = formatString(content.replace(/"/g, "'"), 'css')
-  const { getPageSchema } = useCanvas()
   const { addHistory } = useHistory()
-  const { updateRect, setPageCss } = useCanvas().canvasApi.value
-  const { getSchema: getCanvasPageSchema } = useCanvas()
-  getPageSchema().css = cssString
-  getCanvasPageSchema().css = cssString
-  setPageCss(cssString)
+  const { updateRect } = useCanvas().canvasApi.value
+  const { updateSchema } = useCanvas()
+
+  updateSchema({ css: cssString })
   state.schemaUpdateKey++
 
   addHistory()

--- a/packages/settings/styles/src/js/useEditor.js
+++ b/packages/settings/styles/src/js/useEditor.js
@@ -15,6 +15,7 @@ import { useHistory, useCanvas } from '@opentiny/tiny-engine-meta-register'
 import { obj2StyleStr, styleStrRemoveRoot } from './cssConvert'
 import { CSS_TYPE } from './cssType'
 
+// TODO: 确认是否还有地方引用，没有就删除了
 export default ({ style, pageState }) => {
   const { addHistory } = useHistory()
 
@@ -55,10 +56,9 @@ export default ({ style, pageState }) => {
         addHistory()
       }
     } else if (editor.type === CSS_TYPE.Css) {
-      pageState.pageSchema.css = content
-      const { setPageCss } = useCanvas().canvasApi.value
+      const { updateSchema } = useCanvas()
+      updateSchema({ css: content })
 
-      setPageCss(content)
       addHistory()
     }
   }

--- a/packages/settings/styles/src/js/useStyle.js
+++ b/packages/settings/styles/src/js/useStyle.js
@@ -23,7 +23,7 @@ const state = reactive({
   // 当前选中节点的  style，解析成对象返回
   style: {},
   // 编辑器显示的行内样式字符串
-  styleContent: '',
+  styleContent: formatString(`:root {\n \n}`, 'css'),
   // 编辑器显示的全局样式字符串
   cssContent: '',
   pageCssObject: {},
@@ -130,50 +130,49 @@ const getClassNameAndIdList = (schema) => {
   }
 }
 
-watch(
-  () => [
-    useCanvas().getCurrentSchema?.(),
-    state.schemaUpdateKey,
-    useProps().propsUpdateKey?.value,
-    useCanvas()?.getSchema?.()
-  ],
-  ([curSchema], [oldCurSchema] = []) => {
-    const { getCurrentSchema, getSchema } = useCanvas()
-    let schema = getCurrentSchema()
+export const initStylePanelWatch = () => {
+  watch(
+    () => [
+      useCanvas().getCurrentSchema?.(),
+      state.schemaUpdateKey,
+      useProps().propsUpdateKey?.value,
+      useCanvas()?.getSchema?.()
+    ],
+    ([curSchema], [oldCurSchema] = []) => {
+      const { getCurrentSchema, getSchema } = useCanvas()
+      let schema = getCurrentSchema()
 
-    if (!schema || Object.keys(schema).length === 0) {
-      schema = getSchema?.()
-    }
-
-    if (!schema) {
-      return
-    }
-
-    // 获取当前选中组件的类名以及 id 列表
-    const { classNameList, idList } = getClassNameAndIdList(schema)
-
-    state.currentClassNameList = classNameList.map((item) => `.${item}`)
-    state.currentIdList = idList.map((item) => `#${item}`)
-
-    // 变化了相当于重新选中了，需要重置当前选中的 className 以及样式面板的样式
-    if (curSchema !== oldCurSchema) {
-      state.className = {
-        classNameList: '',
-        mouseState: ''
+      if (!schema || Object.keys(schema).length === 0) {
+        schema = getSchema?.()
       }
-      state.style = {}
+
+      if (!schema) {
+        return
+      }
+
+      // 获取当前选中组件的类名以及 id 列表
+      const { classNameList, idList } = getClassNameAndIdList(schema)
+
+      state.currentClassNameList = classNameList.map((item) => `.${item}`)
+      state.currentIdList = idList.map((item) => `#${item}`)
+
+      // 变化了相当于重新选中了，需要重置当前选中的 className 以及样式面板的样式
+      if (curSchema !== oldCurSchema) {
+        state.className = {
+          classNameList: '',
+          mouseState: ''
+        }
+        state.style = {}
+      }
+
+      state.styleContent = formatString(`:root {\n ${schema?.props?.style || ''}\n}`, 'css')
+    },
+    {
+      deep: true
     }
+  )
 
-    state.styleContent = formatString(`:root {\n ${schema?.props?.style || ''}\n}`, 'css')
-  },
-  {
-    // immediate: true, // TODO: 需要评估能否去掉
-    deep: true
-  }
-)
-
-// 监听全局样式的变化，重新解析
-setTimeout(() => {
+  // 监听全局样式的变化，重新解析
   watch(
     () => useCanvas().getPageSchema?.()?.css,
     (value) => {
@@ -187,76 +186,76 @@ setTimeout(() => {
       state.styleObject = styleObject
     }
   )
-}, 0) // 这里需要延时，不然页面初始化的时候，watch不到实际的对象，会使得这里失效
 
-// 计算当前类名下拉列表
-watch(
-  () => [state.currentClassNameList, state.currentIdList, state.styleObject],
-  () => {
-    let list = []
+  // 计算当前类名下拉列表
+  watch(
+    () => [state.currentClassNameList, state.currentIdList, state.styleObject],
+    () => {
+      let list = []
 
-    const classNameListOptions = state.currentClassNameList.map((item) => ({ label: item, value: item }))
-    const idListOptions = state.currentIdList.map((item) => ({ label: item, value: item }))
+      const classNameListOptions = state.currentClassNameList.map((item) => ({ label: item, value: item }))
+      const idListOptions = state.currentIdList.map((item) => ({ label: item, value: item }))
 
-    list = list.concat(classNameListOptions, idListOptions)
+      list = list.concat(classNameListOptions, idListOptions)
 
-    Object.values(state.styleObject).forEach((value) => {
-      const selectorArr = getSelectorArr(value.pureSelector)
+      Object.values(state.styleObject).forEach((value) => {
+        const selectorArr = getSelectorArr(value.pureSelector)
 
-      if (selectorArr.length <= 1) {
+        if (selectorArr.length <= 1) {
+          return
+        }
+
+        const isComboSelector = selectorArr.every(
+          (item) => state.currentClassNameList.includes(item) || state.currentIdList.includes(item)
+        )
+
+        if (isComboSelector) {
+          list.push({ label: value.pureSelector, value: value.pureSelector })
+        }
+      })
+
+      // 默认选择的类
+      let defaultSelector = ''
+      let defaultMouseState = ''
+      const curClassName = state.className.classNameList
+
+      if (list.find(({ value }) => value === curClassName)) {
+        defaultSelector = curClassName
+        defaultMouseState = state.className.mouseState
+      } else if (list.length) {
+        defaultSelector = list.at(-1).value
+      }
+
+      state.selectorOptionLists = list
+
+      state.className = {
+        classNameList: defaultSelector,
+        mouseState: defaultMouseState
+      }
+    }
+  )
+
+  // 计算当前样式面板展示的样式
+  watch(
+    () => state.className,
+    () => {
+      const { classNameList, mouseState } = state.className
+
+      if (!classNameList) {
         return
       }
 
-      const isComboSelector = selectorArr.every(
-        (item) => state.currentClassNameList.includes(item) || state.currentIdList.includes(item)
+      const matchStyles = Object.values(state.styleObject).filter(
+        (value) => value.pureSelector === classNameList && value.mouseState === mouseState
       )
-
-      if (isComboSelector) {
-        list.push({ label: value.pureSelector, value: value.pureSelector })
-      }
-    })
-
-    // 默认选择的类
-    let defaultSelector = ''
-    let defaultMouseState = ''
-    const curClassName = state.className.classNameList
-
-    if (list.find(({ value }) => value === curClassName)) {
-      defaultSelector = curClassName
-      defaultMouseState = state.className.mouseState
-    } else if (list.length) {
-      defaultSelector = list.at(-1).value
+      const style = matchStyles.length ? matchStyles[0].rules : {}
+      state.style = { ...style }
+    },
+    {
+      deep: true
     }
-
-    state.selectorOptionLists = list
-
-    state.className = {
-      classNameList: defaultSelector,
-      mouseState: defaultMouseState
-    }
-  }
-)
-
-// 计算当前样式面板展示的样式
-watch(
-  () => state.className,
-  () => {
-    const { classNameList, mouseState } = state.className
-
-    if (!classNameList) {
-      return
-    }
-
-    const matchStyles = Object.values(state.styleObject).filter(
-      (value) => value.pureSelector === classNameList && value.mouseState === mouseState
-    )
-    const style = matchStyles.length ? matchStyles[0].rules : {}
-    state.style = { ...style }
-  },
-  {
-    deep: true
-  }
-)
+  )
+}
 
 export const updateGlobalStyleStr = (styleStr) => {
   const { updateSchema } = useCanvas()
@@ -339,7 +338,14 @@ const updateStyle = (properties) => {
   updateRect()
 }
 
+let hasWatchInitialized = false
+
 export default () => {
+  if (!hasWatchInitialized) {
+    initStylePanelWatch()
+    hasWatchInitialized = true
+  }
+
   return {
     state,
     updateStyle

--- a/packages/settings/styles/src/js/useStyle.js
+++ b/packages/settings/styles/src/js/useStyle.js
@@ -11,16 +11,13 @@
  */
 
 import { computed, reactive, watch } from 'vue'
-import { useBroadcastChannel } from '@vueuse/core'
 import { useCanvas, useHistory, useProperties as useProps, getOptions } from '@opentiny/tiny-engine-meta-register'
 import { formatString } from '@opentiny/tiny-engine-common/js/ast'
 import { constants, utils } from '@opentiny/tiny-engine-utils'
 import { parser, stringify, getSelectorArr } from './parser'
 
-const { BROADCAST_CHANNEL, EXPRESSION_TYPE } = constants
+const { EXPRESSION_TYPE } = constants
 const { generateRandomLetters, parseExpression } = utils
-
-const { data: schemaLength } = useBroadcastChannel({ name: BROADCAST_CHANNEL.SchemaLength })
 
 const state = reactive({
   // 当前选中节点的  style，解析成对象返回
@@ -138,8 +135,7 @@ watch(
     useCanvas().getCurrentSchema?.(),
     state.schemaUpdateKey,
     useProps().propsUpdateKey?.value,
-    useCanvas()?.getSchema?.(),
-    schemaLength
+    useCanvas()?.getSchema?.()
   ],
   ([curSchema], [oldCurSchema] = []) => {
     const { getCurrentSchema, getSchema } = useCanvas()

--- a/packages/settings/styles/src/js/useStyle.js
+++ b/packages/settings/styles/src/js/useStyle.js
@@ -263,13 +263,9 @@ watch(
 )
 
 export const updateGlobalStyleStr = (styleStr) => {
-  const { getSchema, getPageSchema, canvasApi } = useCanvas()
-  const pageSchema = getPageSchema()
-  const { setPageCss } = canvasApi.value
+  const { updateSchema } = useCanvas()
 
-  pageSchema.css = styleStr
-  getSchema().css = styleStr
-  setPageCss(styleStr)
+  updateSchema({ css: styleStr })
   state.schemaUpdateKey++
 }
 

--- a/packages/settings/styles/src/js/useStyle.js
+++ b/packages/settings/styles/src/js/useStyle.js
@@ -138,15 +138,15 @@ watch(
     useCanvas().getCurrentSchema?.(),
     state.schemaUpdateKey,
     useProps().propsUpdateKey?.value,
-    useCanvas().canvasApi?.value?.getSchema?.(),
+    useCanvas()?.getSchema?.(),
     schemaLength
   ],
   ([curSchema], [oldCurSchema] = []) => {
-    const { getCurrentSchema, canvasApi } = useCanvas()
+    const { getCurrentSchema, getSchema } = useCanvas()
     let schema = getCurrentSchema()
 
     if (!schema || Object.keys(schema).length === 0) {
-      schema = canvasApi.value?.getSchema?.()
+      schema = getSchema?.()
     }
 
     if (!schema) {
@@ -263,9 +263,9 @@ watch(
 )
 
 export const updateGlobalStyleStr = (styleStr) => {
-  const { getPageSchema, canvasApi } = useCanvas()
+  const { getSchema, getPageSchema, canvasApi } = useCanvas()
   const pageSchema = getPageSchema()
-  const { getSchema, setPageCss } = canvasApi.value
+  const { setPageCss } = canvasApi.value
 
   pageSchema.css = styleStr
   getSchema().css = styleStr
@@ -302,10 +302,10 @@ const updateGlobalStyle = (newSelector) => {
 
 // 更新 style 对象到 schema
 const updateStyle = (properties) => {
-  const { canvasApi } = useCanvas()
+  const { canvasApi, getSchema: getCanvasPageSchema } = useCanvas()
   const { getSchema } = useProps()
   const { addHistory } = useHistory()
-  const { getSchema: getCanvasPageSchema, updateRect } = canvasApi.value
+  const { updateRect } = canvasApi.value
   const schema = getSchema() || getCanvasPageSchema()
   const pageOptions = getOptions('engine.plugins.appmanage')
   const materialsOptions = getOptions('engine.plugins.materials')

--- a/packages/toolbars/generate-code/src/Main.vue
+++ b/packages/toolbars/generate-code/src/Main.vue
@@ -51,7 +51,7 @@ export default {
     })
 
     const getParams = () => {
-      const { getSchema } = useCanvas().canvasApi.value
+      const { getSchema } = useCanvas()
       const params = {
         framework: getMergeMeta('engine.config')?.dslMode,
         platform: getMergeMeta('engine.config')?.platformId,

--- a/packages/toolbars/preview/src/Main.vue
+++ b/packages/toolbars/preview/src/Main.vue
@@ -28,7 +28,7 @@ export default {
     }
   },
   setup() {
-    const { isBlock, getCurrentPage, canvasApi } = useCanvas()
+    const { isBlock, getCurrentPage, getSchema } = useCanvas()
     const { getCurrentBlock } = useBlock()
 
     const preview = async () => {
@@ -66,7 +66,7 @@ export default {
         framework: getMergeMeta('engine.config')?.dslMode,
         platform: getMergeMeta('engine.config')?.platformId,
         pageInfo: {
-          schema: canvasApi.value?.getSchema?.()
+          schema: getSchema?.()
         }
       }
 

--- a/packages/toolbars/redoundo/src/composable/useHistory.js
+++ b/packages/toolbars/redoundo/src/composable/useHistory.js
@@ -95,7 +95,7 @@ const clear = () => {
 const addHistory = (schema) => {
   if (!schema) {
     useCanvas().setSaved(false)
-    push(useCanvas().canvasApi.value?.getSchema())
+    push(useCanvas().getSchema())
   } else {
     clear()
     // 初始 schema 需要设置为第一条历史记录

--- a/packages/toolbars/redoundo/src/composable/useHistory.js
+++ b/packages/toolbars/redoundo/src/composable/useHistory.js
@@ -61,7 +61,7 @@ const push = (schema) => {
 
 const go = (addend, valid) => {
   historyState.index = historyState.index + addend
-  useCanvas().canvasApi.value?.setSchema(string2Schema(list[historyState.index]))
+  useCanvas().importSchema(string2Schema(list[historyState.index]))
 
   // 不是锁定状态，撤销操作后，传递第二个标识位，将 list 的长度减一，置灰 undoredo 操作按钮
   if (typeof valid === 'boolean') {

--- a/packages/toolbars/save/src/js/index.js
+++ b/packages/toolbars/save/src/js/index.js
@@ -98,7 +98,7 @@ export const saveCommon = (value) => {
   return isBlock() ? saveBlock(pageSchema) : savePage(pageSchema)
 }
 export const openCommon = async () => {
-  const { isSaved, canvasApi } = useCanvas()
+  const { isSaved, getSchema } = useCanvas()
   if (isSaved() || state.disabled) {
     return
   }
@@ -127,7 +127,6 @@ export const openCommon = async () => {
   const pageStatus = useLayout().layoutState?.pageStatus
   const curPageState = pageStatus?.state
   const pageInfo = pageStatus?.data
-  const { getSchema } = canvasApi.value
   const ERR_MSG = {
     [PAGE_STATUS.Release]: '当前页面未锁定，请先锁定再保存',
     [PAGE_STATUS.Empty]: '当前应用无页面，请先新建页面再保存',

--- a/packages/toolbars/save/src/js/index.js
+++ b/packages/toolbars/save/src/js/index.js
@@ -68,10 +68,6 @@ export const saveCommon = (value) => {
   const pageSchema = JSON.parse(value)
   const { selectNode } = canvasApi.value
 
-  // pageState.pageSchema = pageSchema
-  // setSchema 是异步，保存直接传递当前 schema
-  // setSchema(pageSchema)
-
   if (isBlock()) {
     resetBlockCanvasState({ ...pageState, pageSchema })
   } else {

--- a/packages/toolbars/save/src/js/index.js
+++ b/packages/toolbars/save/src/js/index.js
@@ -64,13 +64,19 @@ const savePage = async (pageSchema) => {
 
 export const saveCommon = (value) => {
   const { pageSettingState, isTemporaryPage } = usePage()
-  const { isBlock, canvasApi, pageState } = useCanvas()
+  const { isBlock, canvasApi, pageState, resetBlockCanvasState, resetPageCanvasState } = useCanvas()
   const pageSchema = JSON.parse(value)
-  const { setSchema, selectNode } = canvasApi.value
+  const { selectNode } = canvasApi.value
 
-  pageState.pageSchema = pageSchema
+  // pageState.pageSchema = pageSchema
   // setSchema 是异步，保存直接传递当前 schema
-  setSchema(pageSchema)
+  // setSchema(pageSchema)
+
+  if (isBlock()) {
+    resetBlockCanvasState({ ...pageState, pageSchema })
+  } else {
+    resetPageCanvasState({ ...pageState, pageSchema })
+  }
 
   if (pageSettingState?.isAIPage) {
     if (isTemporaryPage.saved) {

--- a/packages/utils/src/constants/index.js
+++ b/packages/utils/src/constants/index.js
@@ -89,8 +89,7 @@ if (typeof sessionStorage !== 'undefined') {
 
 export const BROADCAST_CHANNEL = {
   CanvasLang: `tiny-lowcode-canvas-lang-${CHANNEL_UID}`,
-  Notify: `global-notify-${CHANNEL_UID}`,
-  SchemaLength: `schema-length-${CHANNEL_UID}`
+  Notify: `global-notify-${CHANNEL_UID}`
 }
 
 export const STORAGE_KEY_FIXED_PANELS = `tiny-engine-fixed-panels-${CHANNEL_UID}`


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### 【背景&问题】What is the current behavior?

1. 当前对 schema 的修改都是直接对画布内的 schema 引用进行修改。
2. 画布外的主进程 host 与画布内是两个 vue 实例。导致 host 主进程无法主动监听到最新 schema 的变化。
	- 比如大纲树无法观察到元素的拖拽删除，及时渲染最新的大纲树。
	- 比如 schema 面板无法实时观察到画布的变化，只能在打开面板的时候，才获取最新的 schema。
3. 其他插件有观察 schema 变化的场景，当前都无法满足。


### 【解决方案】What is the new behavior?
统一 schema 修改入口 + schema 变更事件发布订阅 + jsondiff 同步差异
![image](https://github.com/user-attachments/assets/f3e02541-8637-436f-9051-7cf75e9c4656)


### 【PR主要改动点】

1. 修改 schema 统一入口。
	以往修改 schema 的方法：直接 `schema.props = xxx` ，即拿到引用直接进行修改
	当前 schema 修改的入口改为：
    - `useCanvas().opeateNode(operation)`  主要用于操作节点删除、节点新增、节点 props 属性修改。
    - `useCanvas().updateSchema(data)`  主要用于更新 schema 的 `state`、`css`、`method`、`lifecycles` 等非节点属性。
    - `useCanvas().importSchema(data)`  主要用于页面、区块之间的切换。

2. 事件通知 schema 改变事件。
	- `schemaChange` 事件。调用 `opeateNode` 以及 `updateSchema` 会触发该事件的发布。
	- `schemaImport` 事件。调用 `importSchema` 会触发该事件的发布。

3. 修改  `utils`、`bridge`、`globalState`、`dataSourceMap` 等入口从直接修改画布改为直接修改 `useResource` 中的 `appSchemaState`

4. 画布 `RenderMain` 减少相关 schema 的操作接口（修改移动到统一的页面修改入口以及 appSchema 修改）
	- 减少的相关接口：`setUtils`、`updateUtils`、`deleteUtils`、`getBridge`、`setBridge`、`getMethods`、`setMethods`、`getSchema`、`setSchema`、`getState`、`deleteState`、`setState`、`getProps`、`setProps`、`getContext`、`getRoot`、`getNode`、`setNode`、`getCondition`、`getGlobalState`、`setGlobalState`、`getDataSourceMap`、`setDataSourceMap`

5. 画布对 schema 变更的状态的感知，改为 schema 相关修改事件的监听以及状态的订阅。

6. 语义化重命名：`resState` 改为 `appSchemaState`

7. 内置组件数据源 collection 改造：
	组件内置的逻辑：刷新 children schema、检测 children 变更。（即 `CanvasCollection.vue` 中的 `setup` 逻辑、`canvasCollection.js` ，迁移到  `configurator/src/collection-configurator` 中 ）
   迁移过来之后遗留问题： configurator 中无法感知 children 的变化（需要手动点击刷新按钮），所以无法自动提示刷新 children 中的 相关数据源字段。
   新旧版本皆有的遗留问题：数据源刷新了，表格数据无法刷新（需要刷新页面）


【PR 分拆任务】	（待确认）
由于本次 PR 改动基础 api。涉及的改动点较多，代码量也较大，为了避免单次PR合入过多特性，我们将一些新特性分拆到后续的 PR 中逐次迭代演进。简要梳理如下：

- 历史堆栈：需要改造成为快照型，基于 `schemaChange` 事件记录堆栈。并支持 `batchChange` 批量事件的历史堆栈记录。（即 schema 历史堆栈自动化记录、配置化能力支持）。
- `useProperties` 相关的 api 整改。整改为以 `node` 节点为基础的对象实例，自带增删查改的相关 api。
	- 由此特性可以衍生出来设置面板、样式面板的设置组件自定义能力、可插拔能力。
- 更丰富的节点事件：比如父节点监听子节点增加、删除、属性之间联动监听
- 画布插件化：支持画布自定义逻辑注入，比如我们往 schema 中扩展了私有的协议，需要在画布中进行监听，此时就可以注入局部的逻辑进行监听。

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new section in the DesignCanvas README for experimental APIs related to schema management.
	- Enhanced functionality for managing node operations within the canvas.
	- Added a new method for refreshing data in the DataSourceList component.
	- Streamlined schema retrieval across various components, improving data handling.
	- Added a method for updating styles directly in the schema.

- **Bug Fixes**
	- Improved error handling in various components, including BlockDeployDialog and DataSourceRecordList.

- **Documentation**
	- Updated README files to reflect new functionalities and usage examples.

- **Style**
	- Refactored styles and class management in several components for improved clarity and maintainability. 

- **Chores**
	- Updated dependencies in package.json files across multiple packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->