### PR TITLE
feat: sync page state and global state saving behavior

### DIFF
--- a/packages/plugins/state/src/Main.vue
+++ b/packages/plugins/state/src/Main.vue
@@ -230,7 +230,7 @@ export default {
 
       if (activeName.value === STATE.CURRENT_STATE) {
         // 校验
-        variableRef.value.validateForm().then(() => {
+        variableRef.value.validateForm().then(async () => {
           // 获取数据
           const variable = variableRef.value.getFormData()
 
@@ -243,7 +243,17 @@ export default {
           updateSchema({ state: { ...(schema.state || {}), [name]: variable } })
 
           useHistory().addHistory()
-          openCommon()
+
+          const isFixed = props.fixedPanels.includes(PLUGIN_NAME.State)
+          // 如果面板没有固定，临时固定，避免因保存时清空选中状态导致的面板关闭
+          if (!isFixed) {
+            useLayout().changeLeftFixedPanels(PLUGIN_NAME.State)
+          }
+          await openCommon()
+          // 恢复原来固定的状态
+          if (!isFixed) {
+            useLayout().changeLeftFixedPanels(PLUGIN_NAME.State)
+          }
         })
       } else {
         storeRef.value.validateForm().then(() => {
@@ -276,6 +286,7 @@ export default {
           updateGlobalState(id, { global_state: storeList }).then((res) => {
             isPanelShow.value = false
             useResource().appSchemaState.globalState = res.global_state || []
+            useNotify({ message: '保存成功!', type: 'success' })
           })
           openCommon()
         })

--- a/packages/toolbars/save/src/js/index.ts
+++ b/packages/toolbars/save/src/js/index.ts
@@ -173,7 +173,7 @@ export const openCommon = async () => {
         }
    */
 
-  saveCommon(state.code).finally(() => {
+  return saveCommon(state.code).finally(() => {
     state.disabled = false
 
     if (typeof saved === 'function') {


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved panel behavior to prevent it from closing unexpectedly during variable saving.
  * Success notification is now shown after saving global state data.

* **Refactor**
  * Enhanced internal handling of asynchronous save operations for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->