### PR TITLE
fix(page-tree): Restore page tree collapsed when clearing the search

### DIFF
--- a/packages/plugins/page/src/Tree.vue
+++ b/packages/plugins/page/src/Tree.vue
@@ -176,16 +176,17 @@ watch(
     const filtered = nodes.value.filter((node) => node.label.toLowerCase().includes(filterValue.toLowerCase()))
 
     let collapseMapChanged = false
-
-    filtered.forEach((node) => {
-      // 每个节点的祖先节点中，如果存在折叠的节点，则展开
-      for (const id of getAncestorIds(node.id)) {
-        if (collapseMap.value[id]) {
-          setCollapse(id, false)
-          collapseMapChanged = true
+    if (filterValue) {
+      filtered.forEach((node) => {
+        // 每个节点的祖先节点中，如果存在折叠的节点，则展开
+        for (const id of getAncestorIds(node.id)) {
+          if (collapseMap.value[id]) {
+            setCollapse(id, false)
+            collapseMapChanged = true
+          }
         }
-      }
-    })
+      })
+    }
 
     // - 如果 collapseMap 有变化，会自动重新计算 nodes，更新路径：
     //   props.filterValue -> collapseMap -> nodes -> filteredNodes -> filteredNodesWithAncestors


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->
手动收起页面树的时候，如果清除搜索后，已收起的页面且没被搜索到的也会自动展开
### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tree view behavior so that ancestor nodes are only expanded when a filter is applied, preventing unnecessary expansion when no filter is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->