### PR TITLE
fix: defineService multiple time will get error instance

### DIFF
--- a/designer-demo/package.json
+++ b/designer-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "designer-demo",
   "private": true,
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "type": "module",
   "scripts": {
     "dev": "cross-env vite",

--- a/designer-demo/package.json
+++ b/designer-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "designer-demo",
   "private": true,
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "type": "module",
   "scripts": {
     "dev": "cross-env vite",

--- a/mockServer/package.json
+++ b/mockServer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-mock",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/mockServer/package.json
+++ b/mockServer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-mock",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/block-compiler/package.json
+++ b/packages/block-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-block-compiler",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/block-compiler/package.json
+++ b/packages/block-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-block-compiler",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/blockToWebComponentTemplate/package.json
+++ b/packages/blockToWebComponentTemplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-block-build",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "description": "translate block to webcomponent template",
   "main": "./dist/web-components.es.js",
   "type": "module",

--- a/packages/blockToWebComponentTemplate/package.json
+++ b/packages/blockToWebComponentTemplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-block-build",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "description": "translate block to webcomponent template",
   "main": "./dist/web-components.es.js",
   "type": "module",

--- a/packages/build/vite-config/package.json
+++ b/packages/build/vite-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-vite-config",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "description": "",
   "type": "module",
   "main": "./index.js",

--- a/packages/build/vite-config/package.json
+++ b/packages/build/vite-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-vite-config",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "description": "",
   "type": "module",
   "main": "./index.js",

--- a/packages/build/vite-plugin-meta-comments/package.json
+++ b/packages/build/vite-plugin-meta-comments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-vite-plugin-meta-comments",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "description": "",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/build/vite-plugin-meta-comments/package.json
+++ b/packages/build/vite-plugin-meta-comments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-vite-plugin-meta-comments",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "description": "",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/builtinComponent/package.json
+++ b/packages/builtinComponent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-builtin-component",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "description": "",
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",

--- a/packages/builtinComponent/package.json
+++ b/packages/builtinComponent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-builtin-component",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "description": "",
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",

--- a/packages/canvas/package.json
+++ b/packages/canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-canvas",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/canvas/package.json
+++ b/packages/canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-canvas",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-common",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-common",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/configurator/package.json
+++ b/packages/configurator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-configurator",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/configurator/package.json
+++ b/packages/configurator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-configurator",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/design-core/package.json
+++ b/packages/design-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "type": "module",
   "description": "TinyEngine enables developers to customize low-code platforms, build low-bit platforms online in real time, and support secondary development or integration of low-bit platform capabilities.",
   "homepage": "https://opentiny.design/tiny-engine",

--- a/packages/design-core/package.json
+++ b/packages/design-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "type": "module",
   "description": "TinyEngine enables developers to customize low-code platforms, build low-bit platforms online in real time, and support secondary development or integration of low-bit platform capabilities.",
   "homepage": "https://opentiny.design/tiny-engine",

--- a/packages/engine-cli/package.json
+++ b/packages/engine-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-cli",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/engine-cli/package.json
+++ b/packages/engine-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-cli",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/engine-cli/template/designer/package.json
+++ b/packages/engine-cli/template/designer/package.json
@@ -11,8 +11,8 @@
     "serve:mock": "node node_modules/@opentiny/tiny-engine-mock/dist/app.js"
   },
   "dependencies": {
-    "@opentiny/tiny-engine": "^2.6.0",
-    "@opentiny/tiny-engine-utils": "^2.6.0",
+    "@opentiny/tiny-engine": "^2.6.1",
+    "@opentiny/tiny-engine-utils": "^2.6.1",
     "@opentiny/vue": "~3.20.0",
     "@opentiny/vue-design-smb": "~3.20.0",
     "@opentiny/vue-icon": "~3.20.0",
@@ -23,8 +23,8 @@
     "vue": "^3.4.21"
   },
   "devDependencies": {
-    "@opentiny/tiny-engine-mock": "^2.6.0",
-    "@opentiny/tiny-engine-vite-config": "^2.6.0",
+    "@opentiny/tiny-engine-mock": "^2.6.1",
+    "@opentiny/tiny-engine-vite-config": "^2.6.1",
     "@vitejs/plugin-vue": "^5.1.2",
     "cross-env": "^7.0.3",
     "vite": "^5.4.2",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-i18n-host",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-i18n-host",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-layout",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "scripts": {
     "build": "vite build"
   },

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-layout",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "scripts": {
     "build": "vite build"
   },

--- a/packages/plugins/block/package.json
+++ b/packages/plugins/block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-block",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/block/package.json
+++ b/packages/plugins/block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-block",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/bridge/package.json
+++ b/packages/plugins/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-bridge",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/bridge/package.json
+++ b/packages/plugins/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-bridge",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/datasource/package.json
+++ b/packages/plugins/datasource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-datasource",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/datasource/package.json
+++ b/packages/plugins/datasource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-datasource",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/help/package.json
+++ b/packages/plugins/help/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-help",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/help/package.json
+++ b/packages/plugins/help/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-help",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-i18n",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-i18n",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/materials/package.json
+++ b/packages/plugins/materials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-materials",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/materials/package.json
+++ b/packages/plugins/materials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-materials",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/page/package.json
+++ b/packages/plugins/page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-page",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/page/package.json
+++ b/packages/plugins/page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-page",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/robot/package.json
+++ b/packages/plugins/robot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-robot",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/robot/package.json
+++ b/packages/plugins/robot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-robot",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/schema/package.json
+++ b/packages/plugins/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-schema",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/schema/package.json
+++ b/packages/plugins/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-schema",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/script/package.json
+++ b/packages/plugins/script/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-script",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/script/package.json
+++ b/packages/plugins/script/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-script",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/state/package.json
+++ b/packages/plugins/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-state",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/state/package.json
+++ b/packages/plugins/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-state",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/tree/package.json
+++ b/packages/plugins/tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-tree",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/tree/package.json
+++ b/packages/plugins/tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-tree",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/tutorial/package.json
+++ b/packages/plugins/tutorial/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-tutorial",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugins/tutorial/package.json
+++ b/packages/plugins/tutorial/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-plugin-tutorial",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/register/package.json
+++ b/packages/register/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-meta-register",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/register/package.json
+++ b/packages/register/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-meta-register",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/register/src/service.ts
+++ b/packages/register/src/service.ts
@@ -30,6 +30,8 @@ type Service<T, K> = Pick<ServiceOptions<T, K>, 'id' | 'type' | 'options'> & {
  */
 const servicesMap = new Map()
 
+const _servicesMap = new Map()
+
 export const defineService = <T, K>(serviceOptions: ServiceOptions<T, K>): Service<T, K> => {
   const { id, type, initialState, options, init, apis } = serviceOptions
 
@@ -39,6 +41,10 @@ export const defineService = <T, K>(serviceOptions: ServiceOptions<T, K>): Servi
 
   if (type !== 'MetaService') {
     throw new Error('Invalid service type. Expected: MetaService')
+  }
+
+  if (_servicesMap.has(id)) {
+    return _servicesMap.get(id)
   }
 
   /**
@@ -72,6 +78,8 @@ export const defineService = <T, K>(serviceOptions: ServiceOptions<T, K>): Servi
     state,
     init: typeof init === 'function' ? init : () => {}
   })
+
+  _servicesMap.set(id, resultService)
 
   return resultService
 }

--- a/packages/settings/design/package.json
+++ b/packages/settings/design/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-setting-design",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/settings/design/package.json
+++ b/packages/settings/design/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-setting-design",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/settings/events/package.json
+++ b/packages/settings/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-setting-events",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/settings/events/package.json
+++ b/packages/settings/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-setting-events",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/settings/panel/package.json
+++ b/packages/settings/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-settings-panel",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/settings/panel/package.json
+++ b/packages/settings/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-settings-panel",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/settings/props/package.json
+++ b/packages/settings/props/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-setting-props",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/settings/props/package.json
+++ b/packages/settings/props/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-setting-props",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/settings/styles/package.json
+++ b/packages/settings/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-setting-styles",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/settings/styles/package.json
+++ b/packages/settings/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-setting-styles",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/svgs/package.json
+++ b/packages/svgs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-svgs",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/svgs/package.json
+++ b/packages/svgs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-svgs",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/theme/base/package.json
+++ b/packages/theme/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-theme-base",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/theme/base/package.json
+++ b/packages/theme/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-theme-base",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/breadcrumb/package.json
+++ b/packages/toolbars/breadcrumb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-breadcrumb",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/breadcrumb/package.json
+++ b/packages/toolbars/breadcrumb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-breadcrumb",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/clean/package.json
+++ b/packages/toolbars/clean/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-clean",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/clean/package.json
+++ b/packages/toolbars/clean/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-clean",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/collaboration/package.json
+++ b/packages/toolbars/collaboration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-collaboration",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/collaboration/package.json
+++ b/packages/toolbars/collaboration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-collaboration",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/fullscreen/package.json
+++ b/packages/toolbars/fullscreen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-fullscreen",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/fullscreen/package.json
+++ b/packages/toolbars/fullscreen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-fullscreen",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/generate-code/package.json
+++ b/packages/toolbars/generate-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-generate-code",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/generate-code/package.json
+++ b/packages/toolbars/generate-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-generate-code",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/lang/package.json
+++ b/packages/toolbars/lang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-lang",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/lang/package.json
+++ b/packages/toolbars/lang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-lang",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/lock/package.json
+++ b/packages/toolbars/lock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-lock",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/lock/package.json
+++ b/packages/toolbars/lock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-lock",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/logo/package.json
+++ b/packages/toolbars/logo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-logo",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/logo/package.json
+++ b/packages/toolbars/logo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-logo",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/media/package.json
+++ b/packages/toolbars/media/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-media",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/media/package.json
+++ b/packages/toolbars/media/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-media",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/preview/package.json
+++ b/packages/toolbars/preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-preview",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/preview/package.json
+++ b/packages/toolbars/preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-preview",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/redoundo/package.json
+++ b/packages/toolbars/redoundo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-redoundo",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/redoundo/package.json
+++ b/packages/toolbars/redoundo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-redoundo",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/refresh/package.json
+++ b/packages/toolbars/refresh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-refresh",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/refresh/package.json
+++ b/packages/toolbars/refresh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-refresh",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/save/package.json
+++ b/packages/toolbars/save/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-save",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/save/package.json
+++ b/packages/toolbars/save/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-save",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/setting/package.json
+++ b/packages/toolbars/setting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-setting",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/setting/package.json
+++ b/packages/toolbars/setting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-setting",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/themeSwitch/package.json
+++ b/packages/toolbars/themeSwitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-theme-switch",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/themeSwitch/package.json
+++ b/packages/toolbars/themeSwitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-theme-switch",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/view-setting/package.json
+++ b/packages/toolbars/view-setting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-view-setting",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/toolbars/view-setting/package.json
+++ b/packages/toolbars/view-setting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-toolbar-view-setting",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-utils",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-utils",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vue-generator/package.json
+++ b/packages/vue-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-dsl-vue",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vue-generator/package.json
+++ b/packages/vue-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-dsl-vue",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/webcomponent/package.json
+++ b/packages/webcomponent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-webcomponent-core",
-  "version": "2.6.0-alpha.10",
+  "version": "2.6.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/webcomponent/package.json
+++ b/packages/webcomponent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-engine-webcomponent-core",
-  "version": "2.6.0",
+  "version": "2.6.0-alpha.10",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

【问题描述】
1. 二开工程同时使用依赖 `@opentiny/tiny-engine` 和 `@opentiny/tiny-engine-common`
2. 启动项目时，会报错 `getMetaApi` 相关的实例或者是状态无法找到。比如：HttpService 示例为 null。

【问题分析】
1. 同时使用依赖 `@opentiny/tiny-engine` 和 `@opentiny/tiny-engine-common` 时，由于 `@opentiny/tiny-engine` 把 `@opentiny/tiny-engine-common` 打包进去了。所以会有两次的 `defineService`。

```
// @opntiny/tiny-engine-common
// 这里的会调用一遍 defineService，但是没有被任何地方调用。
const HttpService = defineService({
    //...
   
   init() {
   }
  // ...
})

// @opentiny/tiny-engine
// 这里的 HttpService 是实际上会被 getMetaApi 时候返回得到的示例
const HttpService = defineService({
    //...
   
   init() {
   },
   api: {
    //...
   }
  // ...
})

```
2. defineService 在 v2.6 #1365 的版本中，从 `weakMap` 改成了 `Map`，会导致两次重复的 defineService 时，后面一次覆盖前面一次的 defineService。
3. initService 的时候，使用 后面一次 `defineService` 得到的 `init` 方法。
4. 实际在使用的时候，获取的是注册表即 `@opentiny/tiny-engine` 的方法，但是由于 init 方法未被调用，所以得到示例和相关状态为空，导致相关报错。

【解决方案】

v2.6 方案：
在 defineService 的地方，增加是否已经注册的判断，如果已经注册了，则返回已经注册的实例。

v2.7 方案：
由于 v2.7 对所有的 @opentiny/tiny-enginexxx 依赖都做了 external，所以不会有多个 HttpService 被重复 defineService 的问题。


### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version numbers across multiple packages from 2.6.0 to 2.6.1.
  * Synchronized dependency versions in related demo and template projects.

* **Refactor**
  * Improved internal service handling to prevent duplicate service creation. No changes to public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->