### PR TITLE
fix: collapse toolbar will error when hiding tools

### DIFF
--- a/packages/layout/index.ts
+++ b/packages/layout/index.ts
@@ -4,7 +4,6 @@ import { LayoutService } from './src/composable'
 import designSmbConfig from '@opentiny/vue-design-smb'
 import { ConfigProvider as TinyConfigProvider } from '@opentiny/vue'
 import './src/styles/vars.less'
-import defaultLayout from './src/defaultLayout'
 
 export default {
   ...metaData,
@@ -13,8 +12,7 @@ export default {
     configProvider: TinyConfigProvider,
     configProviderDesign: designSmbConfig,
     isShowLine: true,
-    isShowCollapse: true,
-    layoutConfig: defaultLayout
+    isShowCollapse: true
   },
   metas: [LayoutService]
 }

--- a/packages/layout/src/ToolbarCollapse.vue
+++ b/packages/layout/src/ToolbarCollapse.vue
@@ -6,7 +6,7 @@
       </span>
     </template>
     <div class="collapse-content">
-      <div class="empty-bar" v-for="(item, idx) in collapseBar" :key="idx">
+      <div class="empty-bar" v-for="(item, idx) in renderCollapseBar" :key="idx">
         <div class="toolbar-list-button" v-if="typeof item === 'string'">
           <component
             :is="getMergeMeta(item)?.entry"
@@ -18,7 +18,7 @@
           <div class="toolbar-list-button" v-for="comp in item" :key="comp">
             <component
               :is="getMergeMeta(comp)?.entry"
-              :options="getMergeMeta(comp).options"
+              :options="getMergeMeta(comp)?.options"
               position="collapse"
             ></component>
           </div>
@@ -35,6 +35,8 @@ import { Popover } from '@opentiny/vue'
 import { IconPopup } from '@opentiny/vue-icon'
 import { getMergeMeta } from '@opentiny/tiny-engine-meta-register'
 import { constants } from '@opentiny/tiny-engine-utils'
+import { computed } from 'vue'
+
 const { OPEN_DELAY } = constants
 
 export default {
@@ -48,10 +50,29 @@ export default {
       default: () => []
     }
   },
-  setup() {
+  setup(props) {
+    const renderCollapseBar = computed(() => {
+      const result = props.collapseBar.map((item) => {
+        if (typeof item === 'string') {
+          return item
+        }
+
+        if (Array.isArray(item)) {
+          const subItem = item.filter((itemComp) => getMergeMeta(itemComp)?.entry)
+
+          return subItem.length > 0 ? subItem : null
+        }
+
+        return item
+      })
+
+      return result.filter((item) => Boolean(item))
+    })
+
     return {
       getMergeMeta,
-      OPEN_DELAY
+      OPEN_DELAY,
+      renderCollapseBar
     }
   }
 }

--- a/packages/layout/src/composable/useLayout.ts
+++ b/packages/layout/src/composable/useLayout.ts
@@ -391,13 +391,6 @@ export default () => {
     pluginStorageReactive.value = pluginList
   }
 
-  const getIsUserCustomLayout = () => {
-    const defaultLayoutString = JSON.stringify(defaultLayout)
-    const userLayoutString = JSON.stringify(getMergeMeta('engine.layout')?.options?.layoutConfig)
-
-    return defaultLayoutString !== userLayoutString
-  }
-
   const removeUndefineLayoutId = (layout) => {
     if (Array.isArray(layout)) {
       layout.forEach((item, index) => {
@@ -496,11 +489,10 @@ export default () => {
       return finalLayoutConfig
     }
 
-    const isUserCustomLayout = getIsUserCustomLayout()
+    const userCustomLayout = getMergeMeta('engine.layout')?.options?.layoutConfig
     // 用户传了自定义配置，则忽略 insertBefore insertAfter 的配置
-    if (isUserCustomLayout) {
-      finalLayoutConfig = getMergeMeta('engine.layout')?.options?.layoutConfig
-      return finalLayoutConfig
+    if (userCustomLayout) {
+      return userCustomLayout
     }
 
     const relativeLayoutConfig = getMergeMeta('engine.layout')?.options?.relativeLayoutConfig || {}


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

【问题描述】

问题一： v2.7 工具栏 collapse 隐藏部分工具时，可能会导致报错，分隔线条可能会导致重复渲染。
问题二： 使用 layoutConfig 全局替换，改变插件的位置，会导致重复渲染。

【问题分析】
问题一：
隐藏时，layoutconfig 仍然没有直接删减掉，使用 layoutConfig 全局替换时，也不会删减掉（注册表会进行深度 merge）

所以，当设置某一个工具栏为 false时：，会得到 `getMergeMeta(comp).options` 中的 `getMergeMeta(comp)` 为 undefined，访问 `.opotions` 属性导致报错：

```jsx
<component
  :is="getMergeMeta(comp)?.entry"
  :options="getMergeMeta(comp).options"
  position="collapse"
></component>
```

分隔线仍然重复渲染：

分组的 item 数组全部为时，仍然会进入 `v-if="Array.isArray(item)"` 的 整个大循环，导致 `empty-line` 渲染。

```jsx
<div v-if="Array.isArray(item)">
  <div class="toolbar-list-button" v-for="comp in item" :key="comp">
    <component
      :is="getMergeMeta(comp)?.entry"
      :options="getMergeMeta(comp)?.options"
      position="collapse"
    ></component>
  </div>
  <div class="empty-line"></div>
</div>
```

问题二：
layout 插件默认的 defaultLayout 放置到了默认的 options 里面，会跟用户的 options 进行深度的 merge，从而导致修改位置插件后，会导致重复的渲染。比如插件X从数组 A，移动到了数组B，此时数组A中的插件并X没有消失，同时数组B还新增了插件X。


【解决方案】
问题一：
提前对 `collapseBar` 进行过滤，在注册表无法找到的 id、或者 id 为空的，直接过滤掉。

问题二：
在 layout 插件的默认 options 中，移除默认的  layoutConfig。

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the rendering of collapse bar items to handle invalid or missing entries more gracefully, reducing the chance of errors or empty elements appearing in the toolbar.
* **Refactor**
  * Enhanced internal logic for processing collapse bar items, resulting in more reliable and maintainable toolbar behavior.
  * Simplified layout configuration handling by directly using user custom layouts when available, improving layout management consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->