### PR TITLE
fix: time asc add i18n failed

### DIFF
--- a/packages/plugins/i18n/src/Main.vue
+++ b/packages/plugins/i18n/src/Main.vue
@@ -245,7 +245,7 @@ export default {
     }
 
     watch(
-      () => [fullLangList.value, currentSearchType.value],
+      () => [fullLangList.value, currentSearchType.value, searchKey.value],
       () => {
         langList.value = fullLangList.value.filter((item) => {
           const reg = new RegExp(searchKey.value, 'i')

--- a/packages/plugins/i18n/src/Main.vue
+++ b/packages/plugins/i18n/src/Main.vue
@@ -123,7 +123,7 @@
 </template>
 
 <script lang="jsx">
-import { computed, ref, watchEffect, reactive, onMounted, nextTick, resolveComponent } from 'vue'
+import { computed, ref, watchEffect, reactive, onMounted, nextTick, resolveComponent, watch } from 'vue'
 import useClipboard from 'vue-clipboard3'
 import { Grid, GridColumn, Input, Popover, Button, FileUpload, Loading, Tooltip, Select } from '@opentiny/vue'
 import { iconLoadingShadow, iconUpload } from '@opentiny/vue-icon'
@@ -244,13 +244,16 @@ export default {
       }
     }
 
-    watchEffect(() => {
-      langList.value = fullLangList.value.filter((item) => {
-        const reg = new RegExp(searchKey.value, 'i')
-        return reg.test(item?.zh_CN) || reg.test(item?.en_US) || reg.test(item?.key)
-      })
-      sortTypeChanges(currentSearchType.value)
-    })
+    watch(
+      () => [fullLangList.value, currentSearchType.value],
+      () => {
+        langList.value = fullLangList.value.filter((item) => {
+          const reg = new RegExp(searchKey.value, 'i')
+          return reg.test(item?.zh_CN) || reg.test(item?.en_US) || reg.test(item?.key)
+        })
+        sortTypeChanges(currentSearchType.value)
+      }
+    )
 
     watchEffect(() => {
       if (i18nResource.locales.length) {


### PR DESCRIPTION
# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

【问题描述】

i1n 国际化插件，当使用非时间倒序排序时，点击添加词条按钮，无法添加国际化词条。

【问题分析】

1. 点击添加词条的时候，会往 `langList.value` 插入一行数据。
2. `watchEffect` 函数同时监听了 `langList.value`。此时会触发该函数，将新增的数据移除。

【解决方案】
将 `watchEffect` 改为 `watch`，只监听 `[fullLangList.value, currentSearchType.value]`


### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced language selection filtering and sorting in the internationalization (i18n) plugin panel.
- **Bug Fixes**
	- Improved validation for language entry keys, preventing duplicate entries during editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->