### PR TITLE
fix: 修复组件分离时，组件信息的不完整，根据组件的npm包，补全组件npm 字段

### DIFF
--- a/scripts/splitMaterials.mjs
+++ b/scripts/splitMaterials.mjs
@@ -9,7 +9,7 @@ const bundlePath = path.join(process.cwd(), '/designer-demo/public/mock/bundle.j
 // 物料文件存放文件夹名称
 const materialsDir = 'materials'
 const bundle = fs.readJSONSync(bundlePath)
-const { components, snippets, blocks } = bundle.data.materials
+const { components, snippets, blocks, packages } = bundle.data.materials
 
 const capitalize = (str) => `${str.charAt(0).toUpperCase()}${str.slice(1)}`
 const toPascalCase = (str) => str.split('-').map(capitalize).join('')
@@ -38,7 +38,12 @@ const splitMaterials = () => {
 
         return false
       })
-
+      // 补全组件的npm 字段
+      const pack = packages.find((child) => child.package === comp.npm?.package);
+      if (pack) {
+        const complete = ['version', 'destructuring', 'script', 'css'];
+        complete.forEach(e => !comp.npm?.[e] && (comp.npm[e] = pack[e]))
+      }
       const fileName = Array.isArray(comp.component) ? comp.component[0] : comp.component
       const componentPath = path.join(process.cwd(), materialsDir, 'components', `${toPascalCase(fileName)}.json`)
 


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced how component details are populated by automatically incorporating available package metadata. This improvement ensures that missing information—such as version, destructuring, script, and style data—is reliably added when applicable for a more complete display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->