### PR TITLE
feat: update vite plugins to use new API

### DIFF
--- a/packages/build/vite-config/src/externalDeps.js
+++ b/packages/build/vite-config/src/externalDeps.js
@@ -29,8 +29,8 @@ const importmapPlugin = (importmap, importMapStyles = []) => {
       }
     },
     transformIndexHtml: {
-      enforce: 'pre',
-      transform(html) {
+      order: 'pre',
+      handler(html) {
         return {
           html,
           tags: [

--- a/packages/build/vite-config/src/vite-plugins/genImportMapOnly.js
+++ b/packages/build/vite-config/src/vite-plugins/genImportMapOnly.js
@@ -2,8 +2,8 @@ export function genImportMapPlugin(importMap, importMapStyles) {
   return {
     name: 'vite-plugin-gen-import-map',
     transformIndexHtml: {
-      enforce: 'pre',
-      transform(html) {
+      order: 'pre',
+      handler(html) {
         return {
           html,
           tags: [

--- a/packages/build/vite-config/src/vite-plugins/upgradeHttpsPlugin.js
+++ b/packages/build/vite-config/src/vite-plugins/upgradeHttpsPlugin.js
@@ -18,8 +18,8 @@ export const htmlUpgradeHttpsPlugin = (mode) => {
   return {
     name: 'vite-plugin-html-upgrade-https',
     transformIndexHtml: {
-      enforce: 'pre',
-      transform(html, { filename }) {
+      order: 'pre',
+      handler(html, { filename }) {
         return {
           html,
           tags: includeHtmls.includes(path.basename(filename)) ? upgradeHttpsMetaTags : []

--- a/packages/build/vite-plugin-meta-comments/index.js
+++ b/packages/build/vite-plugin-meta-comments/index.js
@@ -15,8 +15,8 @@ import { transformSFC } from './src/transform-sfc.js'
 export default function () {
   return {
     name: 'vite-plugin-generate-comments',
-    order: 'pre',
-    handler(code, id) {
+    enforce: 'pre',
+    transform(code, id) {
       if (id.endsWith('.vue')) {
         const result = transformSFC(code, id)
         return result

--- a/packages/build/vite-plugin-meta-comments/index.js
+++ b/packages/build/vite-plugin-meta-comments/index.js
@@ -15,8 +15,8 @@ import { transformSFC } from './src/transform-sfc.js'
 export default function () {
   return {
     name: 'vite-plugin-generate-comments',
-    enforce: 'pre',
-    transform(code, id) {
+    order: 'pre',
+    handler(code, id) {
       if (id.endsWith('.vue')) {
         const result = transformSFC(code, id)
         return result


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution

The Vite 5 update introduced some API changes for plugins. The current vite-plugin-html-upgrade-https plugin and vite-plugin-gen-import-map uses deprecated options that generate warning messages in the console during development. This PR updates the plugin to use the new API options, eliminating these warnings.

### What is the current behavior?

Currently, the upgradeHttpsPlugin.js and genImportMapOnly use deprecated API options:
They use enforce: 'pre' instead of the newer order: 'pre'
They use transform function instead of the newer handler function
These deprecated options work but generate warning messages in the console.

<img width="674" alt="image" src="https://github.com/user-attachments/assets/951345db-2bab-432d-98f8-055369ee8702" />

Issue Number: #1383 

### What is the new behavior?

This change eliminates the deprecation warnings while maintaining the same functionality.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

During testing, I found that another plugin vite-plugin-gen-import-map also shows similar deprecation warnings which #1383 didn't mention, this pr I fix it too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated plugin configuration properties and method names for HTML transformation plugins to improve consistency.  
- **Chores**
  - Adjusted internal plugin structure without affecting user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->