### PR TITLE
feat: del old dsl export function

### DIFF
--- a/packages/vue-generator/src/generator/index.js
+++ b/packages/vue-generator/src/generator/index.js
@@ -10,7 +10,6 @@
  *
  */
 
-export { generateCode, generateBlocksCode, generatePageCode } from './page'
 export { genSFCWithDefaultPlugin, generateSFCFile } from './vue/sfc'
 export { generateApp } from './generateApp'
 export { default as CodeGenerator } from './codeGenerator'

--- a/packages/vue-generator/src/index.d.ts
+++ b/packages/vue-generator/src/index.d.ts
@@ -1,7 +1,4 @@
 declare module '@opentiny/tiny-engine-dsl-vue' {
-  export function generateCode(param: { pageInfo: any; componentsMap?: Array<any>; blocksData?: Array<any> }): {
-    [key: string]: any
-  }
   export type defaultPlugins =
     | 'template'
     | 'block'

--- a/packages/vue-generator/src/index.js
+++ b/packages/vue-generator/src/index.js
@@ -12,14 +12,6 @@
 
 import './index.d.ts'
 
-export {
-  generateCode,
-  generateBlocksCode,
-  generatePageCode,
-  generateApp,
-  CodeGenerator,
-  genSFCWithDefaultPlugin,
-  generateSFCFile
-} from './generator'
+export { generateApp, CodeGenerator, genSFCWithDefaultPlugin, generateSFCFile } from './generator'
 
 export { parseRequiredBlocks } from './utils/parseRequiredBlocks'


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR 删除 DSL v1.x 出码导出函数

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

【问题背景】
原有的 DSL v1.x，是给 Nodejs 环境使用的。
所以在 `packages/vue-generator/src/utils/vue-sfc-validator.js` 中，直接对 `vue-eslint-parser` 进行了 require。
```javascript
export function validateByParse(code) {
  // eslint-disable-next-line @typescript-eslint/no-require-imports
                              👇 这里直接对 vue-eslint-parser 进行了 require
  const { parse: parseVue } = require('vue-eslint-parser')
  let errors = []
  // ...
}
```

问题：

在 #1349 中，发布了 alpha 版本之后，二开工程打包，会报错：

```bash
error during build:
node_modules/.pnpm/@humanfs+node@0.16.6/node_modules/@humanfs/node/src/node-hfs.js(24:9): "fiileURLToPath" is not exported by "__vite-browser-external", imported by .......
```

【问题分析】

1. 在 #1349  中对所有的 `@opentiny/tiny-enging-.*` 都进行了 external，为了可以在用户二开工程做  tree-shaking。
2. `@opentiny/tiny-engine-dsl-vue` 中指定了依赖 `"vue-eslint-parser": "8.3.0"`，子依赖为 eslint。
3. 在对所有的 `@opentiny/tiny-enging-.*`  external 之前，tiny-engine 的 monorepo 工程解析 `"vue-eslint-parser": "8.3.0"` 的 eslint 子依赖版本为 `8.57.1`。
4. 对所有的 `@opentiny/tiny-enging-.*`  external 之后，在用户的二开工程，`"vue-eslint-parser": "8.3.0"` 的 eslint 子依赖版本可能被解析为 9+。

eslint 9+ 的版本引入了 @humanfs 相关的依赖，且没有正确解析 `node:url` 相关依赖。导致构建报错。

为什么未将所有的  `@opentiny/tiny-enging-.*` external 之前不会报错？
1. 在对所有的 `@opentiny/tiny-enging-.*`  external 之前，tiny-engine 的 monorepo 工程解析 `"vue-eslint-parser": "8.3.0"` 的 eslint 子依赖版本为 `8.57.1`。
2. 未  external 的时候，在 design-core 即 `@opentiny/tiny-engine` 打包阶段的时候，`vue-eslint-parser` package 就已经被 tree-shaking了，在用户二开工程不涉及该代码片段的重新打包。

【解决方案】
将 v1.x 的出码导出函数删除，这样在 `@opentiny/tiny-engine-dsl-vue` 打包阶段，就可以直接被 tree-shaking。

（后续确定 v1.x 导出函数不再被其他外部 package 引用，无副作用之后，将相关代码实现删除。

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**  
  - Streamlined available features by removing specific code generation options from the export list. Existing core functionality and other features remain unchanged for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->