### PR TITLE
fix: continuous setting same script to js panel can't update ui

### DIFF
--- a/packages/plugins/script/src/js/method.js
+++ b/packages/plugins/script/src/js/method.js
@@ -10,7 +10,7 @@
  *
  */
 
-import { ref, reactive, watchEffect, onActivated, nextTick } from 'vue'
+import { ref, reactive, onActivated, nextTick, watch } from 'vue'
 import { useCanvas, useModal, useNotify } from '@opentiny/tiny-engine-meta-register'
 import { string2Ast, ast2String, insertName, formatString } from '@opentiny/tiny-engine-common/js/ast'
 import { constants } from '@opentiny/tiny-engine-utils'
@@ -58,7 +58,11 @@ const getScriptString = () => {
 }
 
 const change = (value) => {
-  state.isChanged = value !== state.script
+  const lineBreakPattern = /\r\n/g
+  // 使用 prettier 格式化之后，换行符会变成 \n
+  // monaco 传入的 value 在 window下，换行符会变成 \r\n
+  // 对比需要抹平换行符带来的差异
+  state.isChanged = value.replace(lineBreakPattern, '\n') !== state.script.replace(lineBreakPattern, '\n')
 
   if (!monaco.value) {
     return
@@ -84,7 +88,7 @@ export const saveMethod = ({ name, content }) => {
   useCanvas().updateSchema({ methods: { ...methods, [name]: methodItem } })
 }
 
-const saveMethods = () => {
+const saveMethods = async () => {
   const { message } = useModal()
   if (!state.isChanged) {
     return false
@@ -126,7 +130,14 @@ const saveMethods = () => {
 
   useCanvas().updateSchema({ methods: newMethods })
   useCanvas().setSaved(false)
+
+  // 这里需要先置空，再设置回来真正的值, 目的是让 monaco 感知到变化, 更新内容。
+  const newScript = getScriptString()
+  state.script = ''
+  await nextTick()
+  state.script = newScript
   state.isChanged = false
+
   useNotify({
     type: 'success',
     message: '保存成功！'
@@ -203,8 +214,8 @@ export const highlightMethod = (name) => {
 }
 
 export default ({ emit }) => {
-  watchEffect(() => {
-    state.script = getScriptString()
+  watch(getScriptString, (newScript) => {
+    state.script = newScript
   })
 
   onActivated(() => {


### PR DESCRIPTION

English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR 修复连续设置需要过滤内容的 script 到js面板，js 面板没有正确显示更新的 bug

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

【问题描述】
1. 打开左侧插件 JS 面板，输入以下内容：

```javascript
const a = 'xxx'

// test comment
function testa (eventArgs, args0) {
    console.log(eventArgs, args0)
}

/**
 * test comment
 */
function testbbb (eventArgs, args0) {
    console.log(eventArgs, args0)
}
```
2. 点击保存，提示保存成功，格式化会过滤内容，变为：

```javascript
// test comment
function testa (eventArgs, args0) {
    console.log(eventArgs, args0)
}

/**
 * test comment
 */
function testbbb (eventArgs, args0) {
    console.log(eventArgs, args0)
}
```
3. 再次粘贴第一步输入的内容，点击保存，提示保存成功，但是JS 面板内容为：

```javascript
const a = 'xxx'

// test comment
function testa (eventArgs, args0) {
    console.log(eventArgs, args0)
}

/**
 * test comment
 */
function testbbb (eventArgs, args0) {
    console.log(eventArgs, args0)
}
```
查看实际的 schema，仅剩下 `testa` 与 `testbbb` 函数，实际上已经过滤掉第一行的表达式。

问题：第三步重复输入第一步内容点击保存的时候，成功过滤之后，monaco 编辑器没有更新显示。

【问题分析】
第三步过滤后的内容，与第二步得到的内容相等，也就是传递给 monaco 编辑器的 value 没有发生变化，不会引起 monaco 编辑器更新 content。

这里的 `state.script` 没有发生改变，也就不会触发 monaco 更新。
https://github.com/opentiny/tiny-engine/blob/9152de24e41d7917fa3067b8998f75aab2a05520/packages/plugins/script/src/Main.vue#L17-L24

【解决方案】
点击保存内容的时候，先将 `state.script` 置空，然后在下一个 nextTick 设置上点击保存过滤的内容。

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved script content handling with normalized line breaks for consistent display.
	- Upgraded the save process to work asynchronously, ensuring smoother UI updates.
	- Enhanced reactivity monitoring for the script editor, resulting in more reliable content rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->