### PR TITLE
fix: compact schema missing css field

### DIFF
--- a/packages/vue-generator/src/generator/vue/sfc/generateStyle.js
+++ b/packages/vue-generator/src/generator/vue/sfc/generateStyle.js
@@ -13,5 +13,5 @@ export const generateStyleTag = (schema, config = {}) => {
     langDesc = `lang=${langDesc}`
   }
 
-  return `<style ${langDesc} ${scopedStr}> ${css} </style>`
+  return `<style ${langDesc} ${scopedStr}> ${css || ''} </style>`
 }


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

兼容 schema 中 css 字段缺失时，出码成 `<style scoped>undefined</style>` 的 bug。

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved style rendering to always produce valid HTML, preventing potential display issues when no styling content is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->