### PR TITLE
fix: resetCanvasState indirectly called in useHistory, resets the isBlock status

### DIFF
--- a/packages/canvas/DesignCanvas/src/api/useCanvas.js
+++ b/packages/canvas/DesignCanvas/src/api/useCanvas.js
@@ -560,6 +560,7 @@ export default function () {
     setSaved,
     clearCanvas,
     getPageSchema,
+    resetCanvasState,
     resetPageCanvasState,
     resetBlockCanvasState,
     clearCurrentState,

--- a/packages/toolbars/redoundo/src/composable/useHistory.js
+++ b/packages/toolbars/redoundo/src/composable/useHistory.js
@@ -61,7 +61,8 @@ const push = (schema) => {
 
 const go = (addend, valid) => {
   historyState.index = historyState.index + addend
-  useCanvas().importSchema(string2Schema(list[historyState.index]))
+  const { pageState, resetCanvasState } = useCanvas()
+  resetCanvasState({ ...pageState, pageSchema: string2Schema(list[historyState.index]) })
 
   // 不是锁定状态，撤销操作后，传递第二个标识位，将 list 的长度减一，置灰 undoredo 操作按钮
   if (typeof valid === 'boolean') {


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?

历史记录前进或者后退时，会重置全部画布数据，导致部分数据丢失。比如区块中历史记录前进或者后退，画布的 `isBlock` 被重置成了 `false`。下面例子中，画布顶部加了一个路由bar，只有在 `isBlock` 为 `false` 时才显示，但是回退后，出现了路由bar
![isblock1](https://github.com/user-attachments/assets/88d1bbca-836b-4197-abe6-6d7ff42c3396)


### What is the new behavior?

修改后
![isblock2](https://github.com/user-attachments/assets/b004e235-1276-44ab-aee7-098cec2dd3f7)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced canvas state management with more flexible reset and import options.
	- Added ability to perform partial state resets in canvas operations.

- **Improvements**
	- Introduced more granular control over schema importing and canvas state restoration.
	- Updated import and reset mechanisms to support more nuanced state management during navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->