### PR TITLE
fix: multiple data source issues: empty static data handling, length validation, and URL persistence

### DIFF
--- a/packages/plugins/datasource/src/DataSourceForm.vue
+++ b/packages/plugins/datasource/src/DataSourceForm.vue
@@ -43,8 +43,10 @@ import { camelize, capitalize } from '@vue/shared'
 import { ButtonGroup, PluginSetting, SvgButton } from '@opentiny/tiny-engine-common'
 import DataSourceType from './DataSourceType.vue'
 import DataSourceName, { getDataSourceName } from './DataSourceName.vue'
+import { getServiceForm } from './DataSourceRemoteForm.vue'
 import DataSourceSettings from './DataSourceSettings.vue'
 import { close as closeRemoteResult, open as openRemoteResult } from './DataSourceSettingRemoteResult.vue'
+import { getRecordGrid } from './DataSourceSettingRecordList.vue'
 import {
   requestUpdateDataSource,
   requestAddDataSource,
@@ -203,12 +205,20 @@ export default {
       })
     }
 
-    const save = () => {
-      getDataSourceName().validate((valid) => {
-        if (valid) {
-          close()
-          closeRemoteResult()
+    const activeTabChange = (name) => {
+      emit('activeTab', name)
+    }
 
+    const save = async () => {
+      try {
+        // await validate() 如果验证不通过会抛出异常，而不是返回 false
+        await getServiceForm().validate()
+      } catch (error) {
+        activeTabChange('remote')
+        throw new Error(`请先完成表单验证: ${error?.message || ''}`)
+      }
+      getDataSourceName().validate(async (valid) => {
+        if (valid) {
           const columns = state.dataSource.data.columns.map(({ name, title, type, format, field }) => {
             return {
               name,
@@ -218,6 +228,14 @@ export default {
               format
             }
           })
+
+          try {
+            // await validate() 如果验证不通过会抛出异常，而不是返回 false
+            await getRecordGrid().fullValidate()
+          } catch (error) {
+            activeTabChange('record')
+            throw new Error(`请先完成表格验证: ${error?.message || ''}`)
+          }
 
           settingRef.value.saveRecord().then((record) => {
             const editRequestData = {
@@ -254,6 +272,7 @@ export default {
                 emit('save')
                 dataSourceState.dataSourceColumn = {}
                 dataSourceState.dataSourceColumnCopies = {}
+                dataSourceState.remoteConfig = {}
               })
             } else {
               requestAddDataSource({
@@ -270,12 +289,17 @@ export default {
                   emit('save')
                   dataSourceState.dataSourceColumn = {}
                   dataSourceState.dataSourceColumnCopies = {}
+                  dataSourceState.remoteConfig = {}
                 })
                 .catch((error) => {
                   message({ message: `数据源保存失败：${error?.message || ''}`, status: 'error' })
                 })
             }
           })
+          close()
+          closeRemoteResult()
+        } else {
+          activeTabChange('field')
         }
       })
     }
@@ -296,10 +320,6 @@ export default {
 
     const renderRemoteData = (remoteData) => {
       emit('renderRemoteData', remoteData)
-    }
-
-    const activeTabChange = (name) => {
-      emit('activeTab', name)
     }
 
     watch(

--- a/packages/plugins/datasource/src/DataSourceForm.vue
+++ b/packages/plugins/datasource/src/DataSourceForm.vue
@@ -215,7 +215,7 @@ export default {
         await getServiceForm().validate()
       } catch (error) {
         activeTabChange('remote')
-        throw error
+        return
       }
       getDataSourceName().validate(async (valid) => {
         if (valid) {
@@ -234,7 +234,7 @@ export default {
             await getRecordGrid().fullValidate()
           } catch (error) {
             activeTabChange('record')
-            throw error
+            return
           }
 
           settingRef.value.saveRecord().then((record) => {

--- a/packages/plugins/datasource/src/DataSourceForm.vue
+++ b/packages/plugins/datasource/src/DataSourceForm.vue
@@ -215,7 +215,7 @@ export default {
         await getServiceForm().validate()
       } catch (error) {
         activeTabChange('remote')
-        throw new Error(`请先完成表单验证: ${error?.message || ''}`)
+        throw error
       }
       getDataSourceName().validate(async (valid) => {
         if (valid) {
@@ -234,7 +234,7 @@ export default {
             await getRecordGrid().fullValidate()
           } catch (error) {
             activeTabChange('record')
-            throw new Error(`请先完成表格验证: ${error?.message || ''}`)
+            throw error
           }
 
           settingRef.value.saveRecord().then((record) => {

--- a/packages/plugins/datasource/src/DataSourceForm.vue
+++ b/packages/plugins/datasource/src/DataSourceForm.vue
@@ -298,8 +298,6 @@ export default {
           })
           close()
           closeRemoteResult()
-        } else {
-          activeTabChange('field')
         }
       })
     }

--- a/packages/plugins/datasource/src/DataSourceList.vue
+++ b/packages/plugins/datasource/src/DataSourceList.vue
@@ -33,6 +33,7 @@ import { onMounted, reactive, ref } from 'vue'
 import { useResource, getMetaApi, META_SERVICE } from '@opentiny/tiny-engine-meta-register'
 import { fetchDataSourceList, fetchDataSourceDetail } from './js/http'
 import { SvgButton } from '@opentiny/tiny-engine-common'
+import { getServiceForm } from './DataSourceRemoteForm.vue'
 
 const dataSourceList = ref([])
 const activeIndex = ref(-1)
@@ -74,6 +75,7 @@ export default {
           data: { ...item.data, type: 'remote' }
         }
         emit('edit', editData)
+        getServiceForm()?.clearValidate()
       })
     }
 

--- a/packages/plugins/datasource/src/DataSourceSettingRecordList.vue
+++ b/packages/plugins/datasource/src/DataSourceSettingRecordList.vue
@@ -73,6 +73,12 @@ import { fetchDataSourceDetail } from './js/http'
 import { downloadFn, handleImportedData, overrideOrMergeData, getDataAfterPage } from './js/datasource'
 import DataSourceRecordUpload from './DataSourceRecordUpload.vue'
 
+const grid = ref(null)
+
+export const getRecordGrid = () => {
+  return grid.value
+}
+
 export default {
   components: {
     TinyGrid: Grid,
@@ -90,7 +96,6 @@ export default {
   },
   emits: ['edit'],
   setup(props, { emit }) {
-    const grid = ref(null)
     const { confirm } = useModal()
     const { PLUGIN_NAME, getPluginByLayout } = useLayout()
     const align = computed(() => getPluginByLayout(PLUGIN_NAME.Collections))

--- a/packages/plugins/datasource/src/DataSourceSettings.vue
+++ b/packages/plugins/datasource/src/DataSourceSettings.vue
@@ -20,6 +20,7 @@
           :data="state.currentData"
           ref="recordRef"
           @refresh="refresh()"
+          @edit="changeTab()"
         ></data-source-setting-record-list>
       </tiny-tab-item>
     </tiny-tabs>
@@ -93,6 +94,10 @@ export default {
       closeGlobalDataHandler()
     }
 
+    const changeTab = () => {
+      state.activeTabName = 'field'
+    }
+
     const tabClick = (e) => {
       state.activeTabName = e.name
       emit('activeTab', e.name)
@@ -144,6 +149,7 @@ export default {
       tabClick,
       renderRemoteData,
       refresh,
+      changeTab,
       saveRecord
     }
   }


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)



# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

修改内容： 
1. 静态数据无数据时点击新增字段无法点击
2. 数据源的数据有长度限制，但是实际依然可以点击保存，预期保存显示校验
3. 使用远程数据源的时候，在使用过后，新建一个数据源，会发现之前用过的链接会出现在新建的数据源

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved form validation with clearer error handling and automatic tab switching during the data source save process.
  * Enhanced user feedback by switching to relevant tabs when validation errors occur.
  * Automatically clears validation states when editing a data source.
  * Enabled tab switching to the "field" tab when editing records from the settings view.

* **Refactor**
  * Streamlined validation and save logic for a more consistent user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->