### PR TITLE
fix: svg color not work in preview mode

### DIFF
--- a/packages/vue-generator/src/generator/vue/sfc/generateTemplate.js
+++ b/packages/vue-generator/src/generator/vue/sfc/generateTemplate.js
@@ -42,6 +42,9 @@ export const handleTinyIcon = (nameObj, globalHooks) => {
     return
   }
 
+  // 增加 svg 颜色属性，使编辑模式与出码模式一致
+  nameObj.schema.props['fill'] = 'currentColor'
+
   const iconName = name.startsWith(TINY_ICON) ? name : `Tiny${name}`
   const exportName = name.replace(TINY_ICON, 'icon')
 


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->
背景：
svg图标颜色配置出码后不生效
原因：
编辑模式下，svgIcon 使用 CanvsIcon 渲染，CanvasIcon 中自带样式配置：fill: currentColor，而预览或者出码模式下，svg 图标直接编译为 ，此时没有 fill: currentColor 的样式配置，导致颜色配置不一致
解决方案：
编译出码插件：handleTinyIcon 方法中，手动加上 fill: currentColor 的属性prop

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1108

### What is the new behavior?
svg 图标颜色配置在编辑、预览、出码模式下均生效且一致

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- SVG icons now inherit the current text color, ensuring a consistent visual appearance between editing and display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->