### PR TITLE
fix: del Timeline layout setting

### DIFF
--- a/designer-demo/public/mock/bundle.json
+++ b/designer-demo/public/mock/bundle.json
@@ -11169,35 +11169,6 @@
                 },
                 "content": [
                   {
-                    "property": "horizontal",
-                    "type": "Boolean",
-                    "defaultValue": {
-                      "type": "i18n",
-                      "zh_CN": "布局",
-                      "en_US": "layout",
-                      "key": ""
-                    },
-                    "label": {
-                      "text": {
-                        "zh_CN": "水平布局"
-                      }
-                    },
-                    "cols": 12,
-                    "rules": [],
-                    "hidden": false,
-                    "required": true,
-                    "readOnly": false,
-                    "disabled": false,
-                    "widget": {
-                      "component": "CheckBoxConfigurator",
-                      "props": {}
-                    },
-                    "description": {
-                      "zh_CN": "节点和文字横向布局"
-                    },
-                    "labelPosition": "left"
-                  },
-                  {
                     "property": "vertical",
                     "type": "Boolean",
                     "defaultValue": {


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

【背景】
TinyTimeLine 组件默认就是水平布局。
如果设置了垂直布局：以垂直布局优先。水平布局的设置不生效。
如果不设置垂直布局：无论设置不设置该属性，都是水平布局。

结论：该 配置冗余了，我们应该将其删除之。


### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the "horizontal" layout option from the Timeline component settings. Only the "vertical" layout and other existing options remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->