### PR TITLE
feat: route bar support display preview path

### DIFF
--- a/packages/canvas/route-bar/src/CanvasRouteBar.vue
+++ b/packages/canvas/route-bar/src/CanvasRouteBar.vue
@@ -15,7 +15,7 @@
           >{{ route.route }}</span
         >
       </template>
-      <tiny-tooltip v-if="existsPreview" type="normal" content="重置路由视图显示页面">
+      <tiny-tooltip v-if="existsPreview" type="normal" content="重置路由视图为占位符">
         <svg-button name="cross" class="clear-preview" @click="handleClearPreview"></svg-button>
       </tiny-tooltip>
     </div>

--- a/packages/canvas/route-bar/src/CanvasRouteBar.vue
+++ b/packages/canvas/route-bar/src/CanvasRouteBar.vue
@@ -7,7 +7,7 @@
           :class="[
             {
               route: route.isPage && route.id !== pageId,
-              bold: fontIsBold(route.id, index),
+              bold: shouldHighlight(route.id, index),
               'is-preview': route.isPreview
             }
           ]"
@@ -118,7 +118,7 @@ watch(
   { immediate: true }
 )
 
-const fontIsBold = (id, index) => {
+const shouldHighlight = (id, index) => {
   if (existsPreview.value) {
     return id === pageId.value
   }
@@ -181,16 +181,16 @@ const handleClearPreview = () => {
   margin: 0 2px;
 }
 .bold {
-  font-weight: bold;
+  font-weight: var(--te-base-font-weight-bold);
 }
 .is-preview {
   color: var(--te-common-text-weaken);
 }
 #canvas-route-bar:hover .clear-preview {
-  visibility: unset;
+  visibility: visible;
 }
 .clear-preview {
-  border-radius: 999px;
+  border-radius: 50%;
   visibility: hidden;
   margin-left: 2px;
   width: 16px;

--- a/packages/canvas/route-bar/src/CanvasRouteBar.vue
+++ b/packages/canvas/route-bar/src/CanvasRouteBar.vue
@@ -1,8 +1,8 @@
 <template>
   <div id="canvas-route-bar" :style="sizeStyle">
     <div class="address-bar">
-      <template v-for="(route, index) in routes" :key="route.id">
-        <span v-if="index > 0" class="slash">/</span>
+      <template v-for="route in routes" :key="route.id">
+        <span class="slash">/</span>
         <span
           :class="[
             { route: route.isPage && route.id !== pageId, current: route.id === pageId, 'is-preview': route.isPreview }
@@ -31,8 +31,9 @@ const sizeStyle = computed(() => {
 
 const { pageSettingState, getAncestors, switchPageWithConfirm } = usePage()
 
-const pageId = ref(getMetaApi(META_SERVICE.GlobalService).getBaseInfo().pageId)
-const previewId = ref(getMetaApi(META_SERVICE.GlobalService).getBaseInfo().previewId)
+const baseInfo = getMetaApi(META_SERVICE.GlobalService).getBaseInfo()
+const pageId = ref(baseInfo.pageId)
+const previewId = ref(baseInfo.previewId)
 const existsPreview = ref(false)
 
 const { subscribe, unsubscribe } = useMessage()
@@ -124,7 +125,7 @@ const handleClickRoute = (route) => {
 }
 
 const handleClearPreview = () => {
-  // TODO
+  getMetaApi(META_SERVICE.GlobalService).updatePreviewId('')
 }
 </script>
 
@@ -160,7 +161,7 @@ const handleClearPreview = () => {
   }
 }
 .slash {
-  margin: 0 4px;
+  margin: 0 2px;
 }
 .current {
   font-weight: bold;

--- a/packages/canvas/route-bar/src/CanvasRouteBar.vue
+++ b/packages/canvas/route-bar/src/CanvasRouteBar.vue
@@ -1,13 +1,13 @@
 <template>
   <div id="canvas-route-bar" :style="sizeStyle">
     <div class="address-bar">
-      <template v-for="route in routes" :key="route.id">
+      <template v-for="(route, index) in routes" :key="route.id">
         <span class="slash">/</span>
         <span
           :class="[
             {
               route: route.isPage && route.id !== pageId,
-              current: route.id === pageId && existsPreview,
+              bold: fontIsBold(route.id, index),
               'is-preview': route.isPreview
             }
           ]"
@@ -118,6 +118,19 @@ watch(
   { immediate: true }
 )
 
+const fontIsBold = (id, index) => {
+  if (existsPreview.value) {
+    return id === pageId.value
+  }
+
+  // 没有previewId时，routes长度大于1，最后一个route path显示高亮
+  if (routes.value.length > 1) {
+    return index === routes.value.length - 1
+  }
+
+  return false
+}
+
 /**
  * @param route {Route}
  */
@@ -167,7 +180,7 @@ const handleClearPreview = () => {
 .slash {
   margin: 0 2px;
 }
-.current {
+.bold {
   font-weight: bold;
 }
 .is-preview {

--- a/packages/canvas/route-bar/src/CanvasRouteBar.vue
+++ b/packages/canvas/route-bar/src/CanvasRouteBar.vue
@@ -48,7 +48,7 @@ onMounted(() => {
   subscriber = subscribe({
     topic: 'locationHistoryChanged',
     callback: (data) => {
-      if (String(data.pageId)) {
+      if (data.pageId) {
         pageId.value = String(data.pageId)
       }
       if ('previewId' in data) {

--- a/packages/canvas/route-bar/src/CanvasRouteBar.vue
+++ b/packages/canvas/route-bar/src/CanvasRouteBar.vue
@@ -15,7 +15,7 @@
           >{{ route.route }}</span
         >
       </template>
-      <tiny-tooltip v-if="existsPreview" type="normal" content="重置预览路径">
+      <tiny-tooltip v-if="existsPreview" type="normal" content="重置路由视图显示页面">
         <svg-button name="cross" class="clear-preview" @click="handleClearPreview"></svg-button>
       </tiny-tooltip>
     </div>

--- a/packages/canvas/route-bar/src/CanvasRouteBar.vue
+++ b/packages/canvas/route-bar/src/CanvasRouteBar.vue
@@ -5,13 +5,17 @@
         <span class="slash">/</span>
         <span
           :class="[
-            { route: route.isPage && route.id !== pageId, current: route.id === pageId, 'is-preview': route.isPreview }
+            {
+              route: route.isPage && route.id !== pageId,
+              current: route.id === pageId && existsPreview,
+              'is-preview': route.isPreview
+            }
           ]"
           @click="handleClickRoute(route)"
           >{{ route.route }}</span
         >
       </template>
-      <tiny-tooltip v-if="existsPreview" type="normal" content="清除预览路径">
+      <tiny-tooltip v-if="existsPreview" type="normal" content="重置预览路径">
         <svg-button name="cross" class="clear-preview" @click="handleClearPreview"></svg-button>
       </tiny-tooltip>
     </div>
@@ -80,10 +84,10 @@ watch(
       return
     }
 
-    let ancestors = ((await getAncestors(pageId, true)) || []).concat(pageId)
+    let ancestors = ((await getAncestors(pageId, true)) || []).concat(pageId).map((id) => String(id))
 
     if (previewId) {
-      const previewAncestors = ((await getAncestors(previewId, true)) || []).concat(previewId)
+      const previewAncestors = ((await getAncestors(previewId, true)) || []).concat(previewId).map((id) => String(id))
 
       // previewId是pageId的子孙，那么previewId才有效
       if (previewAncestors.includes(pageId)) {

--- a/packages/canvas/route-bar/src/CanvasRouteBar.vue
+++ b/packages/canvas/route-bar/src/CanvasRouteBar.vue
@@ -106,7 +106,7 @@ watch(
       .map((pageData, index) => {
         const { id, route, isPage } = pageData
         return {
-          id,
+          id: String(id),
           route: route
             .replace(/\/+/g, '/') // 替换连续的 '/' 为单个 '/'
             .replace(/^\/|\/$/g, ''), // 去掉开头和结尾的 '/'

--- a/packages/canvas/route-bar/src/CanvasRouteBar.vue
+++ b/packages/canvas/route-bar/src/CanvasRouteBar.vue
@@ -48,11 +48,11 @@ onMounted(() => {
   subscriber = subscribe({
     topic: 'locationHistoryChanged',
     callback: (data) => {
-      if (data.pageId) {
-        pageId.value = data.pageId
+      if (String(data.pageId)) {
+        pageId.value = String(data.pageId)
       }
       if ('previewId' in data) {
-        previewId.value = data.previewId
+        previewId.value = String(data.previewId)
       }
     },
     subscriber: 'routeBar'

--- a/packages/canvas/route-bar/src/CanvasRouteBar.vue
+++ b/packages/canvas/route-bar/src/CanvasRouteBar.vue
@@ -1,18 +1,27 @@
 <template>
   <div id="canvas-route-bar" :style="sizeStyle">
     <div class="address-bar">
-      <template v-for="route in routes" :key="route.id">
-        <span class="slash">/</span>
-        <span :class="[{ route: route.isPage && route.id !== pageId }]" @click="handleClickRoute(route)">{{
-          route.route
-        }}</span>
+      <template v-for="(route, index) in routes" :key="route.id">
+        <span v-if="index > 0" class="slash">/</span>
+        <span
+          :class="[
+            { route: route.isPage && route.id !== pageId, current: route.id === pageId, 'is-preview': route.isPreview }
+          ]"
+          @click="handleClickRoute(route)"
+          >{{ route.route }}</span
+        >
       </template>
+      <tiny-tooltip v-if="existsPreview" type="normal" content="清除预览路径">
+        <svg-button name="cross" class="clear-preview" @click="handleClearPreview"></svg-button>
+      </tiny-tooltip>
     </div>
   </div>
 </template>
 
 <script setup>
+import { SvgButton } from '@opentiny/tiny-engine-common'
 import { getMetaApi, META_SERVICE, useLayout, useMessage, usePage } from '@opentiny/tiny-engine-meta-register'
+import { Tooltip as TinyTooltip } from '@opentiny/vue'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 
 const sizeStyle = computed(() => {
@@ -23,6 +32,8 @@ const sizeStyle = computed(() => {
 const { pageSettingState, getAncestors, switchPageWithConfirm } = usePage()
 
 const pageId = ref(getMetaApi(META_SERVICE.GlobalService).getBaseInfo().pageId)
+const previewId = ref(getMetaApi(META_SERVICE.GlobalService).getBaseInfo().previewId)
+const existsPreview = ref(false)
 
 const { subscribe, unsubscribe } = useMessage()
 
@@ -34,6 +45,9 @@ onMounted(() => {
     callback: (data) => {
       if (data.pageId) {
         pageId.value = data.pageId
+      }
+      if ('previewId' in data) {
+        previewId.value = data.previewId
       }
     },
     subscriber: 'routeBar'
@@ -51,32 +65,48 @@ onUnmounted(() => {
  * @property {string | number} id
  * @property {string} route
  * @property {boolean} isPage
+ * @property {boolean} isPreview
  */
 
 /** @type {import('vue').Ref<Route[]>} */
 const routes = ref([])
 
 watch(
-  pageId,
-  async (value) => {
-    if (!value) {
+  [pageId, previewId],
+  async ([pageId, previewId]) => {
+    if (!pageId) {
       routes.value = []
       return
     }
-    const ancestors = (await getAncestors(value, true)) || []
+
+    let ancestors = ((await getAncestors(pageId, true)) || []).concat(pageId)
+
+    if (previewId) {
+      const previewAncestors = ((await getAncestors(previewId, true)) || []).concat(previewId)
+
+      // previewId是pageId的子孙，那么previewId才有效
+      if (previewAncestors.includes(pageId)) {
+        ancestors = previewAncestors
+      }
+    }
+
+    // currentPageIndex逻辑上不可能为-1，所以后续判断位于数组的位置时，不再需要判断是否为-1
+    const currentPageIndex = ancestors.indexOf(pageId)
+
+    // 如果当前编辑页面不是ancestors数组最后一个元素，说明存在preview页面
+    existsPreview.value = currentPageIndex < ancestors.length - 1
 
     routes.value = ancestors
-      .concat(value)
       .map((id) => pageSettingState.treeDataMapping[id])
-      .filter((item) => Boolean(item))
-      .map((pageData) => {
+      .map((pageData, index) => {
         const { id, route, isPage } = pageData
         return {
           id,
           route: route
             .replace(/\/+/g, '/') // 替换连续的 '/' 为单个 '/'
             .replace(/^\/|\/$/g, ''), // 去掉开头和结尾的 '/'
-          isPage
+          isPage,
+          isPreview: index > currentPageIndex
         }
       })
   },
@@ -91,6 +121,10 @@ const handleClickRoute = (route) => {
     return
   }
   switchPageWithConfirm(route.id)
+}
+
+const handleClearPreview = () => {
+  // TODO
 }
 </script>
 
@@ -124,5 +158,25 @@ const handleClickRoute = (route) => {
     text-decoration: underline;
     color: var(--te-common-text-link);
   }
+}
+.slash {
+  margin: 0 4px;
+}
+.current {
+  font-weight: bold;
+}
+.is-preview {
+  color: var(--te-common-text-weaken);
+}
+#canvas-route-bar:hover .clear-preview {
+  visibility: unset;
+}
+.clear-preview {
+  border-radius: 999px;
+  visibility: hidden;
+  margin-left: 2px;
+  width: 16px;
+  height: 16px;
+  font-size: 12px;
 }
 </style>


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution


### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

- 路由bar支持显示预览路径
- 当前编辑页面加粗（只有一个route页面时不加粗），编辑页面的路由后的路径的颜色变浅
- 支持一键清除预览路径。当预览页面时编辑页面的子孙时可以在路由bar上点击清除按钮

![image](https://github.com/user-attachments/assets/11574390-9171-4ef4-b4fb-1dc26c477787)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the route bar with dynamic visual cues, including conditional bold styling.
	- Introduced an interactive tooltip to indicate the existence of a preview route.
	- Improved state management to ensure that navigation and preview signals are consistently reflected in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->