### PR TITLE
fix(vue-generator): 优化区块引用路径，解决多层级路由问题  #1414

### DIFF
--- a/packages/vue-generator/src/generator/page.js
+++ b/packages/vue-generator/src/generator/page.js
@@ -329,7 +329,7 @@ const generateImports = (description, moduleName, type, componentsMap) => {
       blocks.push(`import ${block} from '${depPath}/${block}.vue'`)
     } else {
       const blockDefaultPath =
-        type === 'Block' ? `import ${block} from './${block}.vue'` : `import ${block} from '../components/${block}.vue'`
+        type === 'Block' ? `import ${block} from './${block}.vue'` : `import ${block} from '@/components/${block}.vue'`
 
       blocks.push(blockDefaultPath)
     }

--- a/packages/vue-generator/src/generator/vue/sfc/genSetupSFC.js
+++ b/packages/vue-generator/src/generator/vue/sfc/genSetupSFC.js
@@ -42,7 +42,7 @@ import {
 
 const parseConfig = (config = {}) => {
   const {
-    blockRelativePath = '../components/',
+    blockRelativePath = '@/components/',
     blockSuffix = '.vue',
     scriptConfig = {},
     styleConfig = {}

--- a/packages/vue-generator/src/generator/vue/sfc/parseImport.js
+++ b/packages/vue-generator/src/generator/vue/sfc/parseImport.js
@@ -42,7 +42,7 @@ export const getImportMap = (schema, componentsMap, config) => {
     pkgMap[key].push(item)
   })
 
-  const { blockRelativePath = '../components', blockSuffix = '.vue' } = config
+  const { blockRelativePath = '@/components', blockSuffix = '.vue' } = config
   const blockPkgMap = {}
   const relativePath = blockRelativePath.endsWith('/') ? blockRelativePath.slice(0, -1) : blockRelativePath
 
@@ -67,7 +67,7 @@ export const getImportMap = (schema, componentsMap, config) => {
 export const genCompImport = (schema, componentsMap, config = {}) => {
   const { components, blocks } = parseImport(schema.children)
   const pkgMap = {}
-  const { blockRelativePath = '../components/', blockSuffix = '.vue' } = config
+  const { blockRelativePath = '@/components/', blockSuffix = '.vue' } = config
 
   const importComps = componentsMap.filter(({ componentName }) => components.includes(componentName))
 

--- a/packages/vue-generator/test/testcases/sfc/case07/case07.test.js
+++ b/packages/vue-generator/test/testcases/sfc/case07/case07.test.js
@@ -1,0 +1,12 @@
+import { expect, test } from 'vitest'
+import { genSFCWithDefaultPlugin } from '@/generator/vue/sfc'
+import schema from './page.schema.json'
+import componentsMap from './components-map.json'
+import { formatCode } from '@/utils/formatCode'
+
+test('should use @/components/ as block relative path', async () => {
+  const res = genSFCWithDefaultPlugin(schema, componentsMap)
+  const formattedCode = formatCode(res, 'vue')
+
+  await expect(formattedCode).toMatchFileSnapshot('./expected/BlockPath.vue')
+})

--- a/packages/vue-generator/test/testcases/sfc/case07/components-map.json
+++ b/packages/vue-generator/test/testcases/sfc/case07/components-map.json
@@ -1,0 +1,6 @@
+[
+  {
+    "componentName": "BlockTest1a",
+    "main": "./components"
+  }
+]

--- a/packages/vue-generator/test/testcases/sfc/case07/expected/BlockPath.vue
+++ b/packages/vue-generator/test/testcases/sfc/case07/expected/BlockPath.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="page-base-style">
+    <span style="display: inline-block" class="component-base-style">测试二级页面使用区块</span>
+    <block-test1a class="block-base-style"></block-test1a>
+  </div>
+</template>
+
+<script setup>
+import * as vue from 'vue'
+import { defineProps, defineEmits } from 'vue'
+import { I18nInjectionKey } from 'vue-i18n'
+import BlockTest1a from '@/components/BlockTest1a.vue'
+
+const props = defineProps({})
+
+const emit = defineEmits([])
+const { t, lowcodeWrap, stores } = vue.inject(I18nInjectionKey).lowcode()
+const wrap = lowcodeWrap(props, { emit })
+wrap({ stores })
+
+const state = vue.reactive({})
+wrap({ state })
+</script>
+<style scoped>
+.page-base-style {
+  padding: 24px;
+  background: #ffffff;
+}
+
+.block-base-style {
+  margin: 16px;
+}
+
+.component-base-style {
+  margin: 8px;
+}
+</style>

--- a/packages/vue-generator/test/testcases/sfc/case07/page.schema.json
+++ b/packages/vue-generator/test/testcases/sfc/case07/page.schema.json
@@ -1,0 +1,40 @@
+{
+  "componentName": "Page",
+  "css": ".page-base-style {\n  padding: 24px;background: #FFFFFF;\n}\n\n.block-base-style {\n  margin: 16px;\n}\n\n.component-base-style {\n  margin: 8px;\n}\n",
+  "props": {
+    "className": "page-base-style"
+  },
+  "lifeCycles": {},
+  "children": [
+    {
+      "componentName": "Text",
+      "props": {
+        "style": "display: inline-block;",
+        "className": "component-base-style",
+        "text": "测试二级页面使用区块"
+      },
+      "children": [],
+      "id": "66c62533"
+    },
+    {
+      "componentName": "BlockTest1a",
+      "props": {
+        "className": "block-base-style"
+      },
+      "componentType": "Block",
+      "children": [],
+      "id": "75e25225"
+    }
+  ],
+  "dataSource": {
+    "list": []
+  },
+  "state": {},
+  "methods": {},
+  "utils": [],
+  "bridge": [],
+  "inputs": [],
+  "outputs": [],
+  "fileName": "BlockPath",
+  "id": "body"
+}


### PR DESCRIPTION
将 vue-generator 包中区块的相对路径从 '../components/' 统一修改为 '@/components/'， 解决了多层级路由场景下区块引用路径不一致的问题。这个改动确保了在不同层级的页面中，
区块组件都能被正确引用和加载。

[Issue ](https://github.com/opentiny/tiny-engine/issues/1414)

English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated default import paths for component blocks from relative to alias-based (`@/components`), enhancing import consistency and maintainability.
- **Tests**
  - Added new test verifying the use of alias-based import paths for component blocks.
- **New Features**
  - Introduced a new example page and component demonstrating the updated import path usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->