### PR TITLE
fix: update splitMaterial and buildMaterials path

### DIFF
--- a/scripts/buildMaterials.mjs
+++ b/scripts/buildMaterials.mjs
@@ -9,9 +9,9 @@ const logger = new Logger('buildMaterials')
 // 物料文件存放文件夹名称
 const materialsDir = 'materials'
 // 物料资产包
-const bundlePath = path.join(process.cwd(), '/packages/design-core/public/mock/bundle.json')
+const bundlePath = path.join(process.cwd(), '/designer-demo/public/mock/bundle.json')
 // mockServer应用数据
-const appInfoPath = path.join(process.cwd(), '/mockServer/src/services/appinfo.json')
+const appInfoPath = path.join(process.cwd(), '/mockServer/src/assets/json/appinfo.json')
 const appSchemaPath = path.join(process.cwd(), 'mockServer/src/mock/get/app-center/v1/apps/schema/918.json')
 
 const appInfo = fsExtra.readJSONSync(appInfoPath)

--- a/scripts/splitMaterials.mjs
+++ b/scripts/splitMaterials.mjs
@@ -5,7 +5,7 @@ import Logger from './logger.mjs'
 const logger = new Logger('splitMaterials')
 
 // 物料资产包mock数据路径
-const bundlePath = path.join(process.cwd(), '/packages/design-core/public/mock/bundle.json')
+const bundlePath = path.join(process.cwd(), '/designer-demo/public/mock/bundle.json')
 // 物料文件存放文件夹名称
 const materialsDir = 'materials'
 const bundle = fs.readJSONSync(bundlePath)


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

更新 `splitMaterials` 与 `buildMaterials` 物料构建命令的路径。

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated asset and mock data source paths to align with the new directory structure.
- **Bug Fixes**
	- Enhanced error handling to warn users when necessary files are missing and suggest corrective actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->