### PR TITLE
fix(styles): increase selector specificity to fix ColorInput padding

### DIFF
--- a/packages/configurator/src/color-configurator/ColorConfigurator.vue
+++ b/packages/configurator/src/color-configurator/ColorConfigurator.vue
@@ -71,7 +71,7 @@ export default {
     .tiny-input__prefix {
       left: 2px;
     }
-    .tiny-input__inner {
+    .tiny-input__inner.tiny-input__inner {
       padding-left: 24px;
       padding-right: 8px;
       background-color: transparent;

--- a/packages/settings/styles/src/components/inputs/NumericSelect.vue
+++ b/packages/settings/styles/src/components/inputs/NumericSelect.vue
@@ -122,7 +122,7 @@ export default {
       padding-right: 22px;
     }
 
-    .tiny-numeric__unit {
+    .tiny-numeric__unit.tiny-numeric__unit {
       font-size: 12px;
       color: var(--te-styles-common-text-color-weaken);
       background-color: var(--te-styles-common-bg-color);


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

【问题描述】
<img width="568" height="133" alt="image" src="https://github.com/user-attachments/assets/af5ded65-9c3e-4a38-86db-dc1623823e2b" />

<img width="462" height="169" alt="image" src="https://github.com/user-attachments/assets/bc6665df-1005-4130-a6d4-e2e8424649aa" />

color Input 的 padding 样式权重与主题默认 input padding 样式权重一样，在二开平台中，如果主题样式后加载，则会造成 color Input 的 padding 样式失效。

失效效果：
<img width="321" height="115" alt="image" src="https://github.com/user-attachments/assets/cd605712-bed1-46a2-95a9-6ff19499a91f" />

【修复方案】
- 在 packages/configurator/src/color-configurator/ColorConfigurator.vue 中，将 .tiny-input__inner 提升为 .tiny-input__inner.tiny-input__inner，确保存在前缀图标时的左侧内边距不被覆盖。 
- 在 packages/settings/styles/src/components/inputs/NumericSelect.vue 中，将 .tiny-numeric__unit 提升为 .tiny-numeric__unit.tiny-numeric__unit，避免背景色被主题覆盖。

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Harmonized scoped CSS selectors in Color Configurator and Numeric Select components to align with deep selector conventions. No visual, behavioral, or interaction changes; styling remains consistent across themes and states.
* **Chores**
  * Minor maintenance to keep styles aligned with component library patterns. No impact on performance, accessibility, or settings. No API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->