### PR TITLE
fix:When splitting materials, a component can exist in multiple snippets. Also, there can be two components within one snippet (with the same componentName but different snippetName)

### DIFF
--- a/scripts/splitMaterials.mjs
+++ b/scripts/splitMaterials.mjs
@@ -1,9 +1,3 @@
-/*
- * @Description: 
- * @Date: 2025-03-11 09:54:10
- * @LastEditors: xiaopang
- * @LastEditTime: 2025-03-11 09:54:29
- */
 import fs from 'fs-extra'
 import path from 'node:path'
 import Logger from './logger.mjs'

--- a/scripts/splitMaterials.mjs
+++ b/scripts/splitMaterials.mjs
@@ -1,3 +1,9 @@
+/*
+ * @Description: 
+ * @Date: 2025-03-11 09:54:10
+ * @LastEditors: xiaopang
+ * @LastEditTime: 2025-03-11 09:54:29
+ */
 import fs from 'fs-extra'
 import path from 'node:path'
 import Logger from './logger.mjs'
@@ -19,25 +25,39 @@ const toPascalCase = (str) => str.split('-').map(capitalize).join('')
  */
 const splitMaterials = () => {
   try {
-    components.forEach((comp) => {
-      snippets.some((child) => {
-        const snippet = child.children.find((item) => {
-          if (Array.isArray(comp.component)) {
-            return toPascalCase(comp.component[0]) === toPascalCase(item.snippetName)
-          }
-
-          return toPascalCase(comp.component) === toPascalCase(item.snippetName)
-        })
-
-        if (snippet) {
-          comp.snippets = [snippet]
-          comp.category = child.group
-
-          return true
+    // 预处理 snippets
+    const snippetsMap = {}
+    snippets.forEach((snippetItem) => {
+      if (!Array.isArray(snippetItem?.children)) {
+        return
+      }
+      
+      snippetItem.children.forEach((item) => {
+        const key = item?.schema?.componentName || item.snippetName
+        if (!key) {
+          return
         }
-
-        return false
+        const realKey = toPascalCase(key)
+        if (!snippetsMap[realKey]) {
+          snippetsMap[realKey] = []
+        }
+        snippetsMap[realKey].push({
+          ...item,
+          category: snippetItem.group
+        })
       })
+    })
+    // 处理组件
+    components.forEach((comp) => {
+      const matchKey = Array.isArray(comp.component) 
+        ? toPascalCase(comp.component[0])
+        : toPascalCase(comp.component)
+      
+      const matchedSnippets = snippetsMap[matchKey]
+
+      if (matchedSnippets?.length) {
+        comp.snippets = matchedSnippets
+      }
 
       const fileName = Array.isArray(comp.component) ? comp.component[0] : comp.component
       const componentPath = path.join(process.cwd(), materialsDir, 'components', `${toPascalCase(fileName)}.json`)


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?
- 背景：
表单分类里面存在复选框组和复选框拖拽按钮组两个组件，使用的是同一个组件TinyCheckboxGroup，但是在拆分之后TinyCheckboxGroup.json文件中复选框拖拽按钮组组丢失！
- 原因：
拆包的时候没有考虑一个组件在多个分组里面也没有考虑一个分组里面存在两个组件(组件名相同，配置项不同)
- 解决方案：
在splitMaterials拆分物料脚本的时候将组件名相同，snippetName不相同的组件都写入在拆分的组件文件的snippets字段里面
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?
拆分物料的时候一个组件在snippets中使用多次时在拆分的单个组件文件中snippets存在多项，TinyCheckboxGroup.json文件中存在复选框组和复选框组拖拽组

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Performed a maintenance update to streamline internal documentation by removing outdated internal annotations. These changes enhance code clarity and maintainability without altering any features, functionality, or performance visible to end-users, ensuring a seamless experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->