### PR TITLE
fix: fix issue where clicking the collapse icon does not close the po…

### DIFF
--- a/packages/plugins/page/src/Tree.vue
+++ b/packages/plugins/page/src/Tree.vue
@@ -25,9 +25,9 @@
       @drop="handleDrop($event, node)"
       @dragend="handleDragEnd"
     >
-      <div class="content" @click="handleClickRow(node)">
+      <div class="content" @click="handleClickRow($event, node)">
         <layer-lines :line-data="layerLine[rowIndex]" :level="node.level"></layer-lines>
-        <div class="prefix-icon" @click.stop="handleSwitchCollapse(node)">
+        <div class="prefix-icon" @click="handleSwitchCollapse(node)">
           <svg-icon v-if="node.rawData.isPage" :name="collapseMap[node.id] ? 'page-collection' : 'page'"></svg-icon>
           <svg-icon v-else :name="collapseMap[node.id] ? 'folder' : 'folder-wold'"></svg-icon>
         </div>
@@ -193,7 +193,13 @@ const layerLine = computed(() => {
   return result
 })
 
-const handleClickRow = (node) => {
+const handleClickRow = (event, node) => {
+  // 点击事件来自折叠图标，不触发 clickRow 事件。点击事件仍然可以冒泡
+  const currentTarget = event.currentTarget as HTMLElement
+  if (currentTarget.querySelector('div.prefix-icon')?.contains(event.target)) {
+    return
+  }
+
   emit('clickRow', node)
 }
 


### PR DESCRIPTION
…pover

English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?

页面树节点，点击右侧的菜单按钮。打开菜单后，如果点击展开收起图标，菜单不会消失，导致菜单位置无法与节点对应

Issue Number: N/A

### What is the new behavior?

页面树节点，点击右侧的菜单按钮。打开菜单后，如果点击展开收起图标，关闭菜单

<img src="https://github.com/user-attachments/assets/c809b12a-4d74-4f30-9e91-b523e32b7ff9" width="400px" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved click handling in the tree view to prevent row click events from triggering when the collapse icon is clicked, ensuring more accurate user interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->