### PR TITLE
feat: gen code support attr with function

### DIFF
--- a/packages/vue-generator/src/generator/vue/sfc/genSetupSFC.js
+++ b/packages/vue-generator/src/generator/vue/sfc/genSetupSFC.js
@@ -21,7 +21,8 @@ import {
   handleObjBindAttrHook,
   handleEventAttrHook,
   handleTinyIconPropsHook,
-  handleJsxModelValueUpdate
+  handleJsxModelValueUpdate,
+  handleJSFunctionAttrHook
 } from './generateAttribute'
 import {
   GEN_SCRIPT_HOOKS,
@@ -227,6 +228,7 @@ export const genSFCWithDefaultPlugin = (schema, componentsMap, config = {}, next
     handleAttrKeyHook,
     handlePrimitiveAttributeHook,
     handleExpressionAttrHook,
+    handleJSFunctionAttrHook,
     handleI18nAttrHook,
     handleTinyIconPropsHook,
     handleObjBindAttrHook,

--- a/packages/vue-generator/src/generator/vue/sfc/generateAttribute.js
+++ b/packages/vue-generator/src/generator/vue/sfc/generateAttribute.js
@@ -1,3 +1,4 @@
+import { parse } from '@babel/parser'
 import {
   JS_EXPRESSION,
   JS_FUNCTION,
@@ -352,6 +353,38 @@ export const handleExpressionAttrHook = (schemaData, globalHooks, config) => {
     if (value?.type === JS_EXPRESSION && !isOn(key)) {
       specialTypeHandler[JS_RESOURCE](value, globalHooks, config)
       attributes.push(handleJSExpressionBinding(key, value, isJSX))
+
+      delete props[key]
+    }
+  })
+}
+
+export const handleJSFunctionAttrHook = (schemaData, globalHooks, config) => {
+  const { attributes, schema: { props = {} } = {} } = schemaData || {}
+  const isJSX = config.isJSX
+  Object.entries(props).forEach(([key, value]) => {
+    if (value?.type === JS_FUNCTION && !isOn(key)) {
+      let functionName = `${key}Fun`
+
+      try {
+        const ast = parse(value.value, { sourceType: 'module', plugins: ['typescript', 'jsx'] })
+        // 这里可能会存在命名冲突的场景，应该在设计态阻止命名冲突
+        functionName = ast.program.body[0].id.name
+
+        globalHooks.addStatement({
+          position: INSERT_POSITION.AFTER_METHODS,
+          value: `const ${functionName} = wrap(${value.value})`,
+          key: functionName
+        })
+      } catch (error) {
+        const logger = console
+        logger.warn(`解析失败属性 ${key} 失败: ${error.message || error}`)
+
+        // 解析失败，不处理，原样绑定到属性上
+        functionName = value.value
+      }
+
+      attributes.push(handleJSExpressionBinding(key, { value: functionName }, isJSX))
 
       delete props[key]
     }

--- a/packages/vue-generator/test/testcases/sfc/case01/expected/FormTable.vue
+++ b/packages/vue-generator/test/testcases/sfc/case01/expected/FormTable.vue
@@ -98,9 +98,9 @@ import { IconSearch, IconDel, iconHelpCircle, IconEdit } from '@opentiny/vue-ico
 import * as vue from 'vue'
 import { defineProps, defineEmits } from 'vue'
 import { I18nInjectionKey } from 'vue-i18n'
-import CrmQuoteListGridStatus from '../components/CrmQuoteListGridStatus.vue'
+import CrmQuoteListGridStatus from '@/components/CrmQuoteListGridStatus.vue'
 
-import ImageTitle from '../components/ImageTitle.vue'
+import ImageTitle from '@/components/ImageTitle.vue'
 
 const TinyIconSearch = IconSearch()
 const TinyIconDel = IconDel()

--- a/packages/vue-generator/test/testcases/sfc/case02/expected/UsePropAccessor.vue
+++ b/packages/vue-generator/test/testcases/sfc/case02/expected/UsePropAccessor.vue
@@ -11,7 +11,7 @@ import { Form as TinyForm, FormItem as TinyFormItem } from '@opentiny/vue'
 import * as vue from 'vue'
 import { defineProps, defineEmits } from 'vue'
 import { I18nInjectionKey } from 'vue-i18n'
-import PropAccessor from '../components/PropAccessor.vue'
+import PropAccessor from '@/components/PropAccessor.vue'
 
 const props = defineProps({})
 

--- a/packages/vue-generator/test/testcases/sfc/case03/expected/UseStateAccessor.vue
+++ b/packages/vue-generator/test/testcases/sfc/case03/expected/UseStateAccessor.vue
@@ -12,7 +12,7 @@ import { Form as TinyForm, FormItem as TinyFormItem } from '@opentiny/vue'
 import * as vue from 'vue'
 import { defineProps, defineEmits } from 'vue'
 import { I18nInjectionKey } from 'vue-i18n'
-import StateAccessor from '../components/StateAccessor.vue'
+import StateAccessor from '@/components/StateAccessor.vue'
 
 const props = defineProps({})
 

--- a/packages/vue-generator/test/testcases/sfc/jsFunctionAttr/components-map.json
+++ b/packages/vue-generator/test/testcases/sfc/jsFunctionAttr/components-map.json
@@ -1,0 +1,9 @@
+[
+  {
+    "componentName": "TinyTree",
+    "exportName": "Tree",
+    "package": "@opentiny/vue",
+    "version": "^3.10.0",
+    "destructuring": true
+  }
+]

--- a/packages/vue-generator/test/testcases/sfc/jsFunctionAttr/expected/jsFunctionAttrTest.vue
+++ b/packages/vue-generator/test/testcases/sfc/jsFunctionAttr/expected/jsFunctionAttrTest.vue
@@ -1,0 +1,42 @@
+<template>
+  <div>
+    <div>
+      <tiny-tree
+        class="component-base-style"
+        :render-content="render"
+        :data="[
+          { label: '一级 1', children: [{ label: '二级 1-1', children: [{ label: '三级 1-1-1' }] }] },
+          {
+            label: '一级 2',
+            children: [
+              { label: '二级 2-1', children: [{ label: '三级 2-1-1' }] },
+              { label: '二级 2-2', children: [{ label: '三级 2-2-1' }] }
+            ]
+          }
+        ]"
+      ></tiny-tree>
+    </div>
+  </div>
+</template>
+
+<script setup lang="jsx">
+import { Tree as TinyTree } from '@opentiny/vue'
+import * as vue from 'vue'
+import { defineProps, defineEmits } from 'vue'
+import { I18nInjectionKey } from 'vue-i18n'
+
+const props = defineProps({})
+
+const emit = defineEmits([])
+const { t, lowcodeWrap, stores } = vue.inject(I18nInjectionKey).lowcode()
+const wrap = lowcodeWrap(props, { emit })
+wrap({ stores })
+
+const state = vue.reactive({})
+wrap({ state })
+
+const render = wrap(function render(h, { node, data }) {
+  return <span style="color: red;font-size: 20px;">{node.label}</span>
+})
+</script>
+<style scoped></style>

--- a/packages/vue-generator/test/testcases/sfc/jsFunctionAttr/jsFunctionAttr.test.js
+++ b/packages/vue-generator/test/testcases/sfc/jsFunctionAttr/jsFunctionAttr.test.js
@@ -1,0 +1,12 @@
+import { expect, test } from 'vitest'
+import { genSFCWithDefaultPlugin } from '@/generator/vue/sfc'
+import schema from './page.schema.json'
+import componentsMap from './components-map.json'
+import { formatCode } from '@/utils/formatCode'
+
+test('should generate extra jsFunction on setup', async () => {
+  const res = genSFCWithDefaultPlugin(schema, componentsMap)
+  const formattedCode = formatCode(res, 'vue')
+
+  await expect(formattedCode).toMatchFileSnapshot('./expected/jsFunctionAttrTest.vue')
+})

--- a/packages/vue-generator/test/testcases/sfc/jsFunctionAttr/page.schema.json
+++ b/packages/vue-generator/test/testcases/sfc/jsFunctionAttr/page.schema.json
@@ -1,0 +1,73 @@
+{
+  "state": {},
+  "methods": {},
+  "componentName": "Page",
+  "css": "",
+  "props": {},
+  "lifeCycles": {},
+  "children": [
+    {
+      "componentName": "div",
+      "props": {},
+      "id": "85375559",
+      "children": [
+        {
+          "componentName": "TinyTree",
+          "props": {
+            "data": [
+              {
+                "label": "一级 1",
+                "children": [
+                  {
+                    "label": "二级 1-1",
+                    "children": [
+                      {
+                        "label": "三级 1-1-1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "label": "一级 2",
+                "children": [
+                  {
+                    "label": "二级 2-1",
+                    "children": [
+                      {
+                        "label": "三级 2-1-1"
+                      }
+                    ]
+                  },
+                  {
+                    "label": "二级 2-2",
+                    "children": [
+                      {
+                        "label": "三级 2-2-1"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "className": "component-base-style",
+            "render-content": {
+              "type": "JSFunction",
+              "value": "function render(h, { node, data }) {\n  return <span style=\"color: red;font-size: 20px;\">{node.label}</span>\n}\n"
+            }
+          },
+          "children": [],
+          "id": "43235432"
+        }
+      ]
+    }
+  ],
+  "dataSource": {
+    "list": []
+  },
+  "utils": [],
+  "bridge": [],
+  "inputs": [],
+  "outputs": [],
+  "fileName": "jsFunctionAttrTest"
+}

--- a/packages/vue-generator/test/testcases/sfc/slotParams/expected/slotParamsPage.vue
+++ b/packages/vue-generator/test/testcases/sfc/slotParams/expected/slotParamsPage.vue
@@ -12,7 +12,7 @@
 import * as vue from 'vue'
 import { defineProps, defineEmits } from 'vue'
 import { I18nInjectionKey } from 'vue-i18n'
-import BlockSlotParams from '../components/BlockSlotParams.vue'
+import BlockSlotParams from '@/components/BlockSlotParams.vue'
 
 const props = defineProps({})
 


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

【背景】
组件属性值直接绑定 JSFunction 的时候，出码会错误。比如：

```json
{
  "props": {
      "render-content": {
         "type": "JSFunction",
         "value": "function render(h, { node, data }) {\n  return <span style=\"color: red;font-size: 20px;\">{node.label}</span>\n}\n"
        }
  }
}
```

会出码成为:

```vue
<template>
    <tiny-tree  :render-content="function render(h, { node, data }) {
  return <span style=\"color: red;font-size: 20px;\">{node.label}</span>
}
">
    </tiny-tree>
</template>
```
然后该出码会报错。

【解决方案】

检测到属性为 JSFunction 的时候，将函数值生成到 setup 函数里面。然后属性绑定为该函数。

比如上述的属性会生成为：

```vue
<template>
   <tiny-tree  :render-content="render"></tiny-tree>
</template>

<script setup>

const render = wrap(function render(h, { node, data }) {
  return <span style="color: red; font-size: 20px">{node.label}</span>
})
</script>
```


### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced support for handling JavaScript function attributes in generated Vue components, enabling improved extraction and binding of function-typed properties.

- **Bug Fixes**
  - Improved robustness when processing function attributes, with fallback handling and warning logs if parsing fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->