### PR TITLE
fix: generate code should convert quote on vue template

### DIFF
--- a/packages/vue-generator/src/generator/vue/sfc/generateAttribute.js
+++ b/packages/vue-generator/src/generator/vue/sfc/generateAttribute.js
@@ -85,7 +85,7 @@ const handleJSExpressionBinding = (key, value, isJSX, globalHooks) => {
   }
 
   // expression 使用 v-bind 绑定
-  if (expressValue.includes('"')) {
+  if (expressValue.includes('"') && expressValue.includes("'")) {
     let stateKey = `${key}_${randomString()}`
     let addSuccess = globalHooks.addState(stateKey, `${stateKey}:${expressValue}`)
 
@@ -96,7 +96,7 @@ const handleJSExpressionBinding = (key, value, isJSX, globalHooks) => {
 
     return `:${key}="state.${stateKey}"`
   } else {
-    return `:${key}="${expressValue}"`
+    return `:${key}="${expressValue.replaceAll(/"/g, "'")}"`
   }
 }
 
@@ -188,13 +188,13 @@ export const handleLoopAttrHook = (schemaData = {}, globalHooks, config) => {
   if (loop?.value && loop?.type) {
     source = loop.value.replace(isJSX ? thisRegexp : thisPropsBindRe, '')
   } else {
-    source = JSON.stringify(loop).replaceAll("'", "\\'").replaceAll(/"/g, "'")
+    source = JSON.stringify(loop)
   }
 
   const iterVar = [...loopArgs]
 
   if (!isJSX) {
-    if (source.includes('"')) {
+    if (source.includes('"') && source.includes("'")) {
       let stateKey = `loop_${randomString()}`
       let addSuccess = globalHooks.addState(stateKey, `${stateKey}:${source}`)
 
@@ -205,7 +205,7 @@ export const handleLoopAttrHook = (schemaData = {}, globalHooks, config) => {
 
       attributes.push(`v-for="(${iterVar.join(',')}) in state.${stateKey}"`)
     } else {
-      attributes.push(`v-for="(${iterVar.join(',')}) in ${source}"`)
+      attributes.push(`v-for="(${iterVar.join(',')}) in ${source.replaceAll(/"/g, "'")}"`)
     }
 
     return

--- a/packages/vue-generator/src/generator/vue/sfc/generateAttribute.js
+++ b/packages/vue-generator/src/generator/vue/sfc/generateAttribute.js
@@ -70,7 +70,7 @@ export const checkHasSpecialType = (obj) => {
   return false
 }
 
-const handleJSExpressionBinding = (key, value, isJSX) => {
+const handleJSExpressionBinding = (key, value, isJSX, globalHooks) => {
   const expressValue = value.value.replace(isJSX ? thisRegexp : thisPropsBindRe, '')
 
   if (isJSX) {
@@ -85,7 +85,19 @@ const handleJSExpressionBinding = (key, value, isJSX) => {
   }
 
   // expression 使用 v-bind 绑定
-  return `:${key}="${expressValue}"`
+  if (expressValue.includes('"')) {
+    let stateKey = `${key}_${randomString()}`
+    let addSuccess = globalHooks.addState(stateKey, `${stateKey}:${expressValue}`)
+
+    while (!addSuccess) {
+      stateKey = `${key}_${randomString()}`
+      addSuccess = globalHooks.addState(stateKey, `${stateKey}:${expressValue}`)
+    }
+
+    return `:${key}="state.${stateKey}"`
+  } else {
+    return `:${key}="${expressValue}"`
+  }
 }
 
 const handleBindI18n = (key, value, isJSX) => {
@@ -182,7 +194,19 @@ export const handleLoopAttrHook = (schemaData = {}, globalHooks, config) => {
   const iterVar = [...loopArgs]
 
   if (!isJSX) {
-    attributes.push(`v-for="(${iterVar.join(',')}) in ${source}"`)
+    if (source.includes('"')) {
+      let stateKey = `loop_${randomString()}`
+      let addSuccess = globalHooks.addState(stateKey, `${stateKey}:${source}`)
+
+      while (!addSuccess) {
+        stateKey = `loop_${randomString()}`
+        addSuccess = globalHooks.addState(stateKey, `${stateKey}:${source}`)
+      }
+
+      attributes.push(`v-for="(${iterVar.join(',')}) in state.${stateKey}"`)
+    } else {
+      attributes.push(`v-for="(${iterVar.join(',')}) in ${source}"`)
+    }
 
     return
   }
@@ -352,7 +376,7 @@ export const handleExpressionAttrHook = (schemaData, globalHooks, config) => {
   Object.entries(props).forEach(([key, value]) => {
     if (value?.type === JS_EXPRESSION && !isOn(key)) {
       specialTypeHandler[JS_RESOURCE](value, globalHooks, config)
-      attributes.push(handleJSExpressionBinding(key, value, isJSX))
+      attributes.push(handleJSExpressionBinding(key, value, isJSX, globalHooks))
 
       delete props[key]
     }
@@ -384,7 +408,7 @@ export const handleJSFunctionAttrHook = (schemaData, globalHooks, config) => {
         functionName = value.value
       }
 
-      attributes.push(handleJSExpressionBinding(key, { value: functionName }, isJSX))
+      attributes.push(handleJSExpressionBinding(key, { value: functionName }, isJSX, globalHooks))
 
       delete props[key]
     }
@@ -451,11 +475,15 @@ const genStateAccessor = (value, globalHooks) => {
   }
 }
 
-const transformObjValue = (renderKey, value, globalHooks, config, transformObjType) => {
+const transformObjValue = (renderKey, value, globalHooks, config, transformObjType, shouldConvertQuote = false) => {
   const result = { shouldBindToState: false, res: null }
 
   if (typeof value === 'string') {
-    result.res = `${renderKey}"${value.replaceAll("'", "\\'").replaceAll(/"/g, "'")}"`
+    if (shouldConvertQuote) {
+      result.res = `${renderKey}'${value.replaceAll(/"/g, "'").replaceAll(/'/g, "\\'")}'`
+    } else {
+      result.res = `${renderKey}"${value.replaceAll("'", "\\'").replaceAll(/"/g, "'")}"`
+    }
 
     return result
   }
@@ -468,7 +496,11 @@ const transformObjValue = (renderKey, value, globalHooks, config, transformObjTy
 
   if (specialTypeHandler[value?.type]) {
     const specialVal = specialTypeHandler[value.type](value, globalHooks, config)?.value || ''
-    result.res = `${renderKey}${specialVal}`
+    if (shouldConvertQuote) {
+      result.res = `${renderKey}${specialVal.replaceAll(/"/g, "'")}`
+    } else {
+      result.res = `${renderKey}${specialVal}`
+    }
 
     if (specialTypes.includes(value.type)) {
       result.shouldBindToState = true
@@ -503,7 +535,7 @@ const transformObjValue = (renderKey, value, globalHooks, config, transformObjTy
 }
 
 const normalKeyRegexp = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
-export const transformObjType = (obj, globalHooks, config) => {
+export const transformObjType = (obj, globalHooks, config, shouldConvertQuote = false) => {
   if (!obj || typeof obj !== 'object') {
     return {
       res: obj
@@ -527,7 +559,8 @@ export const transformObjType = (obj, globalHooks, config) => {
       value,
       globalHooks,
       config,
-      transformObjType
+      transformObjType,
+      shouldConvertQuote
     )
 
     if (tmpShouldBindToState) {
@@ -541,7 +574,7 @@ export const transformObjType = (obj, globalHooks, config) => {
 
     // 复杂的 object 类型，需要递归处理
     const { res: tempRes, shouldBindToState: tempShouldBindToState } =
-      transformObjType(value, globalHooks, config) || {}
+      transformObjType(value, globalHooks, config, shouldConvertQuote) || {}
 
     resStr.push(`${renderKey}${tempRes}`)
 
@@ -570,7 +603,7 @@ export const handleObjBindAttrHook = (schemaData, globalHooks, config) => {
       return
     }
 
-    const { res, shouldBindToState } = transformObjType(value, globalHooks, config)
+    const { res, shouldBindToState } = transformObjType(value, globalHooks, config, true)
 
     if (shouldBindToState && !isJSX) {
       let stateKey = key
@@ -583,7 +616,7 @@ export const handleObjBindAttrHook = (schemaData, globalHooks, config) => {
 
       attributes.push(`:${key}="state.${stateKey}"`)
     } else {
-      attributes.push(isJSX ? `${key}={${res}}` : `:${key}="${res.replaceAll(/"/g, "'")}"`)
+      attributes.push(isJSX ? `${key}={${res}}` : `:${key}="${res}"`)
     }
 
     delete props[key]

--- a/packages/vue-generator/src/generator/vue/sfc/generateAttribute.js
+++ b/packages/vue-generator/src/generator/vue/sfc/generateAttribute.js
@@ -70,7 +70,7 @@ export const checkHasSpecialType = (obj) => {
   return false
 }
 
-const handleJSExpressionBinding = (key, value, isJSX, globalHooks) => {
+const handleJSExpressionBinding = (key, value, isJSX) => {
   const expressValue = value.value.replace(isJSX ? thisRegexp : thisPropsBindRe, '')
 
   if (isJSX) {
@@ -85,19 +85,10 @@ const handleJSExpressionBinding = (key, value, isJSX, globalHooks) => {
   }
 
   // expression 使用 v-bind 绑定
-  if (expressValue.includes('"') && expressValue.includes("'")) {
-    let stateKey = `${key}_${randomString()}`
-    let addSuccess = globalHooks.addState(stateKey, `${stateKey}:${expressValue}`)
-
-    while (!addSuccess) {
-      stateKey = `${key}_${randomString()}`
-      addSuccess = globalHooks.addState(stateKey, `${stateKey}:${expressValue}`)
-    }
-
-    return `:${key}="state.${stateKey}"`
-  } else {
-    return `:${key}="${expressValue.replaceAll(/"/g, "'")}"`
-  }
+  // 如果包含双引号，通过 &quot; 编码避免与属性分隔符冲突
+  // 比如绑定的值为：[{ "name": "test" }]
+  // 则转换为: :key="[{ &quot;name&quot;: &quot;test&quot; }]"
+  return `:${key}="${expressValue.replaceAll(/"/g, '&quot;')}"`
 }
 
 const handleBindI18n = (key, value, isJSX) => {
@@ -194,19 +185,7 @@ export const handleLoopAttrHook = (schemaData = {}, globalHooks, config) => {
   const iterVar = [...loopArgs]
 
   if (!isJSX) {
-    if (source.includes('"') && source.includes("'")) {
-      let stateKey = `loop_${randomString()}`
-      let addSuccess = globalHooks.addState(stateKey, `${stateKey}:${source}`)
-
-      while (!addSuccess) {
-        stateKey = `loop_${randomString()}`
-        addSuccess = globalHooks.addState(stateKey, `${stateKey}:${source}`)
-      }
-
-      attributes.push(`v-for="(${iterVar.join(',')}) in state.${stateKey}"`)
-    } else {
-      attributes.push(`v-for="(${iterVar.join(',')}) in ${source.replaceAll(/"/g, "'")}"`)
-    }
+    attributes.push(`v-for="(${iterVar.join(',')}) in ${source.replaceAll(/"/g, '&quot;')}"`)
 
     return
   }
@@ -376,7 +355,7 @@ export const handleExpressionAttrHook = (schemaData, globalHooks, config) => {
   Object.entries(props).forEach(([key, value]) => {
     if (value?.type === JS_EXPRESSION && !isOn(key)) {
       specialTypeHandler[JS_RESOURCE](value, globalHooks, config)
-      attributes.push(handleJSExpressionBinding(key, value, isJSX, globalHooks))
+      attributes.push(handleJSExpressionBinding(key, value, isJSX))
 
       delete props[key]
     }
@@ -408,7 +387,7 @@ export const handleJSFunctionAttrHook = (schemaData, globalHooks, config) => {
         functionName = value.value
       }
 
-      attributes.push(handleJSExpressionBinding(key, { value: functionName }, isJSX, globalHooks))
+      attributes.push(handleJSExpressionBinding(key, { value: functionName }, isJSX))
 
       delete props[key]
     }
@@ -475,15 +454,15 @@ const genStateAccessor = (value, globalHooks) => {
   }
 }
 
-const transformObjValue = (renderKey, value, globalHooks, config, transformObjType, shouldConvertQuote = false) => {
+const transformObjValue = (renderKey, value, globalHooks, config, transformObjType) => {
   const result = { shouldBindToState: false, res: null }
 
   if (typeof value === 'string') {
-    if (shouldConvertQuote) {
-      result.res = `${renderKey}'${value.replaceAll(/"/g, "'").replaceAll(/'/g, "\\'")}'`
-    } else {
-      result.res = `${renderKey}"${value.replaceAll("'", "\\'").replaceAll(/"/g, "'")}"`
-    }
+    result.res = `${renderKey}"${value
+      .replaceAll(/\\/g, '\\\\')
+      .replaceAll(/\n/g, '\\n')
+      .replaceAll(/\r/g, '\\r')
+      .replaceAll(/"/g, '\\"')}"`
 
     return result
   }
@@ -496,11 +475,7 @@ const transformObjValue = (renderKey, value, globalHooks, config, transformObjTy
 
   if (specialTypeHandler[value?.type]) {
     const specialVal = specialTypeHandler[value.type](value, globalHooks, config)?.value || ''
-    if (shouldConvertQuote) {
-      result.res = `${renderKey}${specialVal.replaceAll(/"/g, "'")}`
-    } else {
-      result.res = `${renderKey}${specialVal}`
-    }
+    result.res = `${renderKey}${specialVal}`
 
     if (specialTypes.includes(value.type)) {
       result.shouldBindToState = true
@@ -535,7 +510,7 @@ const transformObjValue = (renderKey, value, globalHooks, config, transformObjTy
 }
 
 const normalKeyRegexp = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
-export const transformObjType = (obj, globalHooks, config, shouldConvertQuote = false) => {
+export const transformObjType = (obj, globalHooks, config) => {
   if (!obj || typeof obj !== 'object') {
     return {
       res: obj
@@ -559,8 +534,7 @@ export const transformObjType = (obj, globalHooks, config, shouldConvertQuote = 
       value,
       globalHooks,
       config,
-      transformObjType,
-      shouldConvertQuote
+      transformObjType
     )
 
     if (tmpShouldBindToState) {
@@ -574,7 +548,7 @@ export const transformObjType = (obj, globalHooks, config, shouldConvertQuote = 
 
     // 复杂的 object 类型，需要递归处理
     const { res: tempRes, shouldBindToState: tempShouldBindToState } =
-      transformObjType(value, globalHooks, config, shouldConvertQuote) || {}
+      transformObjType(value, globalHooks, config) || {}
 
     resStr.push(`${renderKey}${tempRes}`)
 
@@ -603,20 +577,21 @@ export const handleObjBindAttrHook = (schemaData, globalHooks, config) => {
       return
     }
 
-    const { res, shouldBindToState } = transformObjType(value, globalHooks, config, true)
+    const { res, shouldBindToState } = transformObjType(value, globalHooks, config)
 
     if (shouldBindToState && !isJSX) {
       let stateKey = key
       let addSuccess = globalHooks.addState(stateKey, `${stateKey}:${res}`)
+      let retryCount = 0
 
-      while (!addSuccess) {
+      while (!addSuccess && retryCount++ < 100) {
         stateKey = `${key}${randomString()}`
         addSuccess = globalHooks.addState(stateKey, `${stateKey}:${res}`)
       }
 
       attributes.push(`:${key}="state.${stateKey}"`)
     } else {
-      attributes.push(isJSX ? `${key}={${res}}` : `:${key}="${res}"`)
+      attributes.push(isJSX ? `${key}={${res}}` : `:${key}="${res.replaceAll(/"/g, '&quot;')}"`)
     }
 
     delete props[key]
@@ -633,7 +608,7 @@ export const handlePrimitiveAttributeHook = (schemaData, globalHooks, config) =>
     const valueType = typeof value
 
     if (valueType === 'string') {
-      attributes.push(`${key}="${value.replaceAll(/"/g, "'")}"`)
+      attributes.push(`${key}="${value.replaceAll(/"/g, '&quot;')}"`)
 
       delete props[key]
     }

--- a/packages/vue-generator/src/generator/vue/sfc/generateAttribute.js
+++ b/packages/vue-generator/src/generator/vue/sfc/generateAttribute.js
@@ -589,7 +589,12 @@ export const handleObjBindAttrHook = (schemaData, globalHooks, config) => {
         addSuccess = globalHooks.addState(stateKey, `${stateKey}:${res}`)
       }
 
-      attributes.push(`:${key}="state.${stateKey}"`)
+      if (addSuccess) {
+        attributes.push(`:${key}="state.${stateKey}"`)
+      } else {
+        // state 注册失败，回退到内联绑定
+        attributes.push(`:${key}="${res.replaceAll(/"/g, '&quot;')}"`)
+      }
     } else {
       attributes.push(isJSX ? `${key}={${res}}` : `:${key}="${res.replaceAll(/"/g, '&quot;')}"`)
     }

--- a/packages/vue-generator/test/testcases/sfc/accessor/expected/Accessor.vue
+++ b/packages/vue-generator/test/testcases/sfc/accessor/expected/Accessor.vue
@@ -26,7 +26,7 @@ const state = vue.reactive({
   nullValue: null,
   numberValue: 0,
   emptyStr: '',
-  strVal: 'i am str.',
+  strVal: "i am 'str'.",
   trueVal: true,
   falseVal: false,
   arrVal: [1, '2', { aaa: 'aaa' }, [3, 4], true, false],

--- a/packages/vue-generator/test/testcases/sfc/accessor/schema.json
+++ b/packages/vue-generator/test/testcases/sfc/accessor/schema.json
@@ -44,7 +44,7 @@
       }
     },
     "strVal": {
-      "defaultValue": "i am str.",
+      "defaultValue": "i am 'str'.",
       "accessor": {
         "getter": {
           "type": "JSFunction",

--- a/packages/vue-generator/test/testcases/sfc/case01/expected/FormTable.vue
+++ b/packages/vue-generator/test/testcases/sfc/case01/expected/FormTable.vue
@@ -118,7 +118,7 @@ const { utils } = wrap(function () {
 })()
 const state = vue.reactive({
   IconPlusSquare: utils.IconPlusSquare(),
-  theme: "{   'id': 22,   'name': '@cloud/tinybuilder-theme-dark',   'description': '黑暗主题' }",
+  theme: '{   "id": 22,   "name": "@cloud/tinybuilder-theme-dark",   "description": "黑暗主题" }',
   companyName: '',
   companyOptions: null,
   companyCity: '',

--- a/packages/vue-generator/test/testcases/sfc/templateQuote/components-map.json
+++ b/packages/vue-generator/test/testcases/sfc/templateQuote/components-map.json
@@ -1,0 +1,9 @@
+[
+  {
+    "componentName": "TinyButton",
+    "exportName": "Button",
+    "package": "@opentiny/vue",
+    "version": "^3.10.0",
+    "destructuring": true
+  }
+]

--- a/packages/vue-generator/test/testcases/sfc/templateQuote/expected/jsxQuote.vue
+++ b/packages/vue-generator/test/testcases/sfc/templateQuote/expected/jsxQuote.vue
@@ -1,0 +1,27 @@
+<template>
+  <div>
+    <tiny-grid :columns="state.columns"></tiny-grid>
+  </div>
+</template>
+
+<script setup lang="jsx">
+import { Grid as TinyGrid } from '@opentiny/vue'
+import * as vue from 'vue'
+import { defineProps, defineEmits } from 'vue'
+import { I18nInjectionKey } from 'vue-i18n'
+
+const props = defineProps({})
+
+const emit = defineEmits([])
+const { t, lowcodeWrap, stores } = vue.inject(I18nInjectionKey).lowcode()
+const wrap = lowcodeWrap(props, { emit })
+wrap({ stores })
+
+const state = vue.reactive({
+  columns: [
+    { field: 'info', title: '信息', slots: { default: ({ row }, h) => <span title='{"key": "value"}'></span> } }
+  ]
+})
+wrap({ state })
+</script>
+<style scoped></style>

--- a/packages/vue-generator/test/testcases/sfc/templateQuote/expected/multiline.vue
+++ b/packages/vue-generator/test/testcases/sfc/templateQuote/expected/multiline.vue
@@ -1,0 +1,28 @@
+<template>
+  <div>
+    <tiny-button
+      multilineJson='{
+  "name": "test",
+  "value": "data"
+}'
+      :objWithMultiline="{ template: 'line1\nline2', label: 'normal' }"
+    ></tiny-button>
+  </div>
+</template>
+
+<script setup>
+import * as vue from 'vue'
+import { defineProps, defineEmits } from 'vue'
+import { I18nInjectionKey } from 'vue-i18n'
+
+const props = defineProps({})
+
+const emit = defineEmits([])
+const { t, lowcodeWrap, stores } = vue.inject(I18nInjectionKey).lowcode()
+const wrap = lowcodeWrap(props, { emit })
+wrap({ stores })
+
+const state = vue.reactive({})
+wrap({ state })
+</script>
+<style scoped></style>

--- a/packages/vue-generator/test/testcases/sfc/templateQuote/expected/primitiveQuote.vue
+++ b/packages/vue-generator/test/testcases/sfc/templateQuote/expected/primitiveQuote.vue
@@ -1,0 +1,29 @@
+<template>
+  <div>
+    <tiny-button
+      noQuotes="plain text value"
+      onlyDouble='{"name": "test", "id": "main"}'
+      onlySingle="it's a 'test' value"
+      bothQuotes='She said "hello" and it&apos;s fine'
+      htmlAttr='class="primary" id="btn-1"'
+      emptyStr=""
+    ></tiny-button>
+  </div>
+</template>
+
+<script setup>
+import * as vue from 'vue'
+import { defineProps, defineEmits } from 'vue'
+import { I18nInjectionKey } from 'vue-i18n'
+
+const props = defineProps({})
+
+const emit = defineEmits([])
+const { t, lowcodeWrap, stores } = vue.inject(I18nInjectionKey).lowcode()
+const wrap = lowcodeWrap(props, { emit })
+wrap({ stores })
+
+const state = vue.reactive({})
+wrap({ state })
+</script>
+<style scoped></style>

--- a/packages/vue-generator/test/testcases/sfc/templateQuote/expected/quoteScope.vue
+++ b/packages/vue-generator/test/testcases/sfc/templateQuote/expected/quoteScope.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    <tiny-button
+      jsonContent='{"key": "value", "nested": "data"}'
+      mixedQuotes="She said &quot;hello&quot; and he said 'hi'"
+      :filteredItems="state.items.filter((i) => i.name === 'test' && i.tag === 'featured')"
+    ></tiny-button>
+  </div>
+</template>
+
+<script setup>
+import * as vue from 'vue'
+import { defineProps, defineEmits } from 'vue'
+import { I18nInjectionKey } from 'vue-i18n'
+
+const props = defineProps({})
+
+const emit = defineEmits([])
+const { t, lowcodeWrap, stores } = vue.inject(I18nInjectionKey).lowcode()
+const wrap = lowcodeWrap(props, { emit })
+wrap({ stores })
+
+const state = vue.reactive({
+  items: [
+    { name: 'test', tag: 'featured' },
+    { name: 'hello', tag: 'normal' }
+  ]
+})
+wrap({ state })
+</script>
+<style scoped></style>

--- a/packages/vue-generator/test/testcases/sfc/templateQuote/expected/templateQuote.vue
+++ b/packages/vue-generator/test/testcases/sfc/templateQuote/expected/templateQuote.vue
@@ -1,21 +1,42 @@
 <template>
   <div>
     <tiny-button
-      v-for="(item, index) in state.loop_6cio"
+      v-for="(item, index) in [
+        {
+          type: 'primary',
+          subStr: 'primary\'subStr\''
+        },
+        {
+          type: ''
+        },
+        {
+          type: 'info'
+        },
+        {
+          type: 'success'
+        },
+        {
+          type: 'warning'
+        },
+        {
+          type: 'danger'
+        }
+      ]"
       type="primary"
       text="test"
-      subStr="pri'ma'ry'subStr'"
+      subStr="pri&quot;ma&quot;ry'subStr'"
       :customExpressionTest="{
         value: [
           {
-            defaultValue: '{\'class\': \'test-class\', \'id\': \'test-id\'}'
+            defaultValue: '{&quot;class&quot;: &quot;test-class&quot;, &quot;id&quot;: &quot;test-id&quot;}'
           }
         ]
       }"
       :customAttrTest="{
         value: [
           {
-            defaultValue: '{\'class\': \'test-class\', \'id\': \'test-id\', \'class2\': \'te\'st\'-class2\'}',
+            defaultValue:
+              '{&quot;class&quot;: &quot;test-class&quot;, &quot;id&quot;: &quot;test-id&quot;, &quot;class2&quot;: &quot;te\'st\'-class2&quot;}',
             subStr: 'test-\'cl\'ass2'
           }
         ]
@@ -37,28 +58,7 @@ const wrap = lowcodeWrap(props, { emit })
 wrap({ stores })
 
 const state = vue.reactive({
-  loop_6cio: [
-    {
-      type: 'primary',
-      subStr: "primary'subStr'"
-    },
-    {
-      type: ''
-    },
-    {
-      type: 'info'
-    },
-    {
-      type: 'success'
-    },
-    {
-      type: 'warning'
-    },
-    {
-      type: 'danger'
-    }
-  ],
-  customAttrTest: { value: [{ defaultValue: "{'class': 'test-class', 'id': 'test-id'}" }] }
+  customAttrTest: { value: [{ defaultValue: '{"class": "test-class", "id": "test-id"}' }] }
 })
 wrap({ state })
 </script>

--- a/packages/vue-generator/test/testcases/sfc/templateQuote/expected/templateQuote.vue
+++ b/packages/vue-generator/test/testcases/sfc/templateQuote/expected/templateQuote.vue
@@ -1,0 +1,66 @@
+<template>
+  <div>
+    <tiny-button
+      v-for="(item, index) in state.loop_6cio"
+      type="primary"
+      text="test"
+      subStr="pri'ma'ry'subStr'"
+      :customExpressionTest="state.customExpressionTest_vBHN"
+      :customAttrTest="{
+        value: [
+          {
+            defaultValue: '{\'class\': \'test-class\', \'id\': \'test-id\', \'class2\': \'te\'st\'-class2\'}',
+            subStr: 'test-\'cl\'ass2'
+          }
+        ]
+      }"
+    ></tiny-button>
+  </div>
+</template>
+
+<script setup>
+import * as vue from 'vue'
+import { defineProps, defineEmits } from 'vue'
+import { I18nInjectionKey } from 'vue-i18n'
+
+const props = defineProps({})
+
+const emit = defineEmits([])
+const { t, lowcodeWrap, stores } = vue.inject(I18nInjectionKey).lowcode()
+const wrap = lowcodeWrap(props, { emit })
+wrap({ stores })
+
+const state = vue.reactive({
+  loop_6cio: [
+    {
+      type: 'primary',
+      subStr: "primary'subStr'"
+    },
+    {
+      type: ''
+    },
+    {
+      type: 'info'
+    },
+    {
+      type: 'success'
+    },
+    {
+      type: 'warning'
+    },
+    {
+      type: 'danger'
+    }
+  ],
+  customExpressionTest_vBHN: {
+    value: [
+      {
+        defaultValue: '{"class": "test-class", "id": "test-id"}'
+      }
+    ]
+  },
+  customAttrTest: { value: [{ defaultValue: "{'class': 'test-class', 'id': 'test-id'}" }] }
+})
+wrap({ state })
+</script>
+<style scoped></style>

--- a/packages/vue-generator/test/testcases/sfc/templateQuote/expected/templateQuote.vue
+++ b/packages/vue-generator/test/testcases/sfc/templateQuote/expected/templateQuote.vue
@@ -5,7 +5,13 @@
       type="primary"
       text="test"
       subStr="pri'ma'ry'subStr'"
-      :customExpressionTest="state.customExpressionTest_vBHN"
+      :customExpressionTest="{
+        value: [
+          {
+            defaultValue: '{\'class\': \'test-class\', \'id\': \'test-id\'}'
+          }
+        ]
+      }"
       :customAttrTest="{
         value: [
           {
@@ -52,13 +58,6 @@ const state = vue.reactive({
       type: 'danger'
     }
   ],
-  customExpressionTest_vBHN: {
-    value: [
-      {
-        defaultValue: '{"class": "test-class", "id": "test-id"}'
-      }
-    ]
-  },
   customAttrTest: { value: [{ defaultValue: "{'class': 'test-class', 'id': 'test-id'}" }] }
 })
 wrap({ state })

--- a/packages/vue-generator/test/testcases/sfc/templateQuote/jsxQuote.components-map.json
+++ b/packages/vue-generator/test/testcases/sfc/templateQuote/jsxQuote.components-map.json
@@ -1,0 +1,9 @@
+[
+  {
+    "componentName": "TinyGrid",
+    "exportName": "Grid",
+    "package": "@opentiny/vue",
+    "version": "^3.10.0",
+    "destructuring": true
+  }
+]

--- a/packages/vue-generator/test/testcases/sfc/templateQuote/jsxQuote.schema.json
+++ b/packages/vue-generator/test/testcases/sfc/templateQuote/jsxQuote.schema.json
@@ -1,0 +1,45 @@
+{
+  "state": {
+    "columns": [
+      {
+        "field": "info",
+        "title": "信息",
+        "slots": {
+          "default": {
+            "type": "JSSlot",
+            "value": [
+              {
+                "componentName": "span",
+                "props": {
+                  "title": "{\"key\": \"value\"}"
+                },
+                "id": "jsx-span-001",
+                "children": []
+              }
+            ],
+            "params": ["row"]
+          }
+        }
+      }
+    ]
+  },
+  "methods": {},
+  "componentName": "Page",
+  "css": "",
+  "props": {},
+  "lifeCycles": {},
+  "children": [
+    {
+      "componentName": "TinyGrid",
+      "props": {
+        "columns": {
+          "type": "JSExpression",
+          "value": "state.columns"
+        }
+      },
+      "id": "jsx-test-001",
+      "children": []
+    }
+  ],
+  "fileName": "testJsxQuote"
+}

--- a/packages/vue-generator/test/testcases/sfc/templateQuote/multiline.schema.json
+++ b/packages/vue-generator/test/testcases/sfc/templateQuote/multiline.schema.json
@@ -1,0 +1,23 @@
+{
+  "state": {},
+  "methods": {},
+  "componentName": "Page",
+  "css": "",
+  "props": {},
+  "lifeCycles": {},
+  "children": [
+    {
+      "componentName": "TinyButton",
+      "props": {
+        "multilineJson": "{\n  \"name\": \"test\",\n  \"value\": \"data\"\n}",
+        "objWithMultiline": {
+          "template": "line1\nline2",
+          "label": "normal"
+        }
+      },
+      "id": "multiline-test-001",
+      "children": []
+    }
+  ],
+  "fileName": "testMultiline"
+}

--- a/packages/vue-generator/test/testcases/sfc/templateQuote/page.schema.json
+++ b/packages/vue-generator/test/testcases/sfc/templateQuote/page.schema.json
@@ -1,0 +1,46 @@
+{
+  "state": {
+    "customAttrTest": {
+      "value": [
+        {
+          "defaultValue": "{\"class\": \"test-class\", \"id\": \"test-id\"}"
+        }
+      ]
+    }
+  },
+  "methods": {},
+  "componentName": "Page",
+  "css": "",
+  "props": {},
+  "lifeCycles": {},
+  "children": [
+    {
+      "componentName": "TinyButton",
+      "props": {
+        "type": "primary",
+        "text": "test",
+        "subStr": "pri\"ma\"ry'subStr'",
+        "customAttrTest": {
+          "value": [
+            {
+              "defaultValue": "{\"class\": \"test-class\", \"id\": \"test-id\", \"class2\": \"te'st'-class2\"}",
+              "subStr": "test-'cl'ass2"
+            }
+          ]
+        },
+        "customExpressionTest": {
+          "type": "JSExpression",
+          "value": "{\n  \"value\": [\n    {\n      \"defaultValue\": \"{\\\"class\\\": \\\"test-class\\\", \\\"id\\\": \\\"test-id\\\"}\"\n    }\n  ]\n}"
+        }
+      },
+      "loopArgs": ["item", "index"],
+      "loop": {
+        "type": "JSExpression",
+        "value": "[\n  {\n    type: 'primary'\n, subStr: \"primary'subStr'\"\n  },\n  {\n    type: \"\"\n  },\n  {\n    type: \"info\"\n  },\n  {\n    type: \"success\"\n  },\n  {\n    type: \"warning\"\n  },\n  {\n    type: \"danger\"\n  }\n]"
+      },
+      "id": "63623253",
+      "children": []
+    }
+  ],
+  "fileName": "testTemplateQuote"
+}

--- a/packages/vue-generator/test/testcases/sfc/templateQuote/primitiveQuote.schema.json
+++ b/packages/vue-generator/test/testcases/sfc/templateQuote/primitiveQuote.schema.json
@@ -1,0 +1,24 @@
+{
+  "state": {},
+  "methods": {},
+  "componentName": "Page",
+  "css": "",
+  "props": {},
+  "lifeCycles": {},
+  "children": [
+    {
+      "componentName": "TinyButton",
+      "props": {
+        "noQuotes": "plain text value",
+        "onlyDouble": "{\"name\": \"test\", \"id\": \"main\"}",
+        "onlySingle": "it's a 'test' value",
+        "bothQuotes": "She said \"hello\" and it's fine",
+        "htmlAttr": "class=\"primary\" id=\"btn-1\"",
+        "emptyStr": ""
+      },
+      "id": "primitive-quote-001",
+      "children": []
+    }
+  ],
+  "fileName": "testPrimitiveQuote"
+}

--- a/packages/vue-generator/test/testcases/sfc/templateQuote/scope.schema.json
+++ b/packages/vue-generator/test/testcases/sfc/templateQuote/scope.schema.json
@@ -1,0 +1,29 @@
+{
+  "state": {
+    "items": [
+      { "name": "test", "tag": "featured" },
+      { "name": "hello", "tag": "normal" }
+    ]
+  },
+  "methods": {},
+  "componentName": "Page",
+  "css": "",
+  "props": {},
+  "lifeCycles": {},
+  "children": [
+    {
+      "componentName": "TinyButton",
+      "props": {
+        "jsonContent": "{\"key\": \"value\", \"nested\": \"data\"}",
+        "mixedQuotes": "She said \"hello\" and he said 'hi'",
+        "filteredItems": {
+          "type": "JSExpression",
+          "value": "this.state.items.filter(i => i.name === \"test\" && i.tag === 'featured')"
+        }
+      },
+      "id": "scope-test-001",
+      "children": []
+    }
+  ],
+  "fileName": "testQuoteScope"
+}

--- a/packages/vue-generator/test/testcases/sfc/templateQuote/templateQuote.test.js
+++ b/packages/vue-generator/test/testcases/sfc/templateQuote/templateQuote.test.js
@@ -1,28 +1,12 @@
-import { expect, test, beforeEach, afterEach, vi } from 'vitest'
+import { expect, test } from 'vitest'
 import { genSFCWithDefaultPlugin } from '@/generator/vue/sfc'
 import pageSchema from './page.schema.json'
+import scopeSchema from './scope.schema.json'
+import multilineSchema from './multiline.schema.json'
+import jsxQuoteSchema from './jsxQuote.schema.json'
+import jsxQuoteComponentsMap from './jsxQuote.components-map.json'
+import primitiveQuoteSchema from './primitiveQuote.schema.json'
 import { formatCode } from '@/utils/formatCode'
-
-let count = 0
-const mockValue = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
-
-beforeEach(() => {
-  // 伪随机数，保证每次快照都一致
-  vi.spyOn(global.Math, 'random').mockImplementation(() => {
-    const res = mockValue[count]
-
-    count++
-    if (count > 10) {
-      count = 0
-    }
-
-    return res
-  })
-})
-
-afterEach(() => {
-  vi.spyOn(global.Math, 'random').mockRestore()
-})
 
 test('should generate template quote correctly', async () => {
   const res = genSFCWithDefaultPlugin(pageSchema, [])
@@ -30,4 +14,36 @@ test('should generate template quote correctly', async () => {
   const formattedCode = formatCode(res, 'vue')
 
   await expect(formattedCode).toMatchFileSnapshot('./expected/templateQuote.vue')
+})
+
+test('should preserve expression scope and string content with quotes', async () => {
+  const res = genSFCWithDefaultPlugin(scopeSchema, [])
+
+  const formattedCode = formatCode(res, 'vue')
+
+  await expect(formattedCode).toMatchFileSnapshot('./expected/quoteScope.vue')
+})
+
+test('should escape newlines in v-bind string literals for multiline strings with double quotes', async () => {
+  const res = genSFCWithDefaultPlugin(multilineSchema, [])
+
+  const formattedCode = formatCode(res, 'vue')
+
+  await expect(formattedCode).toMatchFileSnapshot('./expected/multiline.vue')
+})
+
+test('should not use v-bind string literal syntax in JSX slot mode', async () => {
+  const res = genSFCWithDefaultPlugin(jsxQuoteSchema, jsxQuoteComponentsMap)
+
+  const formattedCode = formatCode(res, 'vue')
+
+  await expect(formattedCode).toMatchFileSnapshot('./expected/jsxQuote.vue')
+})
+
+test('should encode double quotes as &quot; in primitive string attributes', async () => {
+  const res = genSFCWithDefaultPlugin(primitiveQuoteSchema, [])
+
+  const formattedCode = formatCode(res, 'vue')
+
+  await expect(formattedCode).toMatchFileSnapshot('./expected/primitiveQuote.vue')
 })

--- a/packages/vue-generator/test/testcases/sfc/templateQuote/templateQuote.test.js
+++ b/packages/vue-generator/test/testcases/sfc/templateQuote/templateQuote.test.js
@@ -1,0 +1,33 @@
+import { expect, test, beforeEach, afterEach, vi } from 'vitest'
+import { genSFCWithDefaultPlugin } from '@/generator/vue/sfc'
+import pageSchema from './page.schema.json'
+import { formatCode } from '@/utils/formatCode'
+
+let count = 0
+const mockValue = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+
+beforeEach(() => {
+  // 伪随机数，保证每次快照都一致
+  vi.spyOn(global.Math, 'random').mockImplementation(() => {
+    const res = mockValue[count]
+
+    count++
+    if (count > 10) {
+      count = 0
+    }
+
+    return res
+  })
+})
+
+afterEach(() => {
+  vi.spyOn(global.Math, 'random').mockRestore()
+})
+
+test('should generate template quote correctly', async () => {
+  const res = genSFCWithDefaultPlugin(pageSchema, [])
+
+  const formattedCode = formatCode(res, 'vue')
+
+  await expect(formattedCode).toMatchFileSnapshot('./expected/templateQuote.vue')
+})


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## 【问题描述】Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

 vue-generator 在生成 Vue 模板属性时，通过 `"` → `'` 的朴素替换来避免双引号与 HTML 属性分隔符冲突。当属性值**同时包含单引号和双引号**（或在 v-bind 上下文中包含双引号）时，这种策略会生成**无法运行的代码**。

#### 问题 1：v-bind 对象绑定生成无效 JS

  `transformObjValue` 先将值内的 `"` 转为 `'`，`handleObjBindAttrHook` 再将外层包裹的 `"` 也转为 `'`，导致内层未转义的 `'` 与外层定界符 `'` 冲突。

  输入 schema:
    props.theme = { defaultValue: '{"class": "test-class", "id": "test-id"}' }

  transformObjValue 第一步 → 值内 " 变 ':
    defaultValue: "{'class': 'test-class', 'id': 'test-id'}"

  handleObjBindAttrHook 第二步 → 外层 " 也变 ':
    defaultValue: '{'class': 'test-class', 'id': 'test-id'}'
                   ↑ 内层 ' 没有转义，与外层 ' 冲突

  最终生成:
    :theme="{ defaultValue: '{'class': 'test-class', 'id': 'test-id'}' }"
                             ↑ Vue 执行这段 JS 表达式 → 语法错误 ❌

  如果值同时含 `"` 和 `'`（如 `{"class": "te'st'-class"}`），问题更严重——转义后的 `\'` 和未转义的 `'` 混杂，产生不可预测的解析结果。

  #### 问题 2：JSExpression 中的双引号截断 HTML 属性

  `handleJSExpressionBinding` 旧代码对表达式值不做任何引号处理，表达式中的 `"` 直接截断 HTML 属性结构。

  输入 schema:
    props.data = { type: "JSExpression", value: '[{ "name": "test" }]' }

  旧代码直接拼接:
    :data="[{ "name": "test" }]"
               ↑ " 截断了 HTML 属性 → 属性值变成 [{ ，后续内容变成无效属性 ❌

  #### 问题 3：v-for 循环源含引号时的脆弱转换

  `handleLoopAttrHook` 非表达式路径使用 `JSON.stringify` → `'` 转义 → `"` 替换的三步链式处理。虽然 `JSON.stringify` 的 `\"` 转义让单纯场景意外可用，但当数据同时包含 `'` 和 `"`
  时，多层替换的交互可能产生异常转义序列。


### 【解决方案】What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

  **统一使用 `&quot;` HTML 实体编码替代 `"` → `'` 替换**，从根本上避免引号冲突：

  - `&quot;` 在 HTML 属性中被浏览器/Vue 模板编译器自动解码为 `"`，不会与属性分隔符冲突
  - 不改变原始字符串内容，语义完全保留
  - Prettier 后处理会自动选择最优引号风格（如切换为单引号包裹并还原 `"` 原文）

  具体修改：

  | 修改点 | 旧策略 | 新策略 |
  |--------|--------|--------|
  | `handlePrimitiveAttributeHook` | `"` → `'` | `"` → `&quot;` |
  | `handleJSExpressionBinding` | 未处理 | `"` → `&quot;` |
  | `handleObjBindAttrHook` 内联属性 | `"` → `'` | `"` → `&quot;` |
  | `handleLoopAttrHook` 非表达式路径 | `JSON.stringify` + `"` → `'` | `JSON.stringify` + `"` → `&quot;` |
  | `transformObjValue` 字符串转义 | 仅 `'` → `\'` + `"` → `'` | 完整转义：`\` → `\\`、`\n` → `\\n`、`\r` → `\\r`、`"` → `\"` |
  | `handleObjBindAttrHook` 状态注册循环 | `while (!addSuccess)` 无上限 | 增加 `retryCount < 100` 防御 |

### 修复后的效果

  输入: props.theme = { defaultValue: '{"class": "test-class"}' }

  transformObjValue → 正确转义:
    defaultValue: "{"class": "test-class"}"

  handleObjBindAttrHook → HTML 实体编码:
    :theme="{ defaultValue: &quot;{&quot;class&quot;: &quot;test-class&quot;}&quot; }"

  HTML 解码后 Vue 收到的 JS 表达式:
    { defaultValue: "{"class": "test-class"}" }  ← 合法 JS ✅

  Prettier 格式化最终输出:
    :theme="{ defaultValue: '{&quot;class&quot;: &quot;test-class&quot;}' }"  ✅

 ## Test coverage

  新增 `templateQuote` 测试套件（5 个测试用例），覆盖：

  | 测试用例 | 覆盖场景 |
  |----------|----------|
  | `templateQuote` | v-for + 对象绑定 + JSExpression + 基本属性在同一组件上的引号交互 |
  | `primitiveQuote` | 纯文本 / 仅双引号 / 仅单引号 / 双单引号共存 / 空字符串 |
  | `quoteScope` | JSExpression 中包含 `"` 和 `'` 的 filter 表达式 |
  | `multiline` | 含 `\n` 换行的多行字符串在 v-bind 对象绑定中的转义 |
  | `jsxQuote` | JSX slot 模式下引号处理（确认 JSX 上下文不使用 `&quot;`） |

Issue Number: N/A


### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML-encoding of double quotes in Vue attribute and object bindings.
  * Enhanced escaping of special characters (backslashes, newlines, carriage returns, double quotes) in bound strings.
  * Added bounded retry safety when registering state to avoid infinite loops.

* **Tests**
  * Expanded test coverage and added multiple fixtures validating quote handling, multiline strings, JSX-slot cases, and template-quoting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->