### PR TITLE
fix: preview ancestor has folder will get plain page

### DIFF
--- a/packages/design-core/src/preview/src/preview/usePreviewData.ts
+++ b/packages/design-core/src/preview/src/preview/usePreviewData.ts
@@ -14,6 +14,7 @@ interface IPage {
   id: number
   name: string
   parentId: number | string
+  isPage: boolean
   page_content: {
     [key: string]: any
     componentName: string
@@ -76,7 +77,7 @@ const getPageOrBlockByApi = async (): Promise<{ currentPage: IPage | null; ances
   const history = searchParams.get('history')
 
   if (pageId) {
-    let ancestors = (await getPageRecursively(pageId)).reverse()
+    let ancestors = (await getPageRecursively(pageId)).reverse().filter((item) => item.isPage)
     let currentPage = await getPageById(pageId)
     if (history) {
       const historyList: IPage[] = await fetchPageHistory(pageId)

--- a/packages/design-core/src/preview/src/preview/usePreviewData.ts
+++ b/packages/design-core/src/preview/src/preview/usePreviewData.ts
@@ -78,6 +78,11 @@ const getPageOrBlockByApi = async (): Promise<{ currentPage: IPage | null; ances
 
   if (pageId) {
     let ancestors = (await getPageRecursively(pageId)).reverse().filter((item) => item.isPage)
+    // 避免祖先页面第一个为文件夹，导致没有 ROOT_ID，导致设置 Main.vue 失败
+    if (ancestors.length && ancestors[0]?.parentId !== ROOT_ID) {
+      ancestors[0].parentId = ROOT_ID
+    }
+
     let currentPage = await getPageById(pageId)
     if (history) {
       const historyList: IPage[] = await fetchPageHistory(pageId)
@@ -198,6 +203,13 @@ const getPageAncestryFiles = (
         index: false
       })
     }
+  }
+
+  const hasMainPage = familyPages.some((item) => item.panelName === 'Main.vue' && item.index)
+
+  if (!hasMainPage && familyPages.length) {
+    familyPages[0].index = true
+    familyPages[0].panelName = 'Main.vue'
   }
 
   return familyPages


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

【问题描述】
使用 url 预览页面时（即非实时预览模式），如果祖先页面有文件夹，则会预览得到空页面。

【问题分析】
如果有文件夹的时候，文件夹出码得到的是空 div。

【问题修复方案】
获取祖先页面的时候，过滤文件夹。

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved ancestor filtering to display only actual pages in the ancestors list.
  * Ensured a main page is always designated as the index in ancestry files for better navigation consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->