### PR TITLE
fix：application state getters cannot be rendered

### DIFF
--- a/packages/canvas/render/src/application-function/global-state.ts
+++ b/packages/canvas/render/src/application-function/global-state.ts
@@ -22,7 +22,7 @@ export function useGlobalState() {
           Object.entries(getters).forEach(([key, getterDef]: [string, any]) => {
             try {
               if (getterDef?.type === 'JSFunction' && getterDef.value) {
-                const getterFn = new Function(`return (${getterDef.value})`)() as Function
+                const getterFn = new Function(`return (${getterDef.value})`)()
                 const computedGetter = computed(() => {
                   try {
                     return getterFn.call(store, reactiveState)

--- a/packages/canvas/render/src/application-function/global-state.ts
+++ b/packages/canvas/render/src/application-function/global-state.ts
@@ -1,28 +1,55 @@
-import { ref, shallowReactive, watchEffect } from 'vue'
+import { ref, shallowReactive, watchEffect, reactive, computed } from 'vue'
 import { reset } from '../data-utils'
 
-const Func = Function
-
 export function useGlobalState() {
-  const globalState = ref([])
+  const globalState = ref<any[]>([])
 
-  const setGlobalState = (data = []) => {
+  const setGlobalState = (data: any[] = []) => {
     globalState.value = data
   }
-  const stores = shallowReactive({})
+
+  const stores = shallowReactive<Record<string, any>>({})
+
   watchEffect(() => {
     reset(stores)
+    
     globalState.value.forEach(({ id, state = {}, getters = {} }) => {
-      const computedGetters = Object.keys(getters).reduce(
-        (acc, key) => ({
-          ...acc,
-          [key]: new Func('return ' + getters[key])().call(acc, state) // parseData(getters[key], null, acc)?.call?.(acc, state)  //理论上不应该走parseData, unibuy代码遗留
-        }),
-        {}
-      )
-      stores[id] = { ...state, ...computedGetters }
+      try {
+        const reactiveState = reactive({ ...state })
+        const store = reactive({ ...reactiveState })
+        
+        if (getters && typeof getters === 'object') {
+          Object.entries(getters).forEach(([key, getterDef]: [string, any]) => {
+            try {
+              if (getterDef?.type === 'JSFunction' && getterDef.value) {
+                const getterFn = new Function(`return (${getterDef.value})`)() as Function
+                const computedGetter = computed(() => {
+                  try {
+                    return getterFn.call(store, reactiveState)
+                  } catch (error) {
+                    console.error(`[useGlobalState] Error in getter "${key}" (store ${id}):`, error)
+                    return null
+                  }
+                })
+
+                Object.defineProperty(store, key, {
+                  get: () => computedGetter.value,
+                  enumerable: true,
+                })
+              }
+            } catch (parseError) {
+              console.error(`[useGlobalState] Invalid getter "${key}" in store ${id}:`, parseError)
+            }
+          })
+        }
+        
+        stores[id] = store
+      } catch (storeError) {
+        console.error(`[useGlobalState] Failed to create store "${id}":`, storeError)
+      }
     })
   })
+
   return {
     globalState,
     setGlobalState,

--- a/packages/canvas/render/src/application-function/global-state.ts
+++ b/packages/canvas/render/src/application-function/global-state.ts
@@ -12,12 +12,12 @@ export function useGlobalState() {
 
   watchEffect(() => {
     reset(stores)
-    
+
     globalState.value.forEach(({ id, state = {}, getters = {} }) => {
       try {
         const reactiveState = reactive({ ...state })
         const store = reactive({ ...reactiveState })
-        
+
         if (getters && typeof getters === 'object') {
           Object.entries(getters).forEach(([key, getterDef]: [string, any]) => {
             try {
@@ -27,24 +27,25 @@ export function useGlobalState() {
                   try {
                     return getterFn.call(store, reactiveState)
                   } catch (error) {
-                    console.error(`[useGlobalState] Error in getter "${key}" (store ${id}):`, error)
                     return null
                   }
                 })
 
                 Object.defineProperty(store, key, {
                   get: () => computedGetter.value,
-                  enumerable: true,
+                  enumerable: true
                 })
               }
             } catch (parseError) {
+              // eslint-disable-next-line no-console
               console.error(`[useGlobalState] Invalid getter "${key}" in store ${id}:`, parseError)
             }
           })
         }
-        
+
         stores[id] = store
       } catch (storeError) {
+        // eslint-disable-next-line no-console
         console.error(`[useGlobalState] Failed to create store "${id}":`, storeError)
       }
     })


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
问题现状：
1.节点绑定全局状态state，设置循环渲染，画布不会正常渲染
2.节点绑定全局状态getter，画布不会正常渲染

### What is the current behavior?

问题1：
![3291759216231_ pic](https://github.com/user-attachments/assets/08cdd54f-3d98-4fa5-938c-b787b3eb7ff3)
![3331759216694_ pic](https://github.com/user-attachments/assets/b9b2be6a-372a-45d5-85b2-0d82922d2d05)
![3281759216230_ pic](https://github.com/user-attachments/assets/19203725-45e9-45cf-8b23-c3001150992c)

问题2：
![3301759216315_ pic](https://github.com/user-attachments/assets/0a4d0227-f5bd-4238-9ed1-4e58dab7b21f)
![3311759216315_ pic](https://github.com/user-attachments/assets/9c68a009-e94b-4705-8c14-05e393ecc34a)
![3321759216315_ pic](https://github.com/user-attachments/assets/d404a8ab-2fb5-42d8-a47b-bc88d2357284)


### What is the new behavior?
当前getter执行时this指向不正确，并且store不是响应式的；所以调整了getter的this指向，使用reactive和computed确保数据响应性
修复后渲染效果如下：
![3341759216694_ pic](https://github.com/user-attachments/assets/6ac488c7-fabf-44ba-b861-81c28f38ce12)
![3351759216734_ pic](https://github.com/user-attachments/assets/9bea4a3f-f781-4230-af6a-6b0328f6d7ca)


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced global state management for improved reliability and reactivity.
  * Getters are now more robust and provide better error handling, resulting in a more stable user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->