### PR TITLE
fix: i18n create empty entries error

### DIFF
--- a/packages/plugins/i18n/src/composable/useTranslate.ts
+++ b/packages/plugins/i18n/src/composable/useTranslate.ts
@@ -62,7 +62,7 @@ const removeI18n = (key = []) => {
 
 const ensureI18n = (obj, send) => {
   const { locales } = i18nResource
-  const contents = Object.fromEntries(locales.map(({ lang }) => [lang, obj[lang]]))
+  const contents = Object.fromEntries(locales.map(({ lang }) => [lang, obj[lang] || '']))
   const langs = getLangs()
   const key = obj.key || utils.guid()
 


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution

i18n插件中创建空词条，`content`中的属性会设置成`undefined`，导致请求体中的`content`没有属性，请求接口会报错（看下方current behavior截图）
方案：创建空词条时，给`content`中的属性设置空字符串（看下方new behavior截图）

有关联的pr #1254 ，这个pr修复了初始化词条不加载的问题

### What is the current behavior?

![image](https://github.com/user-attachments/assets/d4cfaccd-fbde-40b2-92ec-0e7d9b70dc73)

![image](https://github.com/user-attachments/assets/430f212d-7b26-4393-9f80-ee772dd42948)

### What is the new behavior?

![image](https://github.com/user-attachments/assets/2dafd63c-c1a0-4be1-b32b-bfb3093134fc)


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
