### PR TITLE
fix: replace RouterLink to html anchor in canvas

### DIFF
--- a/packages/canvas/render/src/builtin/CanvasRouterLink.vue
+++ b/packages/canvas/render/src/builtin/CanvasRouterLink.vue
@@ -1,5 +1,6 @@
 <template>
-  <span
+  <a
+    href="javascript:void(0)"
     v-bind="$attrs"
     :class="{
       [activeClass]: active,
@@ -7,7 +8,7 @@
     }"
   >
     <slot :href="to" :isActive="active" :isExactActive="exactActive"></slot>
-  </span>
+  </a>
 </template>
 <script lang="ts">
 import { computed, inject, PropType, Ref } from 'vue'

--- a/packages/canvas/render/src/builtin/builtin.json
+++ b/packages/canvas/render/src/builtin/builtin.json
@@ -203,7 +203,7 @@
                     "type": "String",
                     "label": {
                       "text": {
-                        "zh_CN": "准确激活样式雷"
+                        "zh_CN": "准确激活样式类"
                       }
                     },
                     "cols": 12,
@@ -658,7 +658,7 @@
                     "componentName": "RouterLink",
                     "props": {
                       "to": "",
-                      "style": "display: inline-flex; gap: 8px; padding: 10px 20px;"
+                      "style": "display: inline-flex; gap: 8px; padding: 10px 20px; color: inherit; text-decoration: none;"
                     },
                     "children": [
                       {
@@ -680,7 +680,7 @@
                     "componentName": "RouterLink",
                     "props": {
                       "to": "",
-                      "style": "display: inline-flex; gap: 8px; padding: 10px 20px;"
+                      "style": "display: inline-flex; gap: 8px; padding: 10px 20px; color: inherit; text-decoration: none;"
                     },
                     "children": [
                       {
@@ -702,7 +702,7 @@
                     "componentName": "RouterLink",
                     "props": {
                       "to": "",
-                      "style": "display: inline-flex; gap: 8px; padding: 10px 20px;"
+                      "style": "display: inline-flex; gap: 8px; padding: 10px 20px; color: inherit; text-decoration: none;"
                     },
                     "children": [
                       {
@@ -739,7 +739,7 @@
                     "componentName": "RouterLink",
                     "props": {
                       "to": "",
-                      "style": "display: flex; gap: 8px; padding: 10px 20px;"
+                      "style": "display: flex; gap: 8px; padding: 10px 20px; color: inherit; text-decoration: none;"
                     },
                     "children": [
                       {
@@ -761,7 +761,7 @@
                     "componentName": "RouterLink",
                     "props": {
                       "to": "",
-                      "style": "display: flex; gap: 8px; padding: 10px 20px;"
+                      "style": "display: flex; gap: 8px; padding: 10px 20px; color: inherit; text-decoration: none;"
                     },
                     "children": [
                       {
@@ -783,7 +783,7 @@
                     "componentName": "RouterLink",
                     "props": {
                       "to": "",
-                      "style": "display: flex; gap: 8px; padding: 10px 20px;"
+                      "style": "display: flex; gap: 8px; padding: 10px 20px; color: inherit; text-decoration: none;"
                     },
                     "children": [
                       {
@@ -805,7 +805,7 @@
                     "componentName": "RouterLink",
                     "props": {
                       "to": "",
-                      "style": "display: flex; gap: 8px; padding: 10px 20px;"
+                      "style": "display: flex; gap: 8px; padding: 10px 20px; color: inherit; text-decoration: none;"
                     },
                     "children": [
                       {
@@ -827,7 +827,7 @@
                     "componentName": "RouterLink",
                     "props": {
                       "to": "",
-                      "style": "display: flex; gap: 8px; padding: 10px 20px;"
+                      "style": "display: flex; gap: 8px; padding: 10px 20px; color: inherit; text-decoration: none;"
                     },
                     "children": [
                       {


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution

RouterLink在画布中渲染是使用的`span`元素，现在改为`a`元素，和预览的效果保持一致

### What is the current behavior?

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
