### PR TITLE
fix: canvas drag and drop issue

### DIFF
--- a/packages/canvas/DesignCanvas/src/api/useCanvas.ts
+++ b/packages/canvas/DesignCanvas/src/api/useCanvas.ts
@@ -93,12 +93,22 @@ const handleTinyGridColumnsSlots = (node: Node) => {
 
     for (const slotItem of Object.values(columnItem.slots)) {
       if (Array.isArray(slotItem?.value)) {
+        // 这里要给 TinyGrid 的表格列插槽添加一个虚拟 Template 节点
+        // 不然有可能在拖拽的时候，拖拽到插槽的同级节点上，此时由于插槽的父节点是 TinyGrid，导致插入到了TinyGrid 的 children 中。添加一个父节点可以避免该问题
+        const virtualNode = {
+          id: utils.guid(),
+          componentName: 'Template',
+          props: {},
+          children: slotItem.value
+        }
+        nodesMap.value.set(virtualNode.id, { node: virtualNode, parent: node })
+
         slotItem.value.forEach((item: Node) => {
           if (!item.id) {
             item.id = utils.guid()
           }
 
-          nodesMap.value.set(item.id, { node: item, parent: node })
+          nodesMap.value.set(item.id, { node: item, parent: virtualNode })
 
           if (Array.isArray(item.children)) {
             // eslint-disable-next-line @typescript-eslint/no-use-before-define

--- a/packages/canvas/container/src/container.ts
+++ b/packages/canvas/container/src/container.ts
@@ -1041,7 +1041,8 @@ export const canvasApi = {
   },
   updateCanvas: (...args: any[]) => {
     return canvasState.renderer.updateCanvas(...args)
-  }
+  },
+  dragEnd
 }
 
 export const initCanvas = ({ renderer, iframe, emit, controller }: any) => {

--- a/packages/canvas/container/src/container.ts
+++ b/packages/canvas/container/src/container.ts
@@ -927,8 +927,8 @@ export const onMouseUp = () => {
   const absolute = canvasState.type === 'absolute'
   const lineId = lineState.id
   const { getNodeWithParentById, getSchema } = useCanvas()
-
-  if (draging && !forbidden) {
+  // 如果lineId为空，说明找不到参照物节点，则不进行插入
+  if (draging && !forbidden && !['', null, undefined].includes(lineId)) {
     const { parent, node } = getNodeWithParentById(lineId) || {} // target
     const data = dragState.data!
     const sourceId = data.id

--- a/packages/canvas/container/src/container.ts
+++ b/packages/canvas/container/src/container.ts
@@ -927,8 +927,8 @@ export const onMouseUp = () => {
   const absolute = canvasState.type === 'absolute'
   const lineId = lineState.id
   const { getNodeWithParentById, getSchema } = useCanvas()
-  // 如果lineId为空，说明找不到参照物节点，则不进行插入
-  if (draging && !forbidden && !['', null, undefined].includes(lineId)) {
+
+  if (draging && !forbidden) {
     const { parent, node } = getNodeWithParentById(lineId) || {} // target
     const data = dragState.data!
     const sourceId = data.id

--- a/packages/common/component/CanvasDragItem.vue
+++ b/packages/common/component/CanvasDragItem.vue
@@ -30,11 +30,11 @@ export default {
       }
     }
 
-    const dragend = () => {
-      // 拖拽结束，使用一个延迟 setTimeout 触发 dragEnd 的事件清理
-      setTimeout(() => {
+    const dragend = (e) => {
+      // 拖拽结束，但是此时的 dropEffect 为 none ，说明此时没有完成拖拽，需要清理一下拖拽状态
+      if (e.dataTransfer?.dropEffect === 'none') {
         canvasApi.value?.dragEnd?.()
-      }, 0)
+      }
     }
 
     const handleClick = () => {

--- a/packages/common/component/CanvasDragItem.vue
+++ b/packages/common/component/CanvasDragItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div draggable="true" class="drag-item" @dragstart="dragstart" @click="handleClick">
+  <div draggable="true" class="drag-item" @dragstart="dragstart" @dragend="dragend" @click="handleClick">
     <slot></slot>
   </div>
 </template>
@@ -30,6 +30,13 @@ export default {
       }
     }
 
+    const dragend = () => {
+      // 拖拽结束，使用一个延迟 setTimeout 触发 dragEnd 的事件清理
+      setTimeout(() => {
+        canvasApi.value?.dragEnd?.()
+      }, 0)
+    }
+
     const handleClick = () => {
       if (props.data) {
         const data = deepClone(props.data)
@@ -40,6 +47,7 @@ export default {
 
     return {
       dragstart,
+      dragend,
       handleClick
     }
   }


### PR DESCRIPTION
1. 修复从物料列表拖拽取消后，点击选中画布的节点，会导致选中的节点被移动到画布最后的 bug
2. 修复往表格列插槽拖动时，有可能拖动节点到插槽的顶层，导致节点被插入到 TinyGrid children，导致表格显示的 bug。

English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

【问题描述】
**bug1：物料拖拽不完全点击画布组件导致组件被移动到画布最后面的 bug**
- 从物料列表中，拖拽物料，但是不在画布释放，拖动到画布外进行释放（相当于没有完成拖拽过程）
- 选中画布的组件
问题：被选中的画布的组件，被移动到了画布的最后面。

https://github.com/user-attachments/assets/d1bf35b1-98d1-410a-9b75-109dd9b29dc5

**bug2：拖拽组件到表格插槽可能会误拖拽到表格 children 的 bug**
- 拖入 TinyGrid 表格，开启表格列插槽
- 拖入 div
- 再往上一步拖入的 div 旁边拖入 div
- 检查页面 schema，发现 schema 被插入到了 TinyGrid 的 children 中。

https://github.com/user-attachments/assets/2cd29bf0-cc5a-4069-8fca-5d8fc8a4e593

【问题分析】

bug1：在左侧物料列表开启拖拽之后，会触发canvas的拖拽完成监听，但是如果拖拽过程回到了物料列表，或者是通过 esc 键进行释放，但是 canvas 的 mouseup 拖拽完成监听没有取消，等到下一次点击的时候，会误以为是拖拽完成事件，但是此时的参照组件为空，所以被意外移动到了画布最后面。

bug2：在构建表格列插槽的 NodesMap 的时候，表格列插槽是一个数组，他们的 parent 被设置成了 TinyGrid，如果拖拽到了与插槽数组同级的节点，会被误插件到 TinyGrid 的 children 中。

【修复方案】
bug1：  dragItem 增加 dragEnd 监听事件，如果dragEnd 事件得到的 dataTransfer.dropEffect 值是 none，说明没有完成拖拽，此时手动触发 dragEnd 清理函数。
bug2：构建一个虚拟的 Template 节点，使得他们同级插入的时候，都被插入到正确的数组中。

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved drag-and-drop behavior in TinyGrid columns to prevent nodes from being incorrectly inserted directly into TinyGrid.
  - Enhanced insertion logic to ensure nodes are only inserted when a valid reference is available, reducing errors during drag-and-drop operations.
  - Added handling to properly reset drag state when drag operations end without a successful drop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->