### PR TITLE
feat: clicking node in the outline tree is invalid when page unlocked

### DIFF
--- a/packages/plugins/tree/src/Main.vue
+++ b/packages/plugins/tree/src/Main.vue
@@ -134,10 +134,6 @@ export default {
     }
 
     const handleMouseEnterRow = (row) => {
-      if (state.isLock) {
-        return
-      }
-
       const { hoverNode } = useCanvas().canvasApi.value
 
       hoverNode(row.id)
@@ -190,10 +186,6 @@ export default {
     }
 
     const handleClickRow = (row) => {
-      if (state.isLock) {
-        return
-      }
-
       const { selectNode } = useCanvas().canvasApi.value
       selectNode(row.id, 'clickTree')
     }


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution

历史代码遗留问题：当页面未锁定时，大纲树点击节点后，画布中不显示选中的节点
交互更改为：页面即使未锁定，大纲树点击或者悬停节点后，画布中显示选中的节点。因为点击或者悬停节点并没有对页面schema进行修改，所以这个动作是允许的

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the responsiveness of interactive elements so that mouse hover and click actions now consistently trigger the expected behavior, ensuring a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->