### PR TITLE
Fix the error reporting issue of the block on the parent page.

### DIFF
--- a/packages/design-core/src/preview/src/preview/Preview.vue
+++ b/packages/design-core/src/preview/src/preview/Preview.vue
@@ -136,7 +136,7 @@ export default {
       // blockSet 是为了防止重复出码同样的区块，同名区块只出码一遍
       const blockSet = new Set()
       const promises = ancestors.map((item) => getAllNestedBlocksSchema(item.page_content, fetchBlockSchema, blockSet))
-      blocks = (await Promise.all(promises)).flat()
+      const blocks = (await Promise.all(promises)).flat()
       return blocks
     }
 

--- a/packages/design-core/src/preview/src/preview/Preview.vue
+++ b/packages/design-core/src/preview/src/preview/Preview.vue
@@ -137,6 +137,7 @@ export default {
       const blockSet = new Set()
       const promises = ancestors.map((item) => getAllNestedBlocksSchema(item.page_content, fetchBlockSchema, blockSet))
       blocks = (await Promise.all(promises)).flat()
+      return blocks
     }
 
     const promiseList = [

--- a/packages/design-core/src/preview/src/preview/Preview.vue
+++ b/packages/design-core/src/preview/src/preview/Preview.vue
@@ -132,15 +132,12 @@ export default {
       return familyPages
     }
 
-    const genAllBlocks = (ancestors) =>
-      new Promise((resolve) => {
-        const blocksTask = (ancestors || []).map((item) => {
-          return getAllNestedBlocksSchema(item?.page_content, fetchBlockSchema)
-        })
-        Promise.all(blocksTask).then((rs) => {
-          resolve((rs || [])?.flat())
-        })
-      })
+    const genAllBlocks = async (ancestors) => {
+      // blockSet 是为了防止重复出码同样的区块，同名区块只出码一遍
+      const blockSet = new Set()
+      const promises = ancestors.map((item) => getAllNestedBlocksSchema(item.page_content, fetchBlockSchema, blockSet))
+      blocks = (await Promise.all(promises)).flat()
+    }
 
     const promiseList = [
       fetchAppSchema(queryParams?.app),

--- a/packages/design-core/src/preview/src/preview/Preview.vue
+++ b/packages/design-core/src/preview/src/preview/Preview.vue
@@ -132,16 +132,25 @@ export default {
       return familyPages
     }
 
+    const genAllBlocks = (ancestors) =>
+      new Promise((resolve) => {
+        const blocksTask = (ancestors || []).map((item) => {
+          return getAllNestedBlocksSchema(item?.page_content, fetchBlockSchema)
+        })
+        Promise.all(blocksTask).then((rs) => {
+          resolve((rs || [])?.flat())
+        })
+      })
+
     const promiseList = [
       fetchAppSchema(queryParams?.app),
       fetchMetaData(queryParams),
+      genAllBlocks(queryParams.ancestors),
       setFiles(srcFiles, 'src/Main.vue'),
       getImportMap()
     ]
-    Promise.all(promiseList).then(async ([appData, metaData, _void, importMapData]) => {
+    Promise.all(promiseList).then(async ([appData, metaData, blocks, _void, importMapData]) => {
       store.setImportMap(importMapData)
-
-      const blocks = await getAllNestedBlocksSchema(queryParams.pageInfo?.schema, fetchBlockSchema)
 
       // TODO: 需要验证级联生成 block schema
       // TODO: 物料内置 block 需要如何处理？


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1288 

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the preview display by streamlining the asynchronous loading of nested content, ensuring a smoother and more efficient rendering experience for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->