### PR TITLE
Fix the canvas performance issue in the production environment.

### DIFF
--- a/packages/build/vite-config/src/default-config.js
+++ b/packages/build/vite-config/src/default-config.js
@@ -13,6 +13,7 @@ import generateComment from '@opentiny/tiny-engine-vite-plugin-meta-comments'
 import { getBaseUrlFromCli, copyBundleDeps, copyPreviewImportMap } from './localCdnFile/index.js'
 import { devAliasPlugin } from './vite-plugins/devAliasPlugin.js'
 import { htmlUpgradeHttpsPlugin } from './vite-plugins/upgradeHttpsPlugin.js'
+import { vitePluginMoveCanvas } from './vite-plugins/vitePluginMoveCanvas.js'
 import { canvasDevExternal } from './canvas-dev-external.js'
 
 const monacoEditorPlugin = monacoEditorPluginCjs.default
@@ -153,6 +154,7 @@ export function useTinyEngineBaseConfig(engineConfig) {
     }),
     monacoEditorPluginInstance,
     htmlUpgradeHttpsPlugin(mode),
+    vitePluginMoveCanvas(),
     isCopyBundleDeps
       ? copyBundleDeps({
           bundleFile: 'public/mock/bundle.json',

--- a/packages/build/vite-config/src/vite-plugins/vitePluginMoveCanvas.js
+++ b/packages/build/vite-config/src/vite-plugins/vitePluginMoveCanvas.js
@@ -1,0 +1,27 @@
+import fg from 'fast-glob'
+import fs from 'node:fs'
+import path from 'node:path'
+export function vitePluginMoveCanvas(options = {}) {
+  let resolvedConfig
+  return {
+    name: 'vite-plugin-move-canvas',
+    configResolved(config) {
+      resolvedConfig = config
+    },
+    writeBundle() {
+      const { publicPath = 'assets', assetsPath = '../packages/canvas/dist/assets' } = options
+      const assetsDir = path.join(resolvedConfig.root, assetsPath)
+      const distPath = path.join(resolvedConfig.root, resolvedConfig.build.outDir, resolvedConfig.base, publicPath)
+      if (!fs.existsSync(distPath)) {
+        fs.mkdirSync(distPath, { recursive: true })
+      }
+      fg([`${assetsDir}/*`]).then((files) => {
+        files.forEach((file) => {
+          const contentBuffer = fs.readFileSync(file)
+          const fileName = path.basename(file)
+          fs.writeFileSync(`${distPath}/${fileName}`, contentBuffer)
+        })
+      })
+    }
+  }
+}

--- a/packages/canvas/scripts/vite-plugin-separate-build.ts
+++ b/packages/canvas/scripts/vite-plugin-separate-build.ts
@@ -27,7 +27,13 @@ async function bundleBuildEntry(config, options) {
   })
 
   // handle sourceMap
-  const { map: sourcemap, fileName: chunkFileName } = outputChunk
+  const { map: sourcemap, fileName: chunkFileName, code } = outputChunk
+  if (config.needAsset) {
+    saveEmitBundleAssets(config, {
+      fileName: chunkFileName,
+      source: code
+    })
+  }
   if (sourcemap) {
     if (config.build.sourcemap === 'hidden' || config.build.sourcemap === true) {
       saveEmitBundleAssets(config, {
@@ -83,15 +89,20 @@ export async function vitePluginBuildEntry(customBuildConfig) {
         return
       }
       const file = cleanUrl(id)
-      const { code } = await bundleBuildEntry(config, {
+      const { code, fileName } = await bundleBuildEntry(config, {
         customBuildConfig,
         buildConfig: match.groups.name,
         entries: [file]
       })
-      const formatBase64 = (code) => {
-        return 'data:text/javascript;base64,' + Buffer.from(code).toString('base64')
+      if (config.needAsset) {
+        const pathName = `./${fileName}`
+        return `export default ${JSON.stringify(pathName)}\n`
+      } else {
+        const formatBase64 = (code) => {
+          return 'data:text/javascript;base64,' + Buffer.from(code).toString('base64')
+        }
+        return `export default ${JSON.stringify(formatBase64(code))}\n`
       }
-      return `export default ${JSON.stringify(formatBase64(code))}\n`
     },
     generateBundle(opts, bundle) {
       if (opts.__vite_skip_assets_emit__) {

--- a/packages/canvas/vite.config.ts
+++ b/packages/canvas/vite.config.ts
@@ -20,7 +20,7 @@ import { vitePluginBuildEntry } from './scripts/vite-plugin-separate-build'
 // https://vitejs.dev/config/
 export default defineConfig({
   base: './',
-
+  needAsset: true,
   plugins: [
     vue(),
     vueJsx(),


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?
修改引擎的画布包生产环境编译插件， 将iframe中的srcdoc以链接的方式导出，并在外边designer-demo 编译后搬迁静态JS
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1279 

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the build process with improved asset management for canvas outputs.
  - Introduced a configuration option that conditionally saves and organizes assets during build, ensuring more reliable and organized output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->