### PR TITLE
fix: Modify schema panel to close logic

### DIFF
--- a/packages/common/component/PluginPanel.vue
+++ b/packages/common/component/PluginPanel.vue
@@ -109,11 +109,19 @@ export default {
     isShowCollapseIcon: {
       type: Boolean,
       default: false
+    },
+    isCustomClose: {
+      type: Function,
+      default: null
     }
   },
   emits: ['close', 'updateCollapseStatus'],
   setup(props, { emit }) {
     const closePanel = () => {
+      if (typeof props.isCustomClose === 'function') {
+        props.isCustomClose()
+        return
+      }
       emit('close')
     }
 

--- a/packages/common/component/PluginPanel.vue
+++ b/packages/common/component/PluginPanel.vue
@@ -109,19 +109,11 @@ export default {
     isShowCollapseIcon: {
       type: Boolean,
       default: false
-    },
-    isCustomClose: {
-      type: Function,
-      default: null
     }
   },
   emits: ['close', 'updateCollapseStatus'],
   setup(props, { emit }) {
     const closePanel = () => {
-      if (typeof props.isCustomClose === 'function') {
-        props.isCustomClose()
-        return
-      }
       emit('close')
     }
 

--- a/packages/plugins/schema/src/Main.vue
+++ b/packages/plugins/schema/src/Main.vue
@@ -5,7 +5,7 @@
     class="plugin-schema"
     :fixed-name="PLUGIN_NAME.Schema"
     :fixedPanels="fixedPanels"
-    @close="close"
+    :is-custom-close="close"
   >
     <template #header>
       <span class="icon-wrap">

--- a/packages/plugins/schema/src/Main.vue
+++ b/packages/plugins/schema/src/Main.vue
@@ -5,7 +5,7 @@
     class="plugin-schema"
     :fixed-name="PLUGIN_NAME.Schema"
     :fixedPanels="fixedPanels"
-    :is-custom-close="close"
+    @close="close"
   >
     <template #header>
       <span class="icon-wrap">
@@ -58,6 +58,7 @@ export default {
     PluginPanel,
     IconDownloadLink: iconDownloadLink()
   },
+  inheritAttrs: false,
   props: {
     fixedPanels: {
       type: Array


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->
修改schema面板关闭逻辑
### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Adjusted the way component attributes are handled so that attributes are now applied only when explicitly specified, offering improved control over component customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->