### PR TITLE
refactor: multiple selection

### DIFF
--- a/packages/canvas/container/src/CanvasContainer.vue
+++ b/packages/canvas/container/src/CanvasContainer.vue
@@ -107,7 +107,9 @@ export default {
     const containerPanel = ref(null)
     const insertContainer = ref(false)
 
-    const { multiSelectedStates, multiStateLength } = useMultiSelect()
+    const { multiSelectedStates } = useMultiSelect()
+
+    const multiStateLength = computed(() => multiSelectedStates.value.length)
 
     const computedSelectState = computed(() => {
       if (multiSelectedStates.value.length === 1) {

--- a/packages/canvas/container/src/CanvasContainer.vue
+++ b/packages/canvas/container/src/CanvasContainer.vue
@@ -1,9 +1,9 @@
 <template>
-  <div v-for="multiState in multiSelectedStates" :key="multiState.id">
+  <div v-for="state in multiSelectedStates" :key="state.id">
     <canvas-action
       :hoverState="hoverState"
       :inactiveHoverState="inactiveHoverState"
-      :selectState="multiState"
+      :selectState="state"
       :lineState="lineState"
       :windowGetClickEventTarget="target"
       :resize="canvasState.type === 'absolute'"
@@ -15,8 +15,8 @@
   <canvas-router-jumper :hoverState="hoverState" :inactiveHoverState="inactiveHoverState"></canvas-router-jumper>
   <canvas-viewer-switcher :hoverState="hoverState" :inactiveHoverState="inactiveHoverState"></canvas-viewer-switcher>
   <!-- divider似乎是行列容器用到的，剪刀图标 -->
-  <canvas-divider :selectState="selectState"></canvas-divider>
-  <canvas-resize-border :selectState="selectState" :iframe="iframe"></canvas-resize-border>
+  <canvas-divider :selectState="computedSelectState"></canvas-divider>
+  <canvas-resize-border :selectState="computedSelectState" :iframe="iframe"></canvas-resize-border>
   <canvas-resize>
     <template v-if="!loading">
       <iframe
@@ -63,9 +63,9 @@ import {
   onMouseUp,
   dragMove,
   dragState,
+  initialRectState,
   hoverState,
   inactiveHoverState,
-  selectState,
   lineState,
   removeNodeById,
   syncNodeScroll,
@@ -109,6 +109,14 @@ export default {
     const insertContainer = ref(false)
 
     const { multiSelectedStates, multiStateLength } = useMultiSelect()
+
+    const computedSelectState = computed(() => {
+      if (multiSelectedStates.value.length === 1) {
+        return multiSelectedStates.value[0]
+      }
+
+      return initialRectState
+    })
 
     const setCurrentNode = async (event) => {
       const { clientX, clientY } = event
@@ -316,7 +324,7 @@ export default {
       dragState,
       hoverState,
       inactiveHoverState,
-      selectState,
+      computedSelectState,
       lineState,
       multiSelectedStates,
       multiStateLength,

--- a/packages/canvas/container/src/CanvasContainer.vue
+++ b/packages/canvas/container/src/CanvasContainer.vue
@@ -14,8 +14,9 @@
   </div>
   <canvas-router-jumper :hoverState="hoverState" :inactiveHoverState="inactiveHoverState"></canvas-router-jumper>
   <canvas-viewer-switcher :hoverState="hoverState" :inactiveHoverState="inactiveHoverState"></canvas-viewer-switcher>
+  <!-- divider似乎是行列容器用到的，剪刀图标 -->
   <canvas-divider :selectState="selectState"></canvas-divider>
-  <canvas-resize-border :iframe="iframe"></canvas-resize-border>
+  <canvas-resize-border :selectState="selectState" :iframe="iframe"></canvas-resize-border>
   <canvas-resize>
     <template v-if="!loading">
       <iframe
@@ -107,7 +108,7 @@ export default {
     const containerPanel = ref(null)
     const insertContainer = ref(false)
 
-    const { multiSelectedStates, multiStateLength, toggleMultiSelection } = useMultiSelect()
+    const { multiSelectedStates, multiStateLength } = useMultiSelect()
 
     const setCurrentNode = async (event) => {
       const { clientX, clientY } = event
@@ -119,11 +120,12 @@ export default {
         const currentElement = querySelectById(getCurrent().schema?.id)
 
         if (!currentElement?.contains(element) || event.button === 0) {
+          const isCtrlKey = event.ctrlKey || event.metaKey
           const loopId = element.getAttribute(NODE_LOOP)
           if (loopId) {
-            node = await selectNode(element.getAttribute(NODE_UID), `loop-id=${loopId}`)
+            node = await selectNode(element.getAttribute(NODE_UID), `loop-id=${loopId}`, isCtrlKey)
           } else {
-            node = await selectNode(element.getAttribute(NODE_UID))
+            node = await selectNode(element.getAttribute(NODE_UID), undefined, isCtrlKey)
           }
         }
 
@@ -204,8 +206,6 @@ export default {
             if (!element) {
               return
             }
-
-            toggleMultiSelection(event, element)
 
             insertPosition.value = false
             insertContainer.value = false
@@ -299,16 +299,6 @@ export default {
     const selectSlot = (slotName) => {
       hoverState.slot = slotName
     }
-
-    watch(
-      () => multiStateLength.value,
-      (newVal) => {
-        if (newVal > 1) {
-          // 清空属性面板
-          selectNode(null)
-        }
-      }
-    )
 
     onMounted(() => run(iframe))
     onUnmounted(() => {

--- a/packages/canvas/container/src/CanvasContainer.vue
+++ b/packages/canvas/container/src/CanvasContainer.vue
@@ -14,7 +14,6 @@
   </div>
   <canvas-router-jumper :hoverState="hoverState" :inactiveHoverState="inactiveHoverState"></canvas-router-jumper>
   <canvas-viewer-switcher :hoverState="hoverState" :inactiveHoverState="inactiveHoverState"></canvas-viewer-switcher>
-  <!-- divider似乎是行列容器用到的，剪刀图标 -->
   <canvas-divider :selectState="computedSelectState"></canvas-divider>
   <canvas-resize-border :selectState="computedSelectState" :iframe="iframe"></canvas-resize-border>
   <canvas-resize>

--- a/packages/canvas/container/src/components/CanvasAction.vue
+++ b/packages/canvas/container/src/components/CanvasAction.vue
@@ -484,6 +484,11 @@ export default {
     watchPostEffect(async () => {
       const { left, top, width, height, doc } = props.selectState
 
+      // template上虽然已经判断了showQuickAction，这里再加上主要是为了watchPostEffect能够监听它，然后刷新action
+      if (!showQuickAction.value) {
+        return
+      }
+
       // nextTick后ref才能获取到元素。需要把监听的依赖放在await之前，否则无法监听变化
       await nextTick()
 

--- a/packages/canvas/container/src/components/CanvasDivider.vue
+++ b/packages/canvas/container/src/components/CanvasDivider.vue
@@ -181,6 +181,7 @@ export default {
         state.dividerStyle = {
           width: '1px',
           height: `${height}px`,
+          // FIXME verLeft自带了px
           left: `${state.verLeft}px`,
           top: `${top}px`
         }

--- a/packages/canvas/container/src/components/CanvasResizeBorder.vue
+++ b/packages/canvas/container/src/components/CanvasResizeBorder.vue
@@ -9,13 +9,16 @@
 <script>
 import { reactive, watch } from 'vue'
 import { useLayout, useCanvas } from '@opentiny/tiny-engine-meta-register'
-import { getCurrent, updateRect, selectState, querySelectById } from '../container'
+import { getCurrent, updateRect, querySelectById } from '../container'
 
 export default {
   props: {
     iframe: {
       type: Object,
       default: () => ({})
+    },
+    selectState: {
+      type: Object
     }
   },
   setup(props) {
@@ -118,7 +121,7 @@ export default {
     }
 
     const handleResizeStart = () => {
-      const { top, left, width, height } = selectState
+      const { top, left, width, height } = props.selectState
       const { parent, schema } = getCurrent()
 
       let startX = left
@@ -146,8 +149,8 @@ export default {
     }
 
     watch(
-      () => selectState,
-      () => {
+      () => props.selectState,
+      (selectState) => {
         const { top, left, width, height, componentName } = selectState
         const { parent, schema } = getCurrent()
 

--- a/packages/canvas/container/src/composables/useMultiSelect.js
+++ b/packages/canvas/container/src/composables/useMultiSelect.js
@@ -36,13 +36,34 @@ export const useMultiSelect = () => {
     }
   }
 
-  // 添加节点到多选列表
-  const addMultiSelection = (node) => {
-    if (!node || typeof node !== 'object') return
-
-    if (!multiSelectedStates.value.some((state) => state.id === node.id)) {
-      multiSelectedStates.value.push(node)
+  /**
+   * 添加state到多选列表
+   * @param {*} selectState
+   * @param {boolean} isMultipleSelect 是否多选
+   * @returns {boolean} 添加成功返回true，否则返回false
+   */
+  const addMultiSelection = (selectState, isMultipleSelect = false) => {
+    if (!selectState || typeof selectState !== 'object') {
+      return false
     }
+
+    // 多选
+    if (isMultipleSelect) {
+      const isExistNode = multiSelectedStates.value.some((state) => state.id === selectState.id)
+      // 如果多选列表已经存在选中的state，则将选中的state移出多选列表
+      if (isExistNode) {
+        multiSelectedStates.value = multiSelectedStates.value.filter((state) => state.id !== selectState.id)
+      } else {
+        multiSelectedStates.value = multiSelectedStates.value.concat(selectState)
+      }
+
+      return !isExistNode
+    }
+
+    // 单选，直接清空多选列表
+    multiSelectedStates.value = [selectState]
+
+    return true
   }
 
   // 获取多选节点（带缓存）
@@ -111,6 +132,7 @@ export const useMultiSelect = () => {
   return {
     multiSelectedStates,
     multiStateLength,
+    addMultiSelection,
     setMultiSelection,
     getMultiSelectionState,
     toggleMultiSelection,

--- a/packages/canvas/container/src/composables/useMultiSelect.js
+++ b/packages/canvas/container/src/composables/useMultiSelect.js
@@ -1,54 +1,25 @@
-import { ref, computed, toRaw } from 'vue'
-import { useCanvas } from '@opentiny/tiny-engine-meta-register'
-import { NODE_TAG, NODE_UID } from '../../../common'
-import { getRect, getDocument } from '../container'
+import { computed, ref } from 'vue'
+import { getDocument, getRect, querySelectById } from '../container'
 
 // 初始化多选节点
 const multiSelectedStates = ref([])
 
-// 节点位置缓存
-let nodeRectCache = new WeakMap()
-
-// 获取带缓存的节点位置
-const getCachedRect = (element) => {
-  if (nodeRectCache.has(element)) {
-    return nodeRectCache.get(element)
-  }
-  const rect = getRect(element)
-  nodeRectCache.set(element, rect)
-  return rect
-}
-
 export const useMultiSelect = () => {
-  // 记录最后选择的节点
-  const lastSelectedNode = ref(null)
-
   const multiStateLength = computed(() => multiSelectedStates.value.length)
-
-  // 设置多选节点
-  const setMultiSelection = (nodes) => {
-    if (Array.isArray(nodes)) {
-      multiSelectedStates.value = nodes
-    } else if (nodes && typeof nodes === 'object') {
-      multiSelectedStates.value = [nodes]
-    } else {
-      multiSelectedStates.value = []
-    }
-  }
 
   /**
    * 添加state到多选列表
    * @param {*} selectState
-   * @param {boolean} isMultipleSelect 是否多选
+   * @param {boolean} isMultiple 是否多选
    * @returns {boolean} 添加成功返回true，否则返回false
    */
-  const addMultiSelection = (selectState, isMultipleSelect = false) => {
+  const toggleMultiSelection = (selectState, isMultiple = false) => {
     if (!selectState || typeof selectState !== 'object') {
       return false
     }
 
     // 多选
-    if (isMultipleSelect) {
+    if (isMultiple) {
       const isExistNode = multiSelectedStates.value.some((state) => state.id === selectState.id)
       // 如果多选列表已经存在选中的state，则将选中的state移出多选列表
       if (isExistNode) {
@@ -60,82 +31,38 @@ export const useMultiSelect = () => {
       return !isExistNode
     }
 
-    // 单选，直接清空多选列表
+    // 单选
     multiSelectedStates.value = [selectState]
 
     return true
   }
 
-  // 获取多选节点（带缓存）
-  const getMultiSelectionState = (element) => {
-    if (!element) {
-      return null
-    }
+  const refreshSelectionState = () => {
+    multiSelectedStates.value = multiSelectedStates.value.map((state) => {
+      const element = querySelectById(state.id) || getDocument().body
+      const { top, left, width, height } = getRect(element)
 
-    // 使用缓存的位置信息
-    const { top, left, width, height } = getCachedRect(element)
-    const nodeTag = element?.getAttribute(NODE_TAG)
-    const nodeId = element?.getAttribute(NODE_UID) || 'body'
+      return {
+        ...state,
+        top,
+        left,
+        width,
+        height
+      }
+    })
 
-    // 获取节点信息
-    const { node } = useCanvas().getNodeWithParentById(nodeId) || {}
-    lastSelectedNode.value = nodeId
-
-    return {
-      id: nodeId,
-      componentName: nodeTag,
-      doc: getDocument(element),
-      top,
-      left,
-      width,
-      height,
-      schema: toRaw(node)
-    }
+    return multiSelectedStates.value
   }
 
   const clearMultiSelection = () => {
     multiSelectedStates.value = []
-    lastSelectedNode.value = null
-    nodeRectCache = new WeakMap() // 清空缓存
-  }
-
-  // 处理多选节点
-  const toggleMultiSelection = (event, element) => {
-    const isCtrlKey = event.ctrlKey || event.metaKey
-    const selectState = getMultiSelectionState(element)
-
-    if (!selectState) {
-      return
-    }
-
-    const nodeId = selectState?.id
-    const isExistNode = multiSelectedStates.value.some((state) => state.id === nodeId)
-    const isBodyState = selectState?.id === 'body'
-
-    if (isCtrlKey && event.button === 0) {
-      if (isBodyState) return
-      // 按住Ctrl或Meta键时，切换多选状态
-      if (isExistNode && nodeId) {
-        const exList = toRaw(multiSelectedStates.value).filter((state) => state.id !== nodeId)
-        if (!exList.length) return
-        setMultiSelection(exList)
-      } else {
-        addMultiSelection(selectState)
-      }
-    } else {
-      // 没有按住Ctrl或Meta键时，清除所有多选状态并添加当前节点
-      clearMultiSelection()
-      addMultiSelection(selectState)
-    }
   }
 
   return {
     multiSelectedStates,
     multiStateLength,
-    addMultiSelection,
-    setMultiSelection,
-    getMultiSelectionState,
     toggleMultiSelection,
+    refreshSelectionState,
     clearMultiSelection
   }
 }

--- a/packages/canvas/container/src/composables/useMultiSelect.js
+++ b/packages/canvas/container/src/composables/useMultiSelect.js
@@ -1,12 +1,10 @@
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
 import { getDocument, getRect, querySelectById } from '../container'
 
 // 初始化多选节点
 const multiSelectedStates = ref([])
 
 export const useMultiSelect = () => {
-  const multiStateLength = computed(() => multiSelectedStates.value.length)
-
   /**
    * 添加state到多选列表
    * @param {*} selectState
@@ -60,7 +58,6 @@ export const useMultiSelect = () => {
 
   return {
     multiSelectedStates,
-    multiStateLength,
     toggleMultiSelection,
     refreshSelectionState,
     clearMultiSelection

--- a/packages/canvas/container/src/container.js
+++ b/packages/canvas/container/src/container.js
@@ -391,14 +391,16 @@ export const scrollToNode = (element) => {
   return nextTick()
 }
 
-const setSelectRect = (id, element, isMultiple = false) => {
+const setSelectRect = (id, element, options) => {
+  const { type, isMultiple = false } = options || {}
+
   clearHover()
 
   element = element || querySelectById(id) || getDocument().body
 
   const { left, height, top, width } = getRect(element)
   const componentName = getCurrent().schema?.componentName || ''
-  const { node } = useCanvas().getNodeWithParentById(id) || {}
+  const { node, parent } = useCanvas().getNodeWithParentById(id) || {}
 
   return toggleMultiSelection(
     {
@@ -409,7 +411,9 @@ const setSelectRect = (id, element, isMultiple = false) => {
       width,
       componentName,
       doc: getDocument(),
-      schema: toRaw(node)
+      schema: node,
+      parent,
+      type
     },
     isMultiple
   )
@@ -747,13 +751,29 @@ export const selectNode = async (id, type, isMultiple = false) => {
   canvasState.current = node
   canvasState.parent = parent
 
-  if (setSelectRect(id, element, isMultiple)) {
+  const nodeIsSelected = setSelectRect(id, element, { isMultiple, type })
+  // 执行setSelectRect之后再去判断multiSelectedStates的长度
+  // 没有选中或者有多选，则重置canvasState部份数据
+  if (multiSelectedStates.value.length !== 1) {
+    Object.assign(canvasState, {
+      loopId: null,
+      current: null,
+      parent: null
+    })
+  }
+
+  if (nodeIsSelected) {
     await scrollToNode(element)
   }
 
-  canvasState.emit('selected', node, parent, type, id)
-
-  return node
+  if (multiSelectedStates.value.length === 1) {
+    const { schema: node, parent, type, id } = multiSelectedStates.value[0]
+    canvasState.emit('selected', node, parent, type, id)
+    return node
+  } else {
+    canvasState.emit('selected')
+    return null
+  }
 }
 
 export const hoverNode = (id, data) => {

--- a/packages/canvas/container/src/container.js
+++ b/packages/canvas/container/src/container.js
@@ -394,27 +394,28 @@ export const scrollToNode = (element) => {
   return nextTick()
 }
 
-const { clearMultiSelection, setMultiSelection, multiSelectedStates, multiStateLength } = useMultiSelect()
+const { addMultiSelection, multiSelectedStates } = useMultiSelect()
 
-const setSelectRect = (element, multiNodeId) => {
-  element = element || getDocument().body
+const setSelectRect = (id, element, isMultipleSelect = false) => {
+  clearHover()
+
+  element = element || querySelectById(id) || getDocument().body
 
   const { left, height, top, width } = getRect(element)
-  const elementBounds = { left, top, width, height }
   const componentName = getCurrent().schema?.componentName || ''
-  clearHover()
-  Object.assign(selectState, elementBounds, {
-    componentName,
-    doc: getDocument()
-  })
 
-  if (multiNodeId) {
-    multiSelectedStates.value.map((state) => {
-      if (state.id === multiNodeId) {
-        return Object.assign(state, elementBounds)
-      }
-    })
-  }
+  return addMultiSelection(
+    {
+      id,
+      left,
+      height,
+      top,
+      width,
+      componentName,
+      doc: getDocument()
+    },
+    isMultipleSelect
+  )
 }
 
 export const updateRect = (id) => {
@@ -422,7 +423,7 @@ export const updateRect = (id) => {
   clearHover()
 
   if (id) {
-    setTimeout(() => setSelectRect(querySelectById(id)))
+    setTimeout(() => setSelectRect(id))
   } else {
     // 如果选中的是body，不清除选中框
     if (!selectState.componentName && selectState.width > 0) {
@@ -434,9 +435,7 @@ export const updateRect = (id) => {
 
 export const syncNodeScroll = () => {
   multiSelectedStates.value.forEach((state) => {
-    const multiNodeId = state.id
-    const element = querySelectById(multiNodeId)
-    setTimeout(() => setSelectRect(element, multiNodeId))
+    setTimeout(() => setSelectRect(state.id))
   })
 }
 
@@ -729,14 +728,10 @@ export const dragMove = (event, isHover) => {
 }
 
 // type == clickTree, 为点击大纲; type == loop-id=xxx ,为点击循环数据
-export const selectNode = async (id, type) => {
+export const selectNode = async (id, type, isMultipleSelect = false) => {
   if (type && type.indexOf('loop-id') > -1) {
     const loopId = type.split('=')[1]
     canvasState.loopId = loopId
-  }
-
-  if (type !== 'clickTree' && multiStateLength.value === 1) {
-    id = multiSelectedStates.value[0]?.id
   }
 
   const { node, parent } = useCanvas().getNodeWithParentById(id) || {}
@@ -751,12 +746,8 @@ export const selectNode = async (id, type) => {
   canvasState.current = node
   canvasState.parent = parent
 
-  await scrollToNode(element)
-  setSelectRect(element)
-
-  if (type === 'clickTree') {
-    clearMultiSelection()
-    setMultiSelection(selectState)
+  if (setSelectRect(id, element, isMultipleSelect)) {
+    await scrollToNode(element)
   }
 
   canvasState.emit('selected', node, parent, type, id)

--- a/packages/canvas/container/src/container.js
+++ b/packages/canvas/container/src/container.js
@@ -352,8 +352,7 @@ export const querySelectById = (id) => {
   let element = doc.querySelector(selector)
   const loopId = element?.getAttribute('loop-id')
   if (element && loopId) {
-    const currentLoopId = getCurrent().loopId
-    selector = `[${NODE_UID}="${id}"][${NODE_LOOP}="${currentLoopId}"]`
+    selector = `[${NODE_UID}="${id}"][${NODE_LOOP}="${loopId}"]`
     element = doc.querySelector(selector)
   }
   return element
@@ -394,11 +393,11 @@ export const scrollToNode = (element) => {
 const setSelectRect = (id, element, options) => {
   clearHover()
 
-  const { type, isMultiple = false } = options || {}
+  const { type, schema, isMultiple = false } = options || {}
   element = element || querySelectById(id) || getDocument().body
 
   const { left, height, top, width } = getRect(element)
-  const componentName = getCurrent().schema?.componentName || ''
+  const componentName = (schema || getCurrent().schema)?.componentName || ''
   const { node, parent } = useCanvas().getNodeWithParentById(id) || {}
 
   return toggleMultiSelection(
@@ -733,27 +732,28 @@ export const dragMove = (event, isHover) => {
 
 // type == clickTree, 为点击大纲; type == loop-id=xxx ,为点击循环数据
 export const selectNode = async (id, type, isMultiple = false) => {
-  if (type && type.indexOf('loop-id') > -1) {
-    const loopId = type.split('=')[1]
-    canvasState.loopId = loopId
-  }
+  const { node } = useCanvas().getNodeWithParentById(id) || {}
 
-  const { node, parent } = useCanvas().getNodeWithParentById(id) || {}
-
-  let element = querySelectById(id, type)
+  let element = querySelectById(id)
 
   if (element && node) {
     const { rootSelector } = getConfigure(node.componentName)
     element = rootSelector ? element.querySelector(rootSelector) : element
   }
 
-  canvasState.current = node
-  canvasState.parent = parent
+  const nodeIsSelected = setSelectRect(id, element, { isMultiple, type, schema: node })
 
-  const nodeIsSelected = setSelectRect(id, element, { isMultiple, type })
   // 执行setSelectRect之后再去判断multiSelectedStates的长度
-  // 没有选中或者有多选，则重置canvasState部份数据
-  if (multiSelectedStates.value.length !== 1) {
+  if (multiSelectedStates.value.length === 1) {
+    const { schema: node, parent, type } = multiSelectedStates.value[0]
+    const loopId = type?.includes('loop-id') ? type.split('=')[1] : null
+    Object.assign(canvasState, {
+      loopId,
+      current: node,
+      parent
+    })
+  } else {
+    // 没有选中或者有多选，则重置canvasState部份数据
     Object.assign(canvasState, {
       loopId: null,
       current: null,

--- a/packages/canvas/container/src/container.js
+++ b/packages/canvas/container/src/container.js
@@ -392,10 +392,9 @@ export const scrollToNode = (element) => {
 }
 
 const setSelectRect = (id, element, options) => {
-  const { type, isMultiple = false } = options || {}
-
   clearHover()
 
+  const { type, isMultiple = false } = options || {}
   element = element || querySelectById(id) || getDocument().body
 
   const { left, height, top, width } = getRect(element)

--- a/packages/canvas/container/src/container.js
+++ b/packages/canvas/container/src/container.js
@@ -105,11 +105,6 @@ const initialLineState = {
   doc: null
 }
 
-// 选中画布中元素时的状态
-export const selectState = reactive({
-  ...initialRectState
-})
-
 // 鼠标移入画布中元素时的状态
 export const hoverState = reactive({
   ...initialRectState
@@ -124,6 +119,8 @@ export const lineState = reactive({
   ...initialLineState
 })
 
+const { multiSelectedStates, toggleMultiSelection, refreshSelectionState, clearMultiSelection } = useMultiSelect()
+
 export const clearHover = () => {
   Object.assign(hoverState, initialRectState, { slot: null })
   Object.assign(inactiveHoverState, initialRectState, { slot: null })
@@ -132,7 +129,7 @@ export const clearHover = () => {
 export const clearSelect = () => {
   canvasState.current = null
   canvasState.parent = null
-  Object.assign(selectState, initialRectState)
+  clearMultiSelection()
   // 临时借用 remote 事件出发 currentSchema 更新
   canvasState?.emit?.('remove')
 }
@@ -394,17 +391,16 @@ export const scrollToNode = (element) => {
   return nextTick()
 }
 
-const { addMultiSelection, multiSelectedStates } = useMultiSelect()
-
-const setSelectRect = (id, element, isMultipleSelect = false) => {
+const setSelectRect = (id, element, isMultiple = false) => {
   clearHover()
 
   element = element || querySelectById(id) || getDocument().body
 
   const { left, height, top, width } = getRect(element)
   const componentName = getCurrent().schema?.componentName || ''
+  const { node } = useCanvas().getNodeWithParentById(id) || {}
 
-  return addMultiSelection(
+  return toggleMultiSelection(
     {
       id,
       left,
@@ -412,9 +408,10 @@ const setSelectRect = (id, element, isMultipleSelect = false) => {
       top,
       width,
       componentName,
-      doc: getDocument()
+      doc: getDocument(),
+      schema: toRaw(node)
     },
-    isMultipleSelect
+    isMultiple
   )
 }
 
@@ -422,21 +419,25 @@ export const updateRect = (id) => {
   id = (typeof id === 'string' && id) || getCurrent().schema?.id
   clearHover()
 
-  if (id) {
+  // 多选场景直接调用 refreshSelectionState
+  if (multiSelectedStates.value.length > 1) {
+    refreshSelectionState()
+    setTimeout(() => refreshSelectionState())
+    return
+  }
+
+  const selectState = multiSelectedStates.value[0] || initialRectState
+  const isBodySelected = !selectState.componentName && selectState.width > 0
+
+  if (id || isBodySelected) {
     setTimeout(() => setSelectRect(id))
   } else {
-    // 如果选中的是body，不清除选中框
-    if (!selectState.componentName && selectState.width > 0) {
-      return
-    }
     clearSelect()
   }
 }
 
 export const syncNodeScroll = () => {
-  multiSelectedStates.value.forEach((state) => {
-    setTimeout(() => setSelectRect(state.id))
-  })
+  refreshSelectionState()
 }
 
 export const getConfigure = (targetName) => {
@@ -728,7 +729,7 @@ export const dragMove = (event, isHover) => {
 }
 
 // type == clickTree, 为点击大纲; type == loop-id=xxx ,为点击循环数据
-export const selectNode = async (id, type, isMultipleSelect = false) => {
+export const selectNode = async (id, type, isMultiple = false) => {
   if (type && type.indexOf('loop-id') > -1) {
     const loopId = type.split('=')[1]
     canvasState.loopId = loopId
@@ -746,7 +747,7 @@ export const selectNode = async (id, type, isMultipleSelect = false) => {
   canvasState.current = node
   canvasState.parent = parent
 
-  if (setSelectRect(id, element, isMultipleSelect)) {
+  if (setSelectRect(id, element, isMultiple)) {
     await scrollToNode(element)
   }
 

--- a/packages/canvas/container/src/keyboard.js
+++ b/packages/canvas/container/src/keyboard.js
@@ -135,7 +135,7 @@ const handleCopyEvent = (event) => {
 }
 
 const handlerClipboardEvent = (event) => {
-  const { schema, parent } = getCurrent()
+  const { schema, parent } = multiSelectedStates.value.slice(-1)[0]
   const nodeList = getClipboardSchema(event)
 
   switch (event.type) {

--- a/packages/canvas/container/src/keyboard.js
+++ b/packages/canvas/container/src/keyboard.js
@@ -115,8 +115,20 @@ const handleClipboardCut = (event) => {
   clearMultiSelection()
 }
 
-const handleClipboardPaste = (nodeList, schema, parent) => {
-  if (!nodeList.length) return
+const handleClipboardPaste = (event) => {
+  const nodeList = getClipboardSchema(event)
+
+  if (!nodeList.length) {
+    return
+  }
+
+  const lastSelected = multiSelectedStates.value.slice(-1)[0]
+
+  if (!lastSelected) {
+    return
+  }
+
+  const { schema, parent } = lastSelected
 
   nodeList.forEach((node) => {
     if (node?.componentName && schema?.componentName && allowInsert(getConfigure(schema.componentName), node)) {
@@ -135,15 +147,12 @@ const handleCopyEvent = (event) => {
 }
 
 const handlerClipboardEvent = (event) => {
-  const { schema, parent } = multiSelectedStates.value.slice(-1)[0]
-  const nodeList = getClipboardSchema(event)
-
   switch (event.type) {
     case 'copy':
       handleCopyEvent(event)
       break
     case 'paste':
-      handleClipboardPaste(nodeList, schema, parent)
+      handleClipboardPaste(event)
       break
     case 'cut':
       handleClipboardCut(event)


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution

之前的多选兼容了以前的单选`selectState`状态，导致不知道哪些场景下使用`selectState`还是`useMultiSelect`，逻辑比较混乱。多选功能bug查看下面的`What is the current behavior?`。重写后把原来在 `container.js` 的 `selectState` 移除，全部使用 `useMultiSelect`

测试场景（重写后都验证通过）

- CanvasAction。单选与原来逻辑保持一致：选择父级、向上移动、向下移动、复制、删除；多选情况下不显示
- CanvasDivider。这是行列容器的剪刀✂图标，单选与原来逻辑保持一致：选中CanvasRow和CanvasCol会显示剪刀图标，纵向切割，选中元素会变化；多选情况下不显示
- CanvasResizeBorder。单选与原来逻辑保持一致：选中CanvasRow和CanvasCol会显示ResizeBorder，拖拽它来改变高宽；多选情况下不显示
- 快捷键。`Ctrl+C`, `Ctrl+V`, `Ctrl+X`, `Delete`, `Ctrl+Z`。以上快捷键单选多选都正常，多选复制特殊的地方：`Ctrl+V` 复制的目标节点是最后一个选中的节点
- 选中状态下，改变画布大小。选中框刷新（查看下一个gif图）
- 鼠标滚轮滚动，或者拖动滚动条滚动页面；点击节点后自动滚动到节点位置
![multi-scroll](https://github.com/user-attachments/assets/26614247-080a-4934-affe-29f816166400)
- 多选状态下属性面板没有属性（查看下一个gif图）
- 取消多选只剩一个选中，则处于单选状态，此时按照单选场景测试
![multi-select](https://github.com/user-attachments/assets/edb6ed8d-f7f6-41f1-b1c8-ff18b12b4132)
- CanvasBreadcrumb。页面底部面包屑

### What is the current behavior?

最新develo分支的Bugs（commitId: 13e7f96063cff8e0d0e6f5582917adaf62876933）

- CanvasAction移动，选择框不更新
![bug1](https://github.com/user-attachments/assets/87eadbb2-e9d6-42fd-8b3e-42511a360429)
- CanvasAction删除后，选择框不更新
![bug2](https://github.com/user-attachments/assets/d7261cd2-9612-4251-9ffe-83eadb1ef017)
- 取消多选只剩一个选中，CanvasAction位置出现错误（如果剩下的一个选中的不是第一个选中的会出现）
![bug3](https://github.com/user-attachments/assets/be81e5f6-e13b-4dc5-b469-2aed2742eea3)
- CanvasDivider，纵向切割后，选中框未更新。下面纵向切割后应该刷新选中框，选中左侧的CanvasCol
![bug4](https://github.com/user-attachments/assets/6d0c84a2-2cd6-434d-b52a-468945dee470)
- CanvasResizeBorder，调节高度后，选中框不刷新
![bug5](https://github.com/user-attachments/assets/9e0669c3-05af-4eae-be31-e12e1df12a82)
- 多选粘贴
![bug-copy](https://github.com/user-attachments/assets/7088e9c3-2ade-4923-a62a-75b04710ac64)
- CanvasBreadcrumb点击失效
![bug-CanvasBreadcrumb](https://github.com/user-attachments/assets/0348b97c-9d45-4da1-80c7-4632892a093e)


### What is the new behavior?

列出的bugs全部修复

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced canvas interactions with improved support for multi-selection using modifier keys, providing a more intuitive node selection experience.
  - Introduced a new prop for managing selection state in the canvas resize border component.

- **Refactor**
  - Streamlined state management for selection and resizing behaviors, resulting in a more responsive and consistent canvas interface.
  - Updated selection logic to utilize computed properties for better encapsulation and clarity.
  - Improved handling of clipboard paste events to ensure valid selection states are utilized.
  - Added conditional logic to optimize rendering of quick actions in the canvas action component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->