### PR TITLE
fix: init app without pageId cannot save page

### DIFF
--- a/packages/plugins/materials/src/composable/useResource.ts
+++ b/packages/plugins/materials/src/composable/useResource.ts
@@ -79,30 +79,21 @@ interface PageInfo {
 
 const initPage = (pageInfo: PageInfo) => {
   try {
-    if (pageInfo.meta) {
-      const { occupier } = pageInfo.meta
-
-      useLayout().layoutState.pageStatus = getCanvasStatus(occupier)
-      goPage(pageInfo.meta?.id)
+    if (pageInfo?.occupier) {
+      useLayout().layoutState.pageStatus = getCanvasStatus(pageInfo.occupier)
+      goPage(pageInfo.id)
     } else {
       useLayout().layoutState.pageStatus = {
         state: 'empty',
         data: {}
       }
     }
-
-    pageInfo.id = pageInfo.meta?.id
   } catch (error) {
     console.log(error) // eslint-disable-line
   }
 
-  const { id, meta, ...pageSchema } = pageInfo
-  // 画布传递 schema ，多余的数据不能传递
-  useCanvas().initData(pageSchema, {
-    id,
-    name: pageInfo?.fileName
-  })
-  useBreadcrumb().setBreadcrumbPage([pageInfo.fileName])
+  useCanvas().initData(pageInfo?.page_content || {}, pageInfo)
+  useBreadcrumb().setBreadcrumbPage([pageInfo?.name || ''])
 }
 
 /**
@@ -125,16 +116,11 @@ const initBlock = async (blockId: string) => {
 
 const initPageOrBlock = async () => {
   const { pageId, blockId } = getMetaApi(META_SERVICE.GlobalService).getBaseInfo()
-  const { setBreadcrumbPage } = useBreadcrumb()
+  const pagePluginApi = getMetaApi(META_APP.AppManage)
 
   if (pageId) {
-    const pagePluginApi = getMetaApi(META_APP.AppManage)
-
     const data = await pagePluginApi.getPageById(pageId)
-
-    useLayout().layoutState.pageStatus = getCanvasStatus(data.occupier)
-    useCanvas().initData(data.page_content, data)
-    setBreadcrumbPage([data.name])
+    initPage(data)
     return
   }
 
@@ -149,9 +135,17 @@ const initPageOrBlock = async () => {
     appSchemaState.pageTree.find(
       (page) => page.componentName === COMPONENT_NAME.Page && page?.meta?.group !== 'publicPages'
     ) || {
-      componentName: COMPONENT_NAME.Page
+      page_content: {
+        componentName: COMPONENT_NAME.Page
+      }
     }
-  initPage(toRaw(pageInfo))
+
+  if (pageInfo.meta?.id) {
+    const data = await pagePluginApi.getPageById(pageInfo.meta.id)
+    initPage(data)
+  } else {
+    initPage(toRaw(pageInfo))
+  }
 }
 
 const handlePopStateEvent = async () => {

--- a/packages/plugins/materials/src/composable/useResource.ts
+++ b/packages/plugins/materials/src/composable/useResource.ts
@@ -141,6 +141,7 @@ const initPageOrBlock = async () => {
     }
 
   if (pageInfo.meta?.id) {
+    // 这里重新请求一遍页面详情数据，是因为 appSchemaState 的页面信息存在字段转换，比如 route 被转换成了 router 字段，导致调用页面保存接口的时候报错
     const data = await pagePluginApi.getPageById(pageInfo.meta.id)
     initPage(data)
   } else {


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->


【问题描述】
进入设计器时，如果 url 上没有页面 id，编辑画布后保存，无法保存，保存接口会报错。
详见 #1282 

【问题分析】
url 上没有页面 id 的逻辑，跟有页面 id 的初始化逻辑有差异，没有页面 id 的初始化逻辑，没有往  `initData` 函数传入页面必要的相关参数，比如 `route`等等。导致点击保存按钮，调用保存接口传参的时候，缺少必要参数，导致报错。

【解决方案】
将有页面 id 和没有页面 id 的初始化逻辑保持一致。确保进入应用没有页面 id 时，自动寻找的页面 id 能够得到必要的相关参数。

【自测用例】
- 进入没有页面的空白应用
- 使用带有页面 id 的 url 进入应用
- 使用不带有页面 id 的 url 进入应用 

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1282 

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved and streamlined page initialization for a more consistent user experience. Breadcrumbs and page status are now set more reliably based on updated page data handling. No visible changes to exported features or user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->