### PR TITLE
fix: AI chat request error

### DIFF
--- a/packages/plugins/robot/src/Main.vue
+++ b/packages/plugins/robot/src/Main.vue
@@ -231,11 +231,8 @@ export default {
         .post('/app-center/api/ai/chat', getSendSeesionProcess(), { timeout: 600000 })
         .then((res) => {
           const { originalResponse, schema, replyWithoutCode } = res
-          const responseMessage = getAiRespMessage(
-            originalResponse.choices?.[0]?.message.role,
-            originalResponse.choices?.[0]?.message.content
-          )
-          const respDisplayMessage = getAiRespMessage(originalResponse.choices?.[0]?.message.role, replyWithoutCode)
+          const responseMessage = getAiRespMessage(originalResponse.role, originalResponse.content)
+          const respDisplayMessage = getAiRespMessage(originalResponse.role, replyWithoutCode)
           sessionProcess.messages.push(responseMessage)
           sessionProcess.displayMessages.push(respDisplayMessage)
           messages.value[messages.value.length - 1].content = replyWithoutCode

--- a/packages/plugins/robot/src/js/robotSetting.js
+++ b/packages/plugins/robot/src/js/robotSetting.js
@@ -15,7 +15,7 @@ import { getMetaApi, META_SERVICE } from '@opentiny/tiny-engine-meta-register'
 
 export const AIModelOptions = [
   { label: 'ChatGPT：gpt-3.5-turbo', value: 'gpt-3.5-turbo', manufacturer: 'openai' },
-  { label: '文心一言：ERNIE-4.0-8k', value: 'ERNIE-4.0-8k', manufacturer: 'baiduai' }
+  { label: '文心一言：ERNIE-4.0-8K', value: 'ERNIE-4.0-8K', manufacturer: 'baiduai' }
 ]
 
 // 这里存放的是aichat的响应式数据


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution

AI聊天框，第一次对话成功回复后，接着第二次对话会报错。
问题根因：后端返回的数据结构变更 tiny-engine-webservice [commit 2993c4a](https://github.com/opentiny/tiny-engine-webservice/commit/2993c4aca79547de55361812eab310ea26c03eb0)。后端直接取了`choices[0].message`里面的内容
解决方法：适配后端返回的新的数据结构。直接去掉前端的`choices[0].message`

### What is the current behavior?

![output_image](https://github.com/user-attachments/assets/fb9897b0-8edc-409d-82a0-d178d41e8fe8)

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Updates**
    - Corrected label casing for AI model "文心一言：ERNIE-4.0-8K"

- **Code Improvements**
    - Simplified AI response handling logic in the main component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->