### PR TITLE
fix: getRenderer could be null before canvas init

### DIFF
--- a/packages/canvas/container/src/container.ts
+++ b/packages/canvas/container/src/container.ts
@@ -946,7 +946,11 @@ export const addScript = (src: string) => appendScript(src, getDocument())
  * @param {*} merge 是否合并，默认是重置所有数据
  */
 export const setLocales = (messages: any, merge?: boolean) => {
-  const i18n = getRenderer().getI18n()
+  const i18n = getRenderer()?.getI18n?.()
+
+  if (!i18n) {
+    return
+  }
 
   Object.keys(messages).forEach((lang) => {
     const fn = merge ? 'mergeLocaleMessage' : 'setLocaleMessage'


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->
![截屏2025-03-29 11 42 28](https://github.com/user-attachments/assets/80e2aa3c-a83e-47fd-8bf3-414de081d166)

在画布 ready 前，getRenderer 有可能是 null，需要判断

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling in the localization process to prevent runtime issues when internationalization resources are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->