### PR TITLE
fix: remove the throw error message statement

### DIFF
--- a/packages/plugins/i18n/src/composable/useTranslate.ts
+++ b/packages/plugins/i18n/src/composable/useTranslate.ts
@@ -108,8 +108,8 @@ const ensureI18n = (obj: { [x: string]: any; key: string }, send?: boolean) => {
     })
 
     useCanvas().canvasApi.value?.setLocales?.(messages, true)
+    // eslint-disable-next-line
   } catch (e) {
-    throw new Error(String(e))
     // 不需要处理，有报错的词条会在画布初始化的时候统一调setLocales这个方法
   }
 

--- a/packages/plugins/i18n/src/composable/useTranslate.ts
+++ b/packages/plugins/i18n/src/composable/useTranslate.ts
@@ -108,7 +108,6 @@ const ensureI18n = (obj: { [x: string]: any; key: string }, send?: boolean) => {
     })
 
     useCanvas().canvasApi.value?.setLocales?.(messages, true)
-    // eslint-disable-next-line
   } catch (e) {
     // 不需要处理，有报错的词条会在画布初始化的时候统一调setLocales这个方法
   }


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?

初始化词条报错

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

移除初始化词条抛出的错误信息

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to prevent unnecessary error messages during language initialization. Errors are now silently managed, ensuring a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->