### PR TITLE
fix: header content lost when dragging from outline tree

### DIFF
--- a/packages/plugins/tree/src/Main.vue
+++ b/packages/plugins/tree/src/Main.vue
@@ -43,7 +43,6 @@ import { PluginPanel, SvgButton } from '@opentiny/tiny-engine-common'
 import { constants } from '@opentiny/tiny-engine-utils'
 import { useCanvas, useMaterial, useLayout, useMessage } from '@opentiny/tiny-engine-meta-register'
 import { extend } from '@opentiny/vue-renderless/common/object'
-import { typeOf } from '@opentiny/vue-renderless/common/type'
 import DraggableTree from './DraggableTree.vue'
 
 const { PAGE_STATUS } = constants
@@ -72,12 +71,8 @@ export default {
           item.show = pageState.nodesStatus[item.id] !== false
           item.showEye = !item.show
           const child = item.children
-          if (typeOf(child) !== 'array') {
-            delete item.children
-          } else {
-            if (item.children.length) {
-              translateChild(item.children)
-            }
+          if (Array.isArray(child)) {
+            translateChild(item.children)
           }
         })
 


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution

问题：拖拽Header组件会导致内容消失
定位：大纲树转换schema数据时，如果某个节点children属性不是数组，会删除children字段。Header组件的children是显示内容
解决方案：如果某个节点children属性不是数组，则不做其他处理

### What is the current behavior?

拖拽Header组件会导致内容消失
Issue Number: #1137 

### What is the new behavior?

![drag-title](https://github.com/user-attachments/assets/c1e9b9d9-95ff-49b2-86f3-6a939d2203a9)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the tree processing logic to ensure consistent handling of nested items in the display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->