### PR TITLE
feat: introduce react-to-dsl plugin

### DIFF
--- a/packages/react-to-dsl/.gitignore
+++ b/packages/react-to-dsl/.gitignore
@@ -1,0 +1,2 @@
+output
+result

--- a/packages/react-to-dsl/.gitignore
+++ b/packages/react-to-dsl/.gitignore
@@ -1,2 +1,1 @@
 output
-result

--- a/packages/react-to-dsl/README.md
+++ b/packages/react-to-dsl/README.md
@@ -1,0 +1,33 @@
+# @opentiny/tiny-engine-react-to-dsl
+
+将 React 源码（JSX/TSX）转换为 TinyEngine DSL（IAppSchema）。
+
+- 输入：React 组件源码字符串
+- 输出：IAppSchema 对象，包含一个 Page 的 children 树（最小能力）
+
+使用示例：
+
+```ts
+import { transformReactToDsl } from '@opentiny/tiny-engine-react-to-dsl'
+
+const code = `
+export default function App(){
+  return <div className="box"><h1 title="t">Hello</h1></div>
+}
+`
+
+const dsl = transformReactToDsl(code, { filename: 'App.tsx' })
+console.log(dsl.pageSchema[0].children)
+```
+
+现状：
+
+- 仅支持从函数组件的 return 中提取首个 JSXElement
+- JSX 属性、表达式容器会被转成 props 的字面值或 JSExpression
+- 文本子节点会转成一个 span 节点
+
+后续可扩展：
+
+- 类组件、Fragment、多返回路径
+- 事件与 state、方法、生命周期提取
+- 组件依赖收集并填充 componentsMap

--- a/packages/react-to-dsl/README.md
+++ b/packages/react-to-dsl/README.md
@@ -23,17 +23,6 @@
 pnpm add @opentiny/tiny-engine-react-to-dsl
 ```
 
-## 测试
-
-使用 Vitest 进行单元与集成测试：
-
-```bash
-pnpm install
-pnpm test
-# 或
-npx vitest run
-```
-
 ## 目录结构
 
 ```text
@@ -126,3 +115,49 @@ function transformReactToDsl(code: string, options?: TransformOptions): IAppSche
 ```bash
 pnpm build
 ```
+
+## 测试
+
+使用 Vitest 进行单元与集成测试：
+
+```bash
+pnpm install
+pnpm test
+# 或
+npx vitest run
+```
+
+### 测试用例说明
+
+集成用例位于 `test/testcases/`，每个用例目录遵循：
+
+- `input/`：包含 1 个 `.jsx/.tsx` 源文件与可选的 `.css` 文件（会被拼接后注入到 `page.css`）
+- `output/`：测试执行后会生成 `app.schema.json` 与首个 `page.schema.json`，便于对照查看
+
+具体用例与断言覆盖点：
+
+- 001_normal
+  - 覆盖点：
+    - CSS 注入：校验注入的样式中包含 `.main-body`
+    - Tiny 组件存在：`TinyForm`、`TinyGrid` 等
+    - 列表渲染识别：`state.buttons.map(...)` 识别为子节点的 `loop: { type: 'JSExpression', value: 'state.buttons' }`
+    - 方法提取：`getTableData`、`handleSearch` 被收集到 `page.methods`
+
+- 002_data-binding
+  - 覆盖点：
+    - 数据绑定保持表达式：`value` 与 `checked` 转为 `{ type: 'JSExpression', value: 'state.xxx' }`
+
+- 003_createVM
+  - 覆盖点：
+    - 组件名映射（antd -> Tiny）：
+      - `Steps -> TinyTimeLine`
+      - `Input.Search -> TinySearch`
+      - `Radio.Group -> TinyButtonGroup`
+      - `Select -> TinySelect`
+    - 图标特殊映射：`DatabaseOutlined -> Icon` 且 `props.name = 'IconPanelMini'`
+    - 样式规范化：对象样式被转为字符串（如 `padding-bottom: 10px`）
+
+- 004_lifecycle
+  - 覆盖点：
+    - 类组件生命周期提取：`componentDidMount`、`componentWillUnmount`、`componentDidUpdate`、`componentDidCatch`
+    - 类字段方法提取：`handleClick` 出现在 `page.methods`

--- a/packages/react-to-dsl/README.md
+++ b/packages/react-to-dsl/README.md
@@ -1,11 +1,55 @@
 # @opentiny/tiny-engine-react-to-dsl
 
-将 React 源码（JSX/TSX）转换为 TinyEngine DSL（IAppSchema）。
+> 将 React 代码（JSX）反向转换为 TinyEngine DSL Schema 的工具包
 
-- 输入：React 组件源码字符串
-- 输出：IAppSchema 对象，包含一个 Page 的 children 树（最小能力）
+## 简介
 
-使用示例：
+`@opentiny/tiny-engine-react-to-dsl` 解析 React 组件源码，生成可用于 TinyEngine 的 DSL Schema（IAppSchema）。当前聚焦“单文件源码 → 单个 Page/Block 的 Schema”，便于在设计器或运行时加载。
+
+## 主要特性
+
+- 解析 JSX/TSX，生成 children 树；JS 表达式以 `{ type: 'JSExpression', value }` 保留
+- 提取函数组件体内的函数声明/箭头函数为 `page.methods`
+- 支持类组件的生命周期方法（如 componentDidMount 等）与类方法提取
+- 识别最常见的 `arr.map(x => <JSX />)` 简单循环为 `node.loop`
+- 支持 `props.style` 对象到 CSS 字符串的规范化
+- 内置组件名映射（如 `Form` -> `TinyForm`、`Input` -> `TinyInput` 等），含个别图标特殊映射
+- 可注入样式字符串（整合外部 .css 内容）
+- TypeScript 实现并导出类型；提供 Vitest 单测与用例输出
+
+## 安装
+
+```bash
+pnpm add @opentiny/tiny-engine-react-to-dsl
+```
+
+## 测试
+
+使用 Vitest 进行单元与集成测试：
+
+```bash
+pnpm install
+pnpm test
+# 或
+npx vitest run
+```
+
+## 目录结构
+
+```text
+src/
+├─ index.ts        # 包导出入口（types 与 transform）
+├─ transform.ts    # 核心转换：React 源码 -> IAppSchema
+├─ types.ts        # DSL 相关类型（IAppSchema/IPageSchema/JSExpression 等）
+├─ constants.ts    # 组件名映射（React 组件名 -> Tiny 组件名）
+└─ utils.ts        # 工具函数（如 8 位 id 生成）
+
+test/
+├─ basic/          # 基础单测（Vitest）
+└─ testcases/      # 集成用例：输入 jsx/css，输出 app/page schema.json
+```
+
+## 快速开始
 
 ```ts
 import { transformReactToDsl } from '@opentiny/tiny-engine-react-to-dsl'
@@ -16,18 +60,69 @@ export default function App(){
 }
 `
 
-const dsl = transformReactToDsl(code, { filename: 'App.tsx' })
-console.log(dsl.pageSchema[0].children)
+const app = transformReactToDsl(code, { filename: 'App.jsx' })
+// Page Schema
+console.log(app.pageSchema[0])
+// children 树
+console.log(app.pageSchema[0].children)
 ```
 
-现状：
+注入额外 CSS 并输出为 Block：
 
-- 仅支持从函数组件的 return 中提取首个 JSXElement
-- JSX 属性、表达式容器会被转成 props 的字面值或 JSExpression
-- 文本子节点会转成一个 span 节点
+```ts
+const css = `.box { color: #333; }`
+const app = transformReactToDsl(code, { filename: 'App.jsx', css })
+console.log(app.pageSchema[0])
+```
 
-后续可扩展：
+## API
 
-- 类组件、Fragment、多返回路径
-- 事件与 state、方法、生命周期提取
-- 组件依赖收集并填充 componentsMap
+函数：
+
+```ts
+function transformReactToDsl(code: string, options?: TransformOptions): IAppSchema
+```
+
+参数（TransformOptions）：
+
+- filename?: string — 源码文件名（用于填充 `page.fileName`）
+- isBlock?: boolean — 是否输出 Block（默认输出 Page）
+- css?: string | string[] — 附加样式内容（可传入多段 CSS 合并）
+
+返回：`IAppSchema`，结构要点：
+
+- `pageSchema: [ IPageSchema ]`：当前只生成一个 Page/Block
+- `page.children: ISchemaChildrenItem[]`：由 JSX 转换而来
+- `page.methods`：从组件体内识别的函数/方法
+- `page.lifeCycles`：类组件生命周期
+- `i18n/utils/dataSource/globalState/componentsMap/meta`：预留/占位（按需扩展）
+
+类型：从包入口导出，详见 `src/types.ts`。
+
+## 组件映射（默认）
+
+定义于 `src/constants.ts`，示例：
+
+- Form -> TinyForm
+- Form.Item -> TinyFormItem
+- Button -> TinyButton
+- Radio.Group -> TinyButtonGroup
+- Select -> TinySelect
+- Input.Search -> TinySearch
+- Input -> TinyInput
+- Grid -> TinyGrid
+- Grid.Item -> TinyGridItem
+- Col -> TinyCol
+- Row -> TinyRow
+- Steps -> TinyTimeLine
+- Typography.Text -> Text
+
+特殊处理：当遇到 `DatabaseOutlined` 时，会映射为 `Icon`，并附加 `props.name = 'IconPanelMini'`。
+
+集成用例会把转换结果写入 `test/testcases/**/output/` 下的 `app.schema.json` 与 `page.schema.json`，便于对比与调试。
+
+## 构建
+
+```bash
+pnpm build
+```

--- a/packages/react-to-dsl/package.json
+++ b/packages/react-to-dsl/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@opentiny/tiny-engine-react-to-dsl",
+  "version": "0.1.0",
+  "description": "Transform React source code (JSX/TSX) to TinyEngine DSL schema.",
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opentiny/tiny-engine",
+    "directory": "packages/react-to-dsl"
+  },
+  "bugs": {
+    "url": "https://github.com/opentiny/tiny-engine/issues"
+  },
+  "author": "OpenTiny Team",
+  "license": "MIT",
+  "homepage": "https://opentiny.design/tiny-engine",
+  "dependencies": {
+    "@babel/generator": "~7.23.2",
+    "@babel/parser": "~7.23.2",
+    "@babel/traverse": "~7.23.2",
+    "nanoid": "^5.0.7"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.28.2",
+    "@babel/types": "^7.28.2",
+    "@types/babel__generator": "^7.27.0",
+    "@types/babel__traverse": "^7.28.0",
+    "typescript": "~5.4.5",
+    "vite": "^5.4.2",
+    "vitest": "^1.6.0"
+  },
+  "peerDependencies": {
+    "react": ">=17",
+    "react-dom": ">=17"
+  }
+}

--- a/packages/react-to-dsl/src/constants.ts
+++ b/packages/react-to-dsl/src/constants.ts
@@ -28,3 +28,14 @@ export const defaultComponentMap: Record<string, string> = {
   AntdText: 'Text',
   AntdTable: 'TinyGrid'
 }
+
+// 组件属性映射示例：key 为“映射后的组件名”，值为属性级规则
+export const defaultPropMap: Record<string, Record<string, { rename?: string; mapValue?: (v: any) => any }>> = {
+  TinyForm: {
+    labelCol: { rename: 'label-position' }
+  },
+  TinyFormItem: {
+    label: { rename: 'label' }
+  }
+  // 待补充...
+}

--- a/packages/react-to-dsl/src/constants.ts
+++ b/packages/react-to-dsl/src/constants.ts
@@ -1,0 +1,15 @@
+export const defaultComponentMap: Record<string, string> = {
+  Form: 'TinyForm',
+  'Form.Item': 'TinyFormItem',
+  Button: 'TinyButton',
+  'Radio.Group': 'TinyButtonGroup',
+  Select: 'TinySelect',
+  'Input.Search': 'TinySearch',
+  Input: 'TinyInput',
+  Grid: 'TinyGrid',
+  'Grid.Item': 'TinyGridItem',
+  Col: 'TinyCol',
+  Row: 'TinyRow',
+  Steps: 'TinyTimeLine',
+  'Typography.Text': 'Text'
+}

--- a/packages/react-to-dsl/src/constants.ts
+++ b/packages/react-to-dsl/src/constants.ts
@@ -11,5 +11,6 @@ export const defaultComponentMap: Record<string, string> = {
   Col: 'TinyCol',
   Row: 'TinyRow',
   Steps: 'TinyTimeLine',
-  'Typography.Text': 'Text'
+  'Typography.Text': 'Text',
+  Table: 'TinyGrid'
 }

--- a/packages/react-to-dsl/src/constants.ts
+++ b/packages/react-to-dsl/src/constants.ts
@@ -12,5 +12,19 @@ export const defaultComponentMap: Record<string, string> = {
   Row: 'TinyRow',
   Steps: 'TinyTimeLine',
   'Typography.Text': 'Text',
-  Table: 'TinyGrid'
+  Table: 'TinyGrid',
+  AntdForm: 'TinyForm',
+  AntdFormItem: 'TinyFormItem',
+  AntdButton: 'TinyButton',
+  AntdButtonGroup: 'TinyButtonGroup',
+  AntdSelect: 'TinySelect',
+  AntdSearch: 'TinySearch',
+  AntdInput: 'TinyInput',
+  AntdGrid: 'TinyGrid',
+  AntdGridItem: 'TinyGridItem',
+  AntdCol: 'TinyCol',
+  AntdRow: 'TinyRow',
+  AntdTimeLine: 'TinyTimeLine',
+  AntdText: 'Text',
+  AntdTable: 'TinyGrid'
 }

--- a/packages/react-to-dsl/src/index.ts
+++ b/packages/react-to-dsl/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export { transformReactToDsl } from './transform'

--- a/packages/react-to-dsl/src/transform.ts
+++ b/packages/react-to-dsl/src/transform.ts
@@ -538,6 +538,52 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
     // ignore mapping errors
   }
 
+  // 受控表单双向绑定规范化：将 value/checked = state.xxx 的场景标记为 model，并移除 onChange
+  try {
+    const walk = (nodes: ISchemaChildrenItem[] | undefined) => {
+      if (!nodes) return
+      for (const n of nodes) {
+        const p: any = n.props || {}
+        const isJSExpr = (v: any) => v && typeof v === 'object' && v.type === 'JSExpression'
+        const matchesStatePath = (code: string) => /(?:^|\b)(?:this\.)?state\.[A-Za-z_$][\w$]*/.test(code)
+        // 处理 value
+        if (p.value && isJSExpr(p.value) && matchesStatePath(p.value.value)) {
+          // 统一加上 this. 前缀，便于运行时解析
+          if (!/^this\./.test(p.value.value)) {
+            p.value = { ...p.value, value: `this.${p.value.value}`, model: true }
+          } else {
+            p.value = { ...p.value, model: true }
+          }
+          // 删除 onChange（由 model 接管）
+          if (p.onChange) delete p.onChange
+        }
+        // 处理 modelValue（Tiny 组件）
+        if (p.modelValue && isJSExpr(p.modelValue) && matchesStatePath(p.modelValue.value)) {
+          if (!/^this\./.test(p.modelValue.value)) {
+            p.modelValue = { ...p.modelValue, value: `this.${p.modelValue.value}`, model: true }
+          } else {
+            p.modelValue = { ...p.modelValue, model: true }
+          }
+          if (p.onChange) delete p.onChange
+        }
+        // 处理 checked
+        if (p.checked && isJSExpr(p.checked) && matchesStatePath(p.checked.value)) {
+          if (!/^this\./.test(p.checked.value)) {
+            p.checked = { ...p.checked, value: `this.${p.checked.value}`, model: true }
+          } else {
+            p.checked = { ...p.checked, model: true }
+          }
+          if (p.onChange) delete p.onChange
+        }
+        n.props = p
+        if (n.children && n.children.length) walk(n.children)
+      }
+    }
+    walk(page.children)
+  } catch (e) {
+    // ignore model normalization errors
+  }
+
   const appSchema: IAppSchema = {
     i18n: { en_US: {}, zh_CN: {} },
     utils: [],

--- a/packages/react-to-dsl/src/transform.ts
+++ b/packages/react-to-dsl/src/transform.ts
@@ -300,6 +300,24 @@ function arrowToFunctionCode(name: string | undefined, node: any): string {
   return `${asyncPrefix}function${namePart}(${params}) ${bodyCode}`
 }
 
+// 将 ClassMethod 转为具名函数源码（用于生命周期重命名）
+function classMethodToNamedFunctionCode(name: string, node: any): string {
+  const params = (node.params || []).map((p: any) => generate(p).code).join(', ')
+  const asyncPrefix = (node as any).async ? 'async ' : ''
+  const body = (node as any).body
+  const bodyCode = body && body.type === 'BlockStatement' ? generate(body).code : '{ }'
+  return `${asyncPrefix}function ${name}(${params}) ${bodyCode}`
+}
+
+// 提取类方法体中的语句源码（不包含函数头与花括号）
+function getMethodBodyCode(node: any): string {
+  const body = node && node.body
+  if (body && body.type === 'BlockStatement' && Array.isArray(body.body)) {
+    return body.body.map((s: any) => generate(s).code).join('\n')
+  }
+  return ''
+}
+
 // 递归应用组件名映射（如 antd -> TinyVue）
 function styleObjToCss(obj: any): any {
   if (!obj || typeof obj === 'string') return obj
@@ -519,22 +537,55 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
     if (componentClassPath && componentClassPath.node && componentClassPath.node.body) {
       const classBody = componentClassPath.node.body.body || []
       const lifeCycleRecord: Record<string, any> = {}
-      const lifecycleNames = new Set([
-        'constructor',
-        'componentDidMount',
-        'componentWillUnmount',
-        'componentDidUpdate',
-        'componentDidCatch',
-        'shouldComponentUpdate',
-        'getSnapshotBeforeUpdate',
-        'componentWillReceiveProps'
-      ])
+      // 预处理：收集 constructor 中除 super(...) 外的语句，稍后合并到 onMounted
+      let constructorExtraCode = ''
+      const ctor = classBody.find(
+        (m: any) => m && m.type === 'ClassMethod' && (m.kind === 'constructor' || m.key?.name === 'constructor')
+      ) as any
+      if (ctor && ctor.body && Array.isArray(ctor.body.body)) {
+        const filtered = ctor.body.body.filter((s: any) => {
+          if (s.type !== 'ExpressionStatement') return true
+          const e = s.expression
+          return !(e && e.type === 'CallExpression' && e.callee && e.callee.type === 'Super')
+        })
+        constructorExtraCode = filtered.map((s: any) => generate(s).code).join('\n')
+      }
+      // React -> Vue3 DSL 生命周期映射
+      const reactToVueLifeMap: Record<string, string> = {
+        componentWillMount: 'onBeforeMount',
+        componentDidMount: 'onMounted',
+        componentWillUnmount: 'onBeforeUnmount',
+        componentDidUpdate: 'onUpdated',
+        componentDidCatch: 'onErrorCaptured',
+        shouldComponentUpdate: 'onBeforeUpdate',
+        getSnapshotBeforeUpdate: 'onBeforeUpdate',
+        componentWillReceiveProps: 'onBeforeUpdate'
+      }
+      const lifecycleNames = new Set(['constructor'].concat(Object.keys(reactToVueLifeMap)))
       for (const m of classBody) {
         if (m.type === 'ClassMethod' && m.key && (m.key.type === 'Identifier' || m.key.type === 'StringLiteral')) {
           const name = m.key.type === 'Identifier' ? m.key.name : String(m.key.value)
           if (name === 'render') continue
           if (lifecycleNames.has(name)) {
-            lifeCycleRecord[name] = { type: 'JSFunction', value: generate(m).code }
+            const vueLife = reactToVueLifeMap[name]
+            if (vueLife) {
+              if (vueLife === 'onMounted') {
+                // onMounted 需要合并 constructor 的语句
+                const mountBody = getMethodBodyCode(m)
+                const merged = [constructorExtraCode, mountBody].filter(Boolean).join('\n')
+                const value = `function onMounted() {\n${merged}\n}`
+                lifeCycleRecord[vueLife] = { type: 'JSFunction', value }
+              } else if (vueLife === 'onBeforeUpdate' && name === 'componentWillReceiveProps') {
+                // onBeforeUpdate 通常不需要参数，移除原参数
+                const value = `function onBeforeUpdate() {\n${getMethodBodyCode(m)}\n}`
+                lifeCycleRecord[vueLife] = { type: 'JSFunction', value }
+              } else {
+                lifeCycleRecord[vueLife] = { type: 'JSFunction', value: classMethodToNamedFunctionCode(vueLife, m) }
+              }
+            } else if (name !== 'constructor') {
+              // 兜底：若未来有未映射的生命周期，保留原名（不处理 constructor）
+              lifeCycleRecord[name] = { type: 'JSFunction', value: classMethodToNamedFunctionCode(name, m) }
+            }
           } else {
             methods[name] = { type: 'JSFunction', value: generate(m).code }
           }
@@ -552,6 +603,13 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
           }
         }
       }
+      // 若无 didMount，但有 constructor 语句，仍然生成 onMounted
+      if (constructorExtraCode && !lifeCycleRecord['onMounted']) {
+        lifeCycleRecord['onMounted'] = {
+          type: 'JSFunction',
+          value: `function onMounted() {\n${constructorExtraCode}\n}`
+        }
+      }
       if (Object.keys(lifeCycleRecord).length > 0) {
         page.lifeCycles = { ...page.lifeCycles, ...lifeCycleRecord }
       }
@@ -567,6 +625,28 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
     applyComponentMapping(page.children, defaultComponentMap)
   } catch (e) {
     // ignore mapping errors
+  }
+
+  // 过滤生命周期：仅保留 DSL 支持的键，避免 constructor 等异常键残留
+  try {
+    const allowed = new Set([
+      'onBeforeMount',
+      'onMounted',
+      'onBeforeUpdate',
+      'onUpdated',
+      'onBeforeUnmount',
+      'onUnmounted',
+      'onErrorCaptured',
+      'onActivated',
+      'onDeactivated'
+    ])
+    const lc = page.lifeCycles || {}
+    for (const k of Object.keys(lc)) {
+      if (!allowed.has(k)) delete (lc as any)[k]
+    }
+    page.lifeCycles = lc
+  } catch {
+    // ignore lifecycle filtering errors
   }
 
   // 受控表单双向绑定规范化：将 value/checked = state.xxx 的场景标记为 model，并移除 onChange

--- a/packages/react-to-dsl/src/transform.ts
+++ b/packages/react-to-dsl/src/transform.ts
@@ -8,6 +8,7 @@ import { genId8 } from './utils'
 export interface TransformOptions {
   filename?: string
   isBlock?: boolean
+  css?: string | string[]
 }
 
 // 将通用 AST 表达式节点转换为可序列化值：基本字面量直接返回；
@@ -167,9 +168,15 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
     }
   })
 
+  // 读取并拼接 css 内容
+  let cssContent = ''
+  if (options.css) {
+    cssContent = Array.isArray(options.css) ? options.css.join('\n') : options.css
+  }
+
   const page: IPageSchema = {
     componentName: options.isBlock ? 'Block' : 'Page',
-    css: '',
+    css: cssContent,
     fileName: filename.replace(/\.(t|j)sx?$/, ''),
     lifeCycles: {},
     methods: {},

--- a/packages/react-to-dsl/src/transform.ts
+++ b/packages/react-to-dsl/src/transform.ts
@@ -3,6 +3,7 @@ import traverse from '@babel/traverse'
 import generate from '@babel/generator'
 import type { File } from '@babel/types'
 import type { IAppSchema, IPageSchema, ISchemaChildrenItem } from './types'
+import { defaultComponentMap } from './constants'
 import { genId8 } from './utils'
 
 export interface TransformOptions {
@@ -156,6 +157,16 @@ function arrowToFunctionCode(name: string | undefined, node: any): string {
   const asyncPrefix = node.async ? 'async ' : ''
   const namePart = name ? ` ${name}` : ''
   return `${asyncPrefix}function${namePart}(${params}) ${bodyCode}`
+}
+
+// 递归应用组件名映射（如 antd -> TinyVue）
+function applyComponentMapping(nodes: ISchemaChildrenItem[] | undefined | null, map: Record<string, string>) {
+  if (!nodes || nodes.length === 0) return
+  for (const n of nodes) {
+    const mapped = map[n.componentName]
+    if (mapped) n.componentName = mapped
+    if (n.children && n.children.length) applyComponentMapping(n.children, map)
+  }
 }
 
 export function transformReactToDsl(code: string, options: TransformOptions = {}): IAppSchema {
@@ -320,6 +331,13 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
     page.methods = { ...page.methods, ...methods }
   } catch (e) {
     // 忽略方法提取失败，不影响总体转换
+  }
+
+  // 在输出 schema 前应用组件映射
+  try {
+    applyComponentMapping(page.children, defaultComponentMap)
+  } catch (e) {
+    // ignore mapping errors
   }
 
   const appSchema: IAppSchema = {

--- a/packages/react-to-dsl/src/transform.ts
+++ b/packages/react-to-dsl/src/transform.ts
@@ -3,7 +3,7 @@ import traverse from '@babel/traverse'
 import generate from '@babel/generator'
 import type { File } from '@babel/types'
 import type { IAppSchema, IPageSchema, ISchemaChildrenItem } from './types'
-import { defaultComponentMap } from './constants'
+import { defaultComponentMap, defaultPropMap } from './constants'
 import { genId8 } from './utils'
 
 export interface TransformOptions {
@@ -317,6 +317,35 @@ function styleObjToCss(obj: any): any {
   return obj
 }
 
+// 按组件的属性规则映射/重命名 props
+function applyPropMapping(
+  componentName: string,
+  props: Record<string, any> | undefined | null
+): Record<string, any> | undefined | null {
+  if (!props) return props
+  const rules = (defaultPropMap as any)[componentName] as
+    | Record<string, { rename?: string; mapValue?: (v: any) => any }>
+    | undefined
+  if (!rules) return props
+  const next: Record<string, any> = {}
+  for (const [key, val] of Object.entries(props)) {
+    if (key === '...') {
+      next[key] = val
+      continue
+    }
+    const rule = rules[key]
+    if (rule) {
+      const newKey = rule.rename || key
+      const newVal = typeof rule.mapValue === 'function' ? rule.mapValue(val) : val
+      // 若已存在同名目标键，保留第一次设置，避免无意覆盖
+      if (!(newKey in next)) next[newKey] = newVal
+    } else {
+      next[key] = val
+    }
+  }
+  return next
+}
+
 function applyComponentMapping(nodes: ISchemaChildrenItem[] | undefined | null, map: Record<string, string>) {
   if (!nodes || nodes.length === 0) return
   for (const n of nodes) {
@@ -332,6 +361,8 @@ function applyComponentMapping(nodes: ISchemaChildrenItem[] | undefined | null, 
     if (n.props && n.props.style) {
       n.props.style = styleObjToCss(n.props.style)
     }
+    // 应用属性级映射（依据组件）
+    n.props = applyPropMapping(n.componentName, n.props) as any
     // Tiny 组件属性名调整
     if (n.componentName === 'TinySelect' || n.componentName === 'TinyInput') {
       if (n.props && n.props.value !== undefined) {

--- a/packages/react-to-dsl/src/transform.ts
+++ b/packages/react-to-dsl/src/transform.ts
@@ -184,10 +184,10 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
     state: [],
     meta: {
       id: 1,
+      isPage: !options.isBlock,
       isHome: true,
-      parentId: 'root',
-      rootElement: 'root',
-      route: '/'
+      parentId: '0',
+      router: '/'
     },
     children: []
   }

--- a/packages/react-to-dsl/src/transform.ts
+++ b/packages/react-to-dsl/src/transform.ts
@@ -132,6 +132,16 @@ function buildNodeFromJSX(jsxEl: any): ISchemaChildrenItem {
   }
 }
 
+// 将箭头函数表达式转换为普通函数源码字符串，尽量保持参数/async/主体一致
+function arrowToFunctionCode(name: string | undefined, node: any): string {
+  const params = (node.params || []).map((p: any) => generate(p).code).join(', ')
+  const bodyCode =
+    node.body?.type === 'BlockStatement' ? generate(node.body).code : `{ return ${generate(node.body).code}; }`
+  const asyncPrefix = node.async ? 'async ' : ''
+  const namePart = name ? ` ${name}` : ''
+  return `${asyncPrefix}function${namePart}(${params}) ${bodyCode}`
+}
+
 export function transformReactToDsl(code: string, options: TransformOptions = {}): IAppSchema {
   const filename = options.filename || 'App.tsx'
   const ast: File = parse(code, {
@@ -238,7 +248,10 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
               const name = decl.id.name
               const init = decl.init
               if (!init) continue
-              if (init.type === 'ArrowFunctionExpression' || init.type === 'FunctionExpression') {
+              if (init.type === 'ArrowFunctionExpression') {
+                methods[name] = { type: 'JSFunction', value: arrowToFunctionCode(name, init) }
+              } else if (init.type === 'FunctionExpression') {
+                // 若是匿名函数表达式，保留为函数表达式；如需可改为具名函数
                 methods[name] = { type: 'JSFunction', value: generate(init).code }
               }
             }
@@ -274,8 +287,12 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
           const key: any = m.key
           const name = key.type === 'Identifier' ? key.name : key.type === 'PrivateName' ? key.id?.name : undefined
           const init: any = (m as any).value
-          if (name && init && (init.type === 'ArrowFunctionExpression' || init.type === 'FunctionExpression')) {
-            methods[name] = { type: 'JSFunction', value: generate(init).code }
+          if (name && init) {
+            if (init.type === 'ArrowFunctionExpression') {
+              methods[name] = { type: 'JSFunction', value: arrowToFunctionCode(name, init) }
+            } else if (init.type === 'FunctionExpression') {
+              methods[name] = { type: 'JSFunction', value: generate(init).code }
+            }
           }
         }
       }

--- a/packages/react-to-dsl/src/transform.ts
+++ b/packages/react-to-dsl/src/transform.ts
@@ -120,6 +120,23 @@ function buildNodeFromJSX(jsxEl: any): ISchemaChildrenItem {
   jsxEl.children.forEach((c: any) => {
     if (c.type === 'JSXElement') {
       children.push(buildNodeFromJSX(c))
+    } else if (c.type === 'JSXFragment') {
+      // 将片段映射为 div，并递归其子元素
+      const wrapped = {
+        type: 'JSXElement',
+        openingElement: {
+          type: 'JSXOpeningElement',
+          name: { type: 'JSXIdentifier', name: 'div' },
+          attributes: [],
+          selfClosing: false
+        },
+        closingElement: {
+          type: 'JSXClosingElement',
+          name: { type: 'JSXIdentifier', name: 'div' }
+        },
+        children: c.children || []
+      }
+      children.push(buildNodeFromJSX(wrapped))
     } else if (c.type === 'JSXText') {
       const text = c.value.trim()
       if (text) {
@@ -156,10 +173,108 @@ function buildNodeFromJSX(jsxEl: any): ISchemaChildrenItem {
           return
         }
       }
+      // 识别条件渲染：test ? <JSX/> : null / undefined / false
+      if (expr && expr.type === 'ConditionalExpression') {
+        const test = expr.test
+        const cons = expr.consequent
+        const alt = expr.alternate
+        const testCode = generate(test).code
+        // 处理分支是 JSX 的情况
+        const handleBranch = (branch: any, condCode: string) => {
+          if (!branch) return false
+          if (branch.type === 'JSXFragment') {
+            const wrapped = {
+              type: 'JSXElement',
+              openingElement: {
+                type: 'JSXOpeningElement',
+                name: { type: 'JSXIdentifier', name: 'div' },
+                attributes: [],
+                selfClosing: false
+              },
+              closingElement: {
+                type: 'JSXClosingElement',
+                name: { type: 'JSXIdentifier', name: 'div' }
+              },
+              children: branch.children || []
+            }
+            const n = buildNodeFromJSX(wrapped)
+            ;(n as any).condition = { type: 'JSExpression', value: condCode }
+            children.push(n)
+            return true
+          }
+          if (branch.type === 'JSXElement') {
+            const n = buildNodeFromJSX(branch)
+            ;(n as any).condition = { type: 'JSExpression', value: condCode }
+            children.push(n)
+            return true
+          }
+          return false
+        }
+        // 优先处理常见写法：test ? <JSX> : null/false
+        const altIsFalsyLiteral =
+          alt && (alt.type === 'NullLiteral' || (alt.type === 'BooleanLiteral' && alt.value === false))
+        if (handleBranch(cons, testCode)) return
+        // 若反向也是 JSX，则生成第二个节点，条件取否定
+        if (!altIsFalsyLiteral && (alt?.type === 'JSXElement' || alt?.type === 'JSXFragment')) {
+          const negTest = `!(${testCode})`
+          if (handleBranch(alt, negTest)) return
+        }
+      }
+      // 识别逻辑与：cond && <JSX/>
+      if (expr && expr.type === 'LogicalExpression' && expr.operator === '&&') {
+        const left = expr.left
+        const right = expr.right
+        if (right && (right.type === 'JSXElement' || right.type === 'JSXFragment')) {
+          const condCode = generate(left).code
+          const jsxNode =
+            right.type === 'JSXFragment'
+              ? {
+                  type: 'JSXElement',
+                  openingElement: {
+                    type: 'JSXOpeningElement',
+                    name: { type: 'JSXIdentifier', name: 'div' },
+                    attributes: [],
+                    selfClosing: false
+                  },
+                  closingElement: {
+                    type: 'JSXClosingElement',
+                    name: { type: 'JSXIdentifier', name: 'div' }
+                  },
+                  children: (right as any).children || []
+                }
+              : right
+          const n = buildNodeFromJSX(jsxNode as any)
+          ;(n as any).condition = { type: 'JSExpression', value: condCode }
+          children.push(n)
+          return
+        }
+      }
+      // 直接是 JSX，继续解析
+      if (expr && (expr.type === 'JSXElement' || expr.type === 'JSXFragment')) {
+        const jsxNode =
+          expr.type === 'JSXFragment'
+            ? {
+                type: 'JSXElement',
+                openingElement: {
+                  type: 'JSXOpeningElement',
+                  name: { type: 'JSXIdentifier', name: 'div' },
+                  attributes: [],
+                  selfClosing: false
+                },
+                closingElement: {
+                  type: 'JSXClosingElement',
+                  name: { type: 'JSXIdentifier', name: 'div' }
+                },
+                children: (expr as any).children || []
+              }
+            : expr
+        children.push(buildNodeFromJSX(jsxNode as any))
+        return
+      }
       // 默认：保留表达式
       const code = generate(expr).code
       children.push({
-        componentName: 'Fragment',
+        componentName: 'div',
         id: genId8(),
         props: { children: { type: 'JSExpression', value: code } },
         children: []
@@ -253,7 +368,25 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
       // find nearest JSXElement in return
       const arg: any = path.node.argument
       if (arg && (arg.type === 'JSXElement' || arg.type === 'JSXFragment') && !rootJsx) {
-        rootJsx = arg.type === 'JSXFragment' ? arg.children.find((c: any) => c.type === 'JSXElement') : arg
+        // 如果是 Fragment，包装成一个 div，保留其 children
+        if (arg.type === 'JSXFragment') {
+          rootJsx = {
+            type: 'JSXElement',
+            openingElement: {
+              type: 'JSXOpeningElement',
+              name: { type: 'JSXIdentifier', name: 'div' },
+              attributes: [],
+              selfClosing: false
+            },
+            closingElement: {
+              type: 'JSXClosingElement',
+              name: { type: 'JSXIdentifier', name: 'div' }
+            },
+            children: arg.children || []
+          }
+        } else {
+          rootJsx = arg
+        }
         // 记录包含该 return 的最近函数（函数声明/函数表达式/箭头函数）——即组件函数
         const funcPath = path.findParent(
           (p: any) => p.isFunctionDeclaration?.() || p.isFunctionExpression?.() || p.isArrowFunctionExpression?.()

--- a/packages/react-to-dsl/src/transform.ts
+++ b/packages/react-to-dsl/src/transform.ts
@@ -282,7 +282,7 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
     lifeCycles: {},
     methods: {},
     props: {},
-    state: [],
+    state: {},
     meta: {
       id: 1,
       isPage: !options.isBlock,
@@ -298,7 +298,13 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
   }
   if (stateInitNode) {
     try {
-      page.state = [astExprToValue(stateInitNode)]
+      const parsed = astExprToValue(stateInitNode)
+      // 如果是对象则直接使用；否则以特殊 key 包裹，尽量保持对象格式
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        page.state = parsed
+      } else {
+        page.state = { value: parsed }
+      }
     } catch (e) {
       // 失败则忽略
     }

--- a/packages/react-to-dsl/src/transform.ts
+++ b/packages/react-to-dsl/src/transform.ts
@@ -142,6 +142,7 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
   let rootJsx: any | null = null
   let stateInitNode: any | null = null
   let componentFuncPath: any | null = null
+  let componentClassPath: any | null = null
 
   traverse(ast, {
     VariableDeclarator(path) {
@@ -170,6 +171,12 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
           (p: any) => p.isFunctionDeclaration?.() || p.isFunctionExpression?.() || p.isArrowFunctionExpression?.()
         )
         if (funcPath && !componentFuncPath) componentFuncPath = funcPath
+        // 如果在类组件的 render 方法中，记录类路径
+        const renderMethodPath = path.findParent((p: any) => p.isClassMethod?.() && p.node.key?.name === 'render')
+        if (renderMethodPath && !componentClassPath) {
+          const cls = renderMethodPath.findParent((p: any) => p.isClassDeclaration?.() || p.isClassExpression?.())
+          if (cls) componentClassPath = cls
+        }
       }
     }
   })
@@ -239,7 +246,45 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
         }
       }
     }
-    page.methods = methods
+    // 类组件方法与生命周期
+    if (componentClassPath && componentClassPath.node && componentClassPath.node.body) {
+      const classBody = componentClassPath.node.body.body || []
+      const lifeCycleRecord: Record<string, any> = {}
+      const lifecycleNames = new Set([
+        'constructor',
+        'componentDidMount',
+        'componentWillUnmount',
+        'componentDidUpdate',
+        'componentDidCatch',
+        'shouldComponentUpdate',
+        'getSnapshotBeforeUpdate',
+        'componentWillReceiveProps'
+      ])
+      for (const m of classBody) {
+        if (m.type === 'ClassMethod' && m.key && (m.key.type === 'Identifier' || m.key.type === 'StringLiteral')) {
+          const name = m.key.type === 'Identifier' ? m.key.name : String(m.key.value)
+          if (name === 'render') continue
+          if (lifecycleNames.has(name)) {
+            lifeCycleRecord[name] = { type: 'JSFunction', value: generate(m).code }
+          } else {
+            methods[name] = { type: 'JSFunction', value: generate(m).code }
+          }
+        }
+        if ((m.type === 'ClassProperty' || m.type === 'ClassPrivateProperty') && m.key) {
+          const key: any = m.key
+          const name = key.type === 'Identifier' ? key.name : key.type === 'PrivateName' ? key.id?.name : undefined
+          const init: any = (m as any).value
+          if (name && init && (init.type === 'ArrowFunctionExpression' || init.type === 'FunctionExpression')) {
+            methods[name] = { type: 'JSFunction', value: generate(init).code }
+          }
+        }
+      }
+      if (Object.keys(lifeCycleRecord).length > 0) {
+        page.lifeCycles = { ...page.lifeCycles, ...lifeCycleRecord }
+      }
+    }
+
+    page.methods = { ...page.methods, ...methods }
   } catch (e) {
     // 忽略方法提取失败，不影响总体转换
   }

--- a/packages/react-to-dsl/src/transform.ts
+++ b/packages/react-to-dsl/src/transform.ts
@@ -141,6 +141,7 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
 
   let rootJsx: any | null = null
   let stateInitNode: any | null = null
+  let componentFuncPath: any | null = null
 
   traverse(ast, {
     VariableDeclarator(path) {
@@ -164,6 +165,11 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
       const arg: any = path.node.argument
       if (arg && (arg.type === 'JSXElement' || arg.type === 'JSXFragment') && !rootJsx) {
         rootJsx = arg.type === 'JSXFragment' ? arg.children.find((c: any) => c.type === 'JSXElement') : arg
+        // 记录包含该 return 的最近函数（函数声明/函数表达式/箭头函数）——即组件函数
+        const funcPath = path.findParent(
+          (p: any) => p.isFunctionDeclaration?.() || p.isFunctionExpression?.() || p.isArrowFunctionExpression?.()
+        )
+        if (funcPath && !componentFuncPath) componentFuncPath = funcPath
       }
     }
   })
@@ -201,6 +207,41 @@ export function transformReactToDsl(code: string, options: TransformOptions = {}
     } catch (e) {
       // 失败则忽略
     }
+  }
+
+  // 提取组件函数体内的方法定义，写入 schema.methods
+  try {
+    const methods: Record<string, any> = {}
+    if (componentFuncPath) {
+      const funcNode: any = componentFuncPath.node
+      // 仅处理块体
+      const block = funcNode.body && funcNode.body.type === 'BlockStatement' ? funcNode.body : null
+      if (block && Array.isArray(block.body)) {
+        for (const stmt of block.body) {
+          // 1) function handleX() {}
+          if (stmt.type === 'FunctionDeclaration' && stmt.id && stmt.id.name) {
+            const name = stmt.id.name
+            methods[name] = { type: 'JSFunction', value: generate(stmt).code }
+          }
+          // 2) const fn = () => {} / function() {}
+          if (stmt.type === 'VariableDeclaration') {
+            for (const decl of stmt.declarations) {
+              if (!decl || decl.type !== 'VariableDeclarator') continue
+              if (!decl.id || decl.id.type !== 'Identifier') continue
+              const name = decl.id.name
+              const init = decl.init
+              if (!init) continue
+              if (init.type === 'ArrowFunctionExpression' || init.type === 'FunctionExpression') {
+                methods[name] = { type: 'JSFunction', value: generate(init).code }
+              }
+            }
+          }
+        }
+      }
+    }
+    page.methods = methods
+  } catch (e) {
+    // 忽略方法提取失败，不影响总体转换
   }
 
   const appSchema: IAppSchema = {

--- a/packages/react-to-dsl/src/transform.ts
+++ b/packages/react-to-dsl/src/transform.ts
@@ -301,12 +301,20 @@ function arrowToFunctionCode(name: string | undefined, node: any): string {
 }
 
 // 递归应用组件名映射（如 antd -> TinyVue）
-function styleObjToCss(obj: Record<string, any> | string | undefined): any {
+function styleObjToCss(obj: any): any {
   if (!obj || typeof obj === 'string') return obj
-  const toKebab = (s: string) => s.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase())
-  return Object.entries(obj)
-    .map(([k, v]) => `${toKebab(k)}: ${v}`)
-    .join('; ')
+  const isJSExpr = (v: any) => v && typeof v === 'object' && v.type === 'JSExpression'
+  // 若整个 style 就是 JSExpression，例如 style={state.style}，原样保留
+  if (isJSExpr(obj)) return obj
+  // 仅当是纯字面量对象且无表达式/展开时，才转换为字符串
+  if (typeof obj === 'object') {
+    const entries = Object.entries(obj)
+    const hasDynamic = entries.some(([k, v]) => k === '...' || isJSExpr(v) || typeof v === 'object')
+    if (hasDynamic) return obj
+    const toKebab = (s: string) => s.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase())
+    return entries.map(([k, v]) => `${toKebab(k)}: ${v}`).join('; ')
+  }
+  return obj
 }
 
 function applyComponentMapping(nodes: ISchemaChildrenItem[] | undefined | null, map: Record<string, string>) {

--- a/packages/react-to-dsl/src/transform.ts
+++ b/packages/react-to-dsl/src/transform.ts
@@ -1,0 +1,211 @@
+import { parse } from '@babel/parser'
+import traverse from '@babel/traverse'
+import generate from '@babel/generator'
+import type { File } from '@babel/types'
+import type { IAppSchema, IPageSchema, ISchemaChildrenItem } from './types'
+import { genId8 } from './utils'
+
+export interface TransformOptions {
+  filename?: string
+  isBlock?: boolean
+}
+
+// 将通用 AST 表达式节点转换为可序列化值：基本字面量直接返回；
+// 对象/数组递归；函数/标识符/成员/调用等保留为 JSExpression。
+function astExprToValue(node: any): any {
+  if (!node) return null
+  switch (node.type) {
+    case 'StringLiteral':
+    case 'NumericLiteral':
+    case 'BooleanLiteral':
+      return node.value
+    case 'NullLiteral':
+      return null
+    case 'TemplateLiteral': {
+      if (!node.expressions || node.expressions.length === 0) {
+        return node.quasis.map((q: any) => q.value.cooked).join('')
+      }
+      return { type: 'JSExpression', value: generate(node).code }
+    }
+    case 'ObjectExpression': {
+      const obj: Record<string, any> = {}
+      for (const prop of node.properties) {
+        if (prop.type === 'ObjectProperty') {
+          const k = prop.computed
+            ? generate(prop.key).code
+            : prop.key.type === 'Identifier'
+            ? prop.key.name
+            : String((prop.key as any).value)
+          obj[k] = astExprToValue(prop.value)
+        } else if (prop.type === 'SpreadElement') {
+          // 以特殊键标识展开
+          obj['...'] = { type: 'JSExpression', value: generate(prop.argument).code }
+        }
+      }
+      return obj
+    }
+    case 'ArrayExpression':
+      return node.elements.map((el: any) => (el ? astExprToValue(el) : null))
+    case 'ArrowFunctionExpression':
+    case 'FunctionExpression':
+    case 'Identifier':
+    case 'MemberExpression':
+    case 'CallExpression':
+    case 'BinaryExpression':
+    case 'LogicalExpression':
+    case 'ConditionalExpression':
+    case 'UnaryExpression':
+    case 'NewExpression':
+      return { type: 'JSExpression', value: generate(node).code }
+    default:
+      return { type: 'JSExpression', value: generate(node).code }
+  }
+}
+
+function jsxAttrValueToLiteral(node: any): any {
+  if (!node) return ''
+  switch (node.type) {
+    case 'StringLiteral':
+    case 'NumericLiteral':
+    case 'BooleanLiteral':
+      return node.value
+    case 'NullLiteral':
+      return null
+    case 'JSXExpressionContainer':
+      return astExprToValue(node.expression)
+    case 'ArrayExpression':
+    case 'ObjectExpression':
+      return astExprToValue(node)
+    default:
+      return astExprToValue(node)
+  }
+}
+
+function buildNodeFromJSX(jsxEl: any): ISchemaChildrenItem {
+  const componentName = jsxEl.openingElement.name.name || 'Fragment'
+  const props: Record<string, any> = {}
+
+  jsxEl.openingElement.attributes.forEach((attr: any) => {
+    if (attr.type === 'JSXAttribute') {
+      const key = attr.name.name
+      const val = attr.value ? jsxAttrValueToLiteral(attr.value) : true
+      props[key] = val
+    } else if (attr.type === 'JSXSpreadAttribute') {
+      props['...'] = {
+        type: 'JSExpression',
+        value: generate(attr.argument).code
+      }
+    }
+  })
+
+  const children: ISchemaChildrenItem[] = []
+  jsxEl.children.forEach((c: any) => {
+    if (c.type === 'JSXElement') {
+      children.push(buildNodeFromJSX(c))
+    } else if (c.type === 'JSXText') {
+      const text = c.value.trim()
+      if (text) {
+        children.push({
+          componentName: 'span',
+          id: genId8(),
+          props: { children: text },
+          children: []
+        })
+      }
+    } else if (c.type === 'JSXExpressionContainer') {
+      const code = generate(c.expression).code
+      children.push({
+        componentName: 'Fragment',
+        id: genId8(),
+        props: { children: { type: 'JSExpression', value: code } },
+        children: []
+      })
+    }
+  })
+
+  return {
+    componentName,
+    id: genId8(),
+    props,
+    children
+  }
+}
+
+export function transformReactToDsl(code: string, options: TransformOptions = {}): IAppSchema {
+  const filename = options.filename || 'App.tsx'
+  const ast: File = parse(code, {
+    sourceType: 'module',
+    plugins: ['jsx', 'typescript']
+  }) as any
+
+  let rootJsx: any | null = null
+  let stateInitNode: any | null = null
+
+  traverse(ast, {
+    VariableDeclarator(path) {
+      if (stateInitNode) return
+      const d: any = path.node
+      if (d.id && d.id.type === 'ArrayPattern' && d.init && d.init.type === 'CallExpression') {
+        const callee = d.init.callee
+        const isUseState =
+          (callee.type === 'Identifier' && callee.name === 'useState') ||
+          (callee.type === 'MemberExpression' &&
+            callee.property &&
+            callee.property.type === 'Identifier' &&
+            callee.property.name === 'useState')
+        if (isUseState && d.init.arguments && d.init.arguments.length > 0) {
+          stateInitNode = d.init.arguments[0]
+        }
+      }
+    },
+    ReturnStatement(path) {
+      // find nearest JSXElement in return
+      const arg: any = path.node.argument
+      if (arg && (arg.type === 'JSXElement' || arg.type === 'JSXFragment') && !rootJsx) {
+        rootJsx = arg.type === 'JSXFragment' ? arg.children.find((c: any) => c.type === 'JSXElement') : arg
+      }
+    }
+  })
+
+  const page: IPageSchema = {
+    componentName: options.isBlock ? 'Block' : 'Page',
+    css: '',
+    fileName: filename.replace(/\.(t|j)sx?$/, ''),
+    lifeCycles: {},
+    methods: {},
+    props: {},
+    state: [],
+    meta: {
+      id: 1,
+      isHome: true,
+      parentId: 'root',
+      rootElement: 'root',
+      route: '/'
+    },
+    children: []
+  }
+
+  if (rootJsx) {
+    page.children = [buildNodeFromJSX(rootJsx)]
+  }
+  if (stateInitNode) {
+    try {
+      page.state = [astExprToValue(stateInitNode)]
+    } catch (e) {
+      // 失败则忽略
+    }
+  }
+
+  const appSchema: IAppSchema = {
+    i18n: { en_US: {}, zh_CN: {} },
+    utils: [],
+    dataSource: { list: [] },
+    globalState: [],
+    pageSchema: [page],
+    blockSchema: [],
+    componentsMap: [],
+    meta: { name: 'App', description: 'Generated from React source' }
+  }
+
+  return appSchema
+}

--- a/packages/react-to-dsl/src/transform.ts
+++ b/packages/react-to-dsl/src/transform.ts
@@ -131,7 +131,33 @@ function buildNodeFromJSX(jsxEl: any): ISchemaChildrenItem {
         })
       }
     } else if (c.type === 'JSXExpressionContainer') {
-      const code = generate(c.expression).code
+      const expr = c.expression
+      // 识别 arr.map((item, idx) => <JSX .../>)
+      if (
+        expr &&
+        expr.type === 'CallExpression' &&
+        expr.callee &&
+        expr.callee.type === 'MemberExpression' &&
+        expr.callee.property &&
+        expr.callee.property.type === 'Identifier' &&
+        expr.callee.property.name === 'map' &&
+        expr.arguments &&
+        expr.arguments.length === 1 &&
+        (expr.arguments[0].type === 'ArrowFunctionExpression' || expr.arguments[0].type === 'FunctionExpression')
+      ) {
+        const fn: any = expr.arguments[0]
+        // 仅处理返回单个 JSXElement 的情况
+        const ret = fn.body?.type === 'JSXElement' ? fn.body : null
+        if (ret) {
+          const node = buildNodeFromJSX(ret)
+          const col = generate(expr.callee.object).code
+          node.loop = { type: 'JSExpression', value: col }
+          children.push(node)
+          return
+        }
+      }
+      // 默认：保留表达式
+      const code = generate(expr).code
       children.push({
         componentName: 'Fragment',
         id: genId8(),
@@ -160,11 +186,36 @@ function arrowToFunctionCode(name: string | undefined, node: any): string {
 }
 
 // 递归应用组件名映射（如 antd -> TinyVue）
+function styleObjToCss(obj: Record<string, any> | string | undefined): any {
+  if (!obj || typeof obj === 'string') return obj
+  const toKebab = (s: string) => s.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase())
+  return Object.entries(obj)
+    .map(([k, v]) => `${toKebab(k)}: ${v}`)
+    .join('; ')
+}
+
 function applyComponentMapping(nodes: ISchemaChildrenItem[] | undefined | null, map: Record<string, string>) {
   if (!nodes || nodes.length === 0) return
   for (const n of nodes) {
-    const mapped = map[n.componentName]
-    if (mapped) n.componentName = mapped
+    // 特殊图标映射：DatabaseOutlined -> Icon name: IconPanelMini
+    if (n.componentName === 'DatabaseOutlined') {
+      n.componentName = 'Icon'
+      n.props = { ...n.props, name: 'IconPanelMini' }
+    } else {
+      const mapped = map[n.componentName]
+      if (mapped) n.componentName = mapped
+    }
+    // 规范 style：对象 -> 字符串
+    if (n.props && n.props.style) {
+      n.props.style = styleObjToCss(n.props.style)
+    }
+    // Tiny 组件属性名调整
+    if (n.componentName === 'TinySelect' || n.componentName === 'TinyInput') {
+      if (n.props && n.props.value !== undefined) {
+        n.props.modelValue = n.props.value
+        delete n.props.value
+      }
+    }
     if (n.children && n.children.length) applyComponentMapping(n.children, map)
   }
 }

--- a/packages/react-to-dsl/src/transform.ts
+++ b/packages/react-to-dsl/src/transform.ts
@@ -82,8 +82,24 @@ function jsxAttrValueToLiteral(node: any): any {
   }
 }
 
+function getJsxName(n: any): string {
+  if (!n) return 'Fragment'
+  if (n.type === 'JSXIdentifier') return n.name
+  if (n.type === 'JSXMemberExpression') {
+    const obj = getJsxName(n.object)
+    const prop = n.property?.name || ''
+    return obj && prop ? `${obj}.${prop}` : prop || obj || 'Fragment'
+  }
+  if (n.type === 'JSXNamespacedName') {
+    const ns = n.namespace?.name || ''
+    const name = n.name?.name || ''
+    return ns && name ? `${ns}:${name}` : name || ns || 'Fragment'
+  }
+  return 'Fragment'
+}
+
 function buildNodeFromJSX(jsxEl: any): ISchemaChildrenItem {
-  const componentName = jsxEl.openingElement.name.name || 'Fragment'
+  const componentName = getJsxName(jsxEl.openingElement.name)
   const props: Record<string, any> = {}
 
   jsxEl.openingElement.attributes.forEach((attr: any) => {

--- a/packages/react-to-dsl/src/types.ts
+++ b/packages/react-to-dsl/src/types.ts
@@ -1,6 +1,8 @@
 export type JSExpression = {
   type: 'JSExpression'
   value: string
+  // 标记为双向绑定
+  model?: boolean
 }
 
 export interface IFuncType {

--- a/packages/react-to-dsl/src/types.ts
+++ b/packages/react-to-dsl/src/types.ts
@@ -1,0 +1,103 @@
+export type JSExpression = {
+  type: 'JSExpression'
+  value: string
+}
+
+export interface IFuncType {
+  type: 'JSFunction'
+  value: string
+}
+
+export interface IFileItem {
+  fileType: string
+  fileName: string
+  path: string
+  fileContent: string
+}
+
+export interface IComponentMapItem {
+  componentName: string
+  destructuring: boolean
+  exportName?: string
+  package?: string
+  version: string
+}
+
+export interface ISchemaChildrenItem {
+  children: Array<ISchemaChildrenItem>
+  componentName: string
+  id: string
+  props: Record<string, any>
+}
+
+export interface IFolderItem {
+  componentName: 'Folder'
+  depth: number
+  folderName: string
+  id: string
+  parentId: string
+  router: string
+}
+
+export interface IPageSchema {
+  componentName: 'Page' | 'Block'
+  css: string
+  fileName: string
+  lifeCycles: {
+    [key: string]: Record<string, IFuncType>
+  }
+  methods: Record<string, IFuncType>
+  props: Record<string, any>
+  state: Array<Record<string, any>>
+  meta: {
+    id: number
+    isHome: boolean
+    parentId: string
+    rootElement: string
+    route: string
+  }
+  children: Array<ISchemaChildrenItem>
+  schema?: {
+    properties: Array<Record<string, any>>
+    events: Record<string, any>
+  }
+}
+
+export interface IUtilsItem {
+  name: string
+  type: 'npm' | 'function'
+  content: object
+}
+
+export interface IDataSource {
+  list: Array<{ id: number; name: string; data: object }>
+  dataHandler?: IFuncType
+  errorHandler?: IFuncType
+  willFetch?: IFuncType
+}
+
+export interface IGlobalStateItem {
+  id: string
+  state: Record<string, any>
+  actions: Record<string, IFuncType>
+  getters: Record<string, IFuncType>
+}
+
+export interface IMetaInfo {
+  name: string
+  description: string
+}
+
+export interface IAppSchema {
+  i18n: {
+    en_US: Record<string, any>
+    zh_CN: Record<string, any>
+  }
+  utils: Array<IUtilsItem>
+  dataSource: IDataSource
+  globalState: Array<IGlobalStateItem>
+  pageSchema: Array<IPageSchema | IFolderItem>
+  blockSchema: Array<IPageSchema>
+  componentsMap: Array<IComponentMapItem>
+  meta: IMetaInfo
+}

--- a/packages/react-to-dsl/src/types.ts
+++ b/packages/react-to-dsl/src/types.ts
@@ -107,3 +107,18 @@ export interface IAppSchema {
   componentsMap: Array<IComponentMapItem>
   meta: IMetaInfo
 }
+
+// 可配置的组件属性映射规则类型
+export type PropTransformRule = {
+  // 将属性名重命名为
+  rename?: string
+  // 对属性值进行变换
+  mapValue?: (value: any) => any
+}
+
+export type ComponentPropMapping = Record<
+  // 组件名（映射后的）
+  string,
+  // 属性名 -> 规则
+  Record<string, PropTransformRule>
+>

--- a/packages/react-to-dsl/src/types.ts
+++ b/packages/react-to-dsl/src/types.ts
@@ -30,6 +30,8 @@ export interface ISchemaChildrenItem {
   props: Record<string, any>
   // optional loop expression for repeated rendering
   loop?: JSExpression
+  // optional visible condition expression for conditional rendering
+  condition?: JSExpression
 }
 
 export interface IFolderItem {

--- a/packages/react-to-dsl/src/types.ts
+++ b/packages/react-to-dsl/src/types.ts
@@ -28,6 +28,8 @@ export interface ISchemaChildrenItem {
   componentName: string
   id: string
   props: Record<string, any>
+  // optional loop expression for repeated rendering
+  loop?: JSExpression
 }
 
 export interface IFolderItem {

--- a/packages/react-to-dsl/src/types.ts
+++ b/packages/react-to-dsl/src/types.ts
@@ -51,10 +51,10 @@ export interface IPageSchema {
   state: Array<Record<string, any>>
   meta: {
     id: number
+    isPage: boolean
     isHome: boolean
     parentId: string
-    rootElement: string
-    route: string
+    router: string
   }
   children: Array<ISchemaChildrenItem>
   schema?: {

--- a/packages/react-to-dsl/src/types.ts
+++ b/packages/react-to-dsl/src/types.ts
@@ -50,7 +50,7 @@ export interface IPageSchema {
   }
   methods: Record<string, IFuncType>
   props: Record<string, any>
-  state: Array<Record<string, any>>
+  state: Record<string, any>
   meta: {
     id: number
     isPage: boolean

--- a/packages/react-to-dsl/src/utils.ts
+++ b/packages/react-to-dsl/src/utils.ts
@@ -1,0 +1,13 @@
+// Local 8-char id generator: digits + lowercase letters only
+const _ID_ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz'
+function genId8(): string {
+  let id = ''
+  for (let i = 0; i < 8; i++) {
+    // Use Math.random for simplicity; sufficient for schema ids
+    const idx = Math.floor(Math.random() * _ID_ALPHABET.length)
+    id += _ID_ALPHABET.charAt(idx)
+  }
+  return id
+}
+
+export { genId8 }

--- a/packages/react-to-dsl/test/basic/basic.test.ts
+++ b/packages/react-to-dsl/test/basic/basic.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { transformReactToDsl } from '../../src'
+
+describe('react-to-dsl basic', () => {
+  it('should transform simple jsx', () => {
+    const code = `
+      export default function App(){
+        return <div className="box"><h1 title="t">Hello</h1></div>
+      }
+    `
+    const dsl = transformReactToDsl(code, { filename: 'App.tsx' })
+    expect(dsl.pageSchema.length).toBe(1)
+    const pageOrFolder = dsl.pageSchema[0]
+    if ((pageOrFolder as any).componentName === 'Folder') {
+      throw new Error('unexpected Folder in pageSchema')
+    }
+    const page = pageOrFolder as any
+    expect(page.children.length).toBe(1)
+    expect(page.children[0].componentName).toBe('div')
+    // props.className should be preserved
+    expect(page.children[0].props.className).toBe('box')
+  })
+})

--- a/packages/react-to-dsl/test/testcases/001_normal/input/FormTable.css
+++ b/packages/react-to-dsl/test/testcases/001_normal/input/FormTable.css
@@ -1,0 +1,28 @@
+.overflow-container .card {
+  padding-bottom: 8px;
+}
+.main-body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  margin: 20px 20px 9px 20px;
+}
+.card {
+  padding: 20px 20px;
+  background-color: #ffffff;
+  box-shadow: 0 2px 10px 0 rgb(0 0 0 / 6%);
+  border-radius: 2px;
+}
+.manage-list {
+  margin-bottom: 60px !important;
+}
+.crm-title-wrapper {
+  display: flex;
+  justify-content: start;
+  align-items: center;
+  margin-bottom: 20px;
+  gap: 20px;
+}
+.crm-import-button:not(:last-child) {
+  margin-right: 10px;
+}

--- a/packages/react-to-dsl/test/testcases/001_normal/input/FormTable.jsx
+++ b/packages/react-to-dsl/test/testcases/001_normal/input/FormTable.jsx
@@ -1,0 +1,209 @@
+import React from 'react'
+import './FormTable.css'
+import { TinyButton, TinyForm, TinyFormItem, TinyInput, TinySelect, TinyGrid } from '@opentiny/react'
+import { TinyIconHelpCircle } from '@opentiny/react-icon'
+import ImageTitle from '../../components/ImageTitle'
+import { useTranslation } from 'react-i18next'
+
+const FormTable = (props = {}) => {
+  const [state, setState] = React.useState({
+    IconPlusSquare: this.utils.IconPlusSquare(),
+    theme: '{   "id": 22,   "name": "@cloud/tinybuilder-theme-dark",   "description": "黑暗主题" }',
+    companyName: '华为云',
+    companyOptions: null,
+    companyCity: '深圳',
+    cityOptions: [
+      { label: '福州', value: 0 },
+      { label: '深圳', value: 1 },
+      { label: '中山', value: 2 },
+      { label: '龙岩', value: 3 },
+      { label: '韶关', value: 4 },
+      { label: '黄冈', value: 5 },
+      { label: '赤壁', value: 6 },
+      { label: '厦门', value: 7 }
+    ],
+    editConfig: {
+      trigger: 'click',
+      mode: 'cell',
+      showStatus: true,
+      activeMethod: () => {
+        return props.isEdit
+      }
+    },
+    columns: [
+      { type: props.isEdit ? 'selection' : 'index', width: '60', title: props.isEdit ? '' : '序号' },
+      {
+        field: 'status',
+        title: '状态',
+        filter: {
+          layout: 'input,enum,default,extends,base',
+          inputFilter: {
+            component: this.utils.Numeric,
+            attrs: { format: 'yyyy/MM/dd hh:mm:ss' },
+            relation: 'A',
+            relations: [
+              {
+                label: '小于',
+                value: 'A',
+                method: ({ value, input }) => {
+                  return value < input
+                }
+              },
+              { label: '等于', value: 'equals' },
+              { label: '大于', value: 'greaterThan' }
+            ]
+          },
+          extends: [
+            {
+              label: '我要过滤大于800的数',
+              method: ({ value }) => {
+                return value > 800
+              }
+            },
+            {
+              label: '我要过滤全部的数',
+              method: () => {
+                return true
+              }
+            }
+          ]
+        },
+        slots: { default: '' }
+      },
+      { type: 'index', width: 60 },
+      { type: 'selection', width: 60 },
+      { field: 'name', title: '公司名称' },
+      { field: 'employees', title: '员工数' },
+      { field: 'city', title: '城市' },
+      { title: '操作', slots: { default: '' } }
+    ],
+    tableData: [
+      { id: '1', name: 'GFD科技有限公司', city: '福州', employees: 800, boole: false },
+      { id: '2', name: 'WWW科技有限公司', city: '深圳', employees: 300, boole: true },
+      { id: '3', name: 'RFV有限责任公司', city: '中山', employees: 1300, boole: false },
+      { id: '4', name: 'TGB科技有限公司', city: '龙岩', employees: 360, boole: true },
+      { id: '5', name: 'YHN科技有限公司', city: '韶关', employees: 810, boole: true },
+      { id: '6', name: 'WSX科技有限公司', city: '黄冈', employees: 800, boole: true },
+      { id: '7', name: 'KBG物业有限公司', city: '赤壁', employees: 400, boole: false },
+      { id: '8', name: '深圳市福德宝网络技术有限公司', boole: true, city: '厦门', employees: 540 }
+    ],
+    status: this.statusData,
+    buttons: [
+      { type: 'primary', text: '主要操作' },
+      { type: 'success', text: '成功操作' },
+      { type: 'danger', text: t('operation.danger') }
+    ]
+  })
+
+  const utils = {}
+
+  const { t } = useTranslation()
+
+  const getTableData = ({ page, filterArgs }) => {
+    const { curPage, pageSize } = page
+    const offset = (curPage - 1) * pageSize
+
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        const { tableData } = this.state
+        let result = [...tableData]
+
+        if (filterArgs) {
+          result = result.filter((item) => item.city === filterArgs)
+        }
+
+        const total = result.length
+        result = result.slice(offset, offset + pageSize)
+
+        resolve({ result, page: { total } })
+      }, 500)
+    })
+  }
+  const handleSearch = (e) => {
+    return ['搜索:', this.i18n('operation.search'), e]
+  }
+  const handleReset = (e) => {
+    return ['重置:', e]
+  }
+  const statusData = () => {
+    return [
+      { name: this.i18n('quotes.common.configure_basic_information'), status: 'ready' },
+      { name: this.i18n('quotes.quote_list.quote'), status: 'wait' },
+      { name: this.i18n('quotes.common.complete_configuration_quote'), status: 'wait' }
+    ]
+  }
+
+  return (
+    <>
+      <div>
+        <span style="background: url('**/public/logo.png');" className="page-header">
+          标题区
+        </span>
+        <span style="background: url('**/public/background.png');">副标题区</span>
+        <ImageTitle
+          className={['basic-info', { 'form-fixed-layout': props.isFixed }, { 'form-auto-layout': props.isAuto }]}
+          hasSplitLine={false}
+          onClickLogo={(...eventArgs) => handleReset(eventArgs, state.flag)}
+        ></ImageTitle>
+        <TinyForm inline={true} style={state.style} className="form">
+          <TinyFormItem>
+            <TinyInput
+              disabled={false}
+              value={state.companyName}
+              onChange={(e) => setState((prev) => ({ ...prev, companyName: e.target.value }))}
+            ></TinyInput>
+          </TinyFormItem>
+          {state.cityOptions.length ? (
+            <TinyFormItem>
+              <TinySelect
+                value={state.companyCity}
+                options={[
+                  { label: t('city.foochow'), value: 0 },
+                  { label: "深'i'圳", value: 1 },
+                  { label: '中山', value: 2 },
+                  { label: '龙岩', value: 3 },
+                  { label: '韶关', value: 4 },
+                  { label: '黄冈', value: 5 },
+                  { label: '赤壁', value: 6 },
+                  { label: '厦门', value: 7 }
+                ]}
+              ></TinySelect>
+            </TinyFormItem>
+          ) : null}
+          <TinyFormItem>
+            <span className="form-footer">表单提交区</span>
+            <TinyButton type="primary" onClick={handleSearch}>
+              搜索
+            </TinyButton>
+            <TinyButton onClick={handleReset}>{t('operation.reset')}</TinyButton>
+          </TinyFormItem>
+        </TinyForm>
+        <div>
+          <TinyGrid columns={state.columns} fetchData={{ api: getTableData }}></TinyGrid>
+        </div>
+        <div>
+          <TinyGrid columns={state.columns1} fetchData={{ api: getTableData }}></TinyGrid>
+        </div>
+        <div style={{ width: this.props.quotePopWidth }}>循环渲染：</div>
+        {false ? <TinyIconHelpCircle></TinyIconHelpCircle> : null}
+        <div>
+          {state.buttons.map((item, index) => (
+            <TinyButton key={item.text} type={item.type} text={index + item.text}></TinyButton>
+          ))}{' '}
+        </div>
+        <br />
+        <div>
+          {[
+            { type: 'primary', text: '字面量' },
+            { type: 'success', text: '字面量' },
+            { type: 'danger', text: '危险操作' }
+          ].map((item) => (
+            <TinyButton key={item.text} type={item.type} text={item.text}></TinyButton>
+          ))}{' '}
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default FormTable

--- a/packages/react-to-dsl/test/testcases/002_data-binding/input/DataBindingDemo.jsx
+++ b/packages/react-to-dsl/test/testcases/002_data-binding/input/DataBindingDemo.jsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import './DataBindingDemo.css'
+import { Checkbox as AntdCheckbox, Input as AntdInput } from 'antd'
+
+const DataBindingDemo = (props = {}) => {
+  const [state, setState] = React.useState({
+    username: '',
+    email: '',
+    isSubscribed: false
+  })
+
+  const utils = {}
+
+  return (
+    <>
+      <div>
+        <div style="padding: 20px;">
+          <AntdInput
+            value={state.username}
+            onChange={(e) => setState((prev) => ({ ...prev, username: e.target.value }))}
+            placeholder="请输入用户名"
+          ></AntdInput>
+          <AntdInput
+            value={state.email}
+            onChange={(e) => setState((prev) => ({ ...prev, email: e.target.value }))}
+            type="email"
+            placeholder="请输入邮箱"
+          ></AntdInput>
+          <AntdCheckbox
+            checked={state.isSubscribed}
+            onChange={(e) => setState((prev) => ({ ...prev, isSubscribed: e.target.checked }))}
+          ></AntdCheckbox>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default DataBindingDemo

--- a/packages/react-to-dsl/test/testcases/003_createVM/input/createVm.css
+++ b/packages/react-to-dsl/test/testcases/003_createVM/input/createVm.css
@@ -1,0 +1,4 @@
+body {
+  background-color: #eef0f5;
+  margin-bottom: 80px;
+}

--- a/packages/react-to-dsl/test/testcases/003_createVM/input/createVm.jsx
+++ b/packages/react-to-dsl/test/testcases/003_createVM/input/createVm.jsx
@@ -1,0 +1,481 @@
+import React from 'react'
+import './createVm.css'
+import { Button, Input, Form, Select, Table, Row, Col, Steps, Radio, Typography } from 'antd'
+import { DatabaseOutlined, PlusOutlined } from '@ant-design/icons'
+
+const CreateVm = (props = {}) => {
+  const [state, setState] = React.useState({
+    dataDisk: [1, 2, 3],
+    formData: {
+      zone: '1',
+      cpu: '1',
+      cpuArch: '1',
+      memory: '1',
+      storageType: '1',
+      storageSize: '40',
+      diskType: '1',
+      diskSize: '100',
+      networkType: '1',
+      bandwidth: '1',
+      instanceType: '1',
+      instanceCount: '1'
+    },
+    inputValues: { diskLabel: '', systemDisk: '', dataDiskSize: '', networkConfig: '' }
+  })
+
+  const utils = {}
+
+  return (
+    <>
+      <div>
+        <div style={{ paddingBottom: '10px', paddingTop: '10px' }}>
+          <Steps
+            current={1}
+            items={[{ title: '基础配置' }, { title: '网络配置' }, { title: '高级配置' }, { title: '确认配置' }]}
+            direction="horizontal"
+            style={{ borderRadius: '0px' }}
+          ></Steps>
+        </div>
+        <div
+          style={{
+            borderWidth: '1px',
+            borderStyle: 'solid',
+            borderRadius: '4px',
+            borderColor: '#fff',
+            paddingTop: '10px',
+            paddingBottom: '10px',
+            paddingLeft: '10px',
+            paddingRight: '10px',
+            boxShadow: 'rgba(0, 0, 0, 0.1) 0px 1px 3px 0px',
+            backgroundColor: '#fff',
+            marginBottom: '10px'
+          }}
+        >
+          <Form labelCol={{ span: 6 }} wrapperCol={{ span: 18 }} layout="horizontal" style={{ borderRadius: '0px' }}>
+            <Form.Item label="计费模式">
+              <Radio.Group
+                options={[
+                  { label: '包年/包月', value: '1' },
+                  { label: '按需计费', value: '2' }
+                ]}
+                value={state.formData.storageType}
+                onChange={(e) =>
+                  setState((prev) => ({ ...prev, formData: { ...prev.formData, storageType: e.target.value } }))
+                }
+              ></Radio.Group>
+            </Form.Item>
+            <Form.Item label="区域">
+              <Radio.Group
+                options={[{ label: '乌兰察布二零一', value: '1' }]}
+                value="1"
+                style={{ borderRadius: '0px', marginRight: '10px' }}
+              ></Radio.Group>
+              <Typography.Text
+                children="温馨提示：页面左上角切换区域"
+                style={{ color: '#8a8e99', fontSize: '12px' }}
+              ></Typography.Text>
+              <Typography.Text
+                children="不同区域的云服务产品之间内网互不相通；请就近选择靠近您业务的区域，可减少网络时延，提高访问速度"
+                style={{ display: 'block', color: '#8a8e99', borderRadius: '0px', fontSize: '12px' }}
+              ></Typography.Text>
+            </Form.Item>
+            <Form.Item label="可用区" style={{ borderRadius: '0px' }}>
+              <Radio.Group
+                options={[
+                  { label: '可用区1', value: '1' },
+                  { label: '可用区2', value: '2' },
+                  { label: '可用区3', value: '3' }
+                ]}
+                value={state.formData.zone}
+                onChange={(e) =>
+                  setState((prev) => ({ ...prev, formData: { ...prev.formData, zone: e.target.value } }))
+                }
+              ></Radio.Group>
+            </Form.Item>
+          </Form>
+        </div>
+        <div
+          style={{
+            borderWidth: '1px',
+            borderStyle: 'solid',
+            borderRadius: '4px',
+            borderColor: '#fff',
+            paddingTop: '10px',
+            paddingBottom: '10px',
+            paddingLeft: '10px',
+            paddingRight: '10px',
+            boxShadow: 'rgba(0, 0, 0, 0.1) 0px 1px 3px 0px',
+            backgroundColor: '#fff',
+            marginBottom: '10px'
+          }}
+        >
+          <Form labelCol={{ span: 6 }} wrapperCol={{ span: 18 }} layout="horizontal" style={{ borderRadius: '0px' }}>
+            <Form.Item label="CPU架构">
+              <Radio.Group
+                options={[
+                  { label: 'x86计算', value: '1' },
+                  { label: '鲲鹏计算', value: '2' }
+                ]}
+                value={state.formData.cpuArch}
+                onChange={(e) =>
+                  setState((prev) => ({ ...prev, formData: { ...prev.formData, cpuArch: e.target.value } }))
+                }
+              ></Radio.Group>
+            </Form.Item>
+            <Form.Item label="区域">
+              <div style={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'center' }}>
+                <div style={{ display: 'flex', alignItems: 'center', marginRight: '10px' }}>
+                  <Typography.Text children="vCPUs" style={{ width: '80px' }}></Typography.Text>
+                  <Select
+                    value={state.formData.cpu}
+                    onChange={(e) => setState((prev) => ({ ...prev, formData: { ...prev.formData, cpu: e } }))}
+                    placeholder="请选择"
+                    options={[
+                      { value: '1', label: '1 vCPU' },
+                      { value: '2', label: '2 vCPU' }
+                    ]}
+                  ></Select>
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', marginRight: '10px' }}>
+                  <Typography.Text children="内存" style={{ width: '80px', borderRadius: '0px' }}></Typography.Text>
+                  <Select
+                    value={state.formData.memory}
+                    onChange={(e) => setState((prev) => ({ ...prev, formData: { ...prev.formData, memory: e } }))}
+                    placeholder="请选择"
+                    options={[
+                      { value: '1', label: '黄金糕' },
+                      { value: '2', label: '双皮奶' }
+                    ]}
+                  ></Select>
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center' }}>
+                  <Typography.Text children="规格名称" style={{ width: '120px' }}></Typography.Text>
+                  <Input.Search
+                    placeholder="输入关键词"
+                    value={state.inputValues.diskLabel}
+                    onChange={(e) =>
+                      setState((prev) => ({ ...prev, inputValues: { ...prev.inputValues, diskLabel: e.target.value } }))
+                    }
+                  ></Input.Search>
+                </div>
+              </div>
+              <div style={{ borderRadius: '0px' }}>
+                <Radio.Group
+                  options={[
+                    { label: '通用计算型', value: '1' },
+                    { label: '通用计算增强型', value: '2' },
+                    { label: '内存优化型', value: '3' },
+                    { label: '内存优化型', value: '4' },
+                    { label: '磁盘增强型', value: '5' },
+                    { label: '超高I/O型', value: '6' },
+                    { label: 'GPU加速型', value: '7' }
+                  ]}
+                  value={state.formData.instanceType}
+                  onChange={(e) =>
+                    setState((prev) => ({ ...prev, formData: { ...prev.formData, instanceType: e.target.value } }))
+                  }
+                  style={{ borderRadius: '0px', marginTop: '12px' }}
+                ></Radio.Group>
+                <Table
+                  editConfig={{ trigger: 'click', mode: 'cell', showStatus: true }}
+                  columns={[
+                    { type: 'radio', width: 60 },
+                    { field: 'employees', title: '规格名称' },
+                    { field: 'created_date', title: 'vCPUs | 内存(GiB)', sortable: true },
+                    { field: 'city', title: 'CPU', sortable: true },
+                    { title: '基准 / 最大带宽\t', sortable: true },
+                    { title: '内网收发包', sortable: true }
+                  ]}
+                  options={[
+                    {
+                      id: '1',
+                      name: 'GFD科技有限公司',
+                      city: '福州',
+                      employees: 800,
+                      created_date: '2014-04-30 00:56:00',
+                      boole: false
+                    },
+                    {
+                      id: '2',
+                      name: 'WWW科技有限公司',
+                      city: '深圳',
+                      employees: 300,
+                      created_date: '2016-07-08 12:36:22',
+                      boole: true
+                    }
+                  ]}
+                  style={{ marginTop: '12px', borderRadius: '0px' }}
+                  auto-resize={true}
+                ></Table>
+                <div style={{ marginTop: '12px', borderRadius: '0px' }}>
+                  <Typography.Text
+                    children="当前规格"
+                    style={{ width: '150px', display: 'inline-block' }}
+                  ></Typography.Text>
+                  <Typography.Text
+                    children="通用计算型 | Si2.large.2 | 2vCPUs | 4 GiB"
+                    style={{ fontWeight: '700' }}
+                  ></Typography.Text>
+                </div>
+              </div>
+            </Form.Item>
+          </Form>
+        </div>
+        <div
+          style={{
+            borderWidth: '1px',
+            borderStyle: 'solid',
+            borderRadius: '4px',
+            borderColor: '#fff',
+            paddingTop: '10px',
+            paddingBottom: '10px',
+            paddingLeft: '10px',
+            paddingRight: '10px',
+            boxShadow: 'rgba(0, 0, 0, 0.1) 0px 1px 3px 0px',
+            backgroundColor: '#fff',
+            marginBottom: '10px'
+          }}
+        >
+          <Form
+            labelCol="80px"
+            layout={false}
+            label-position="left "
+            label-width="150px"
+            style={{ borderRadius: '0px' }}
+          >
+            <Form.Item label="镜像" style={{ borderRadius: '0px' }}>
+              <Radio.Group
+                options={[
+                  { label: '公共镜像', value: '1' },
+                  { label: '私有镜像', value: '2' },
+                  { label: '共享镜像', value: '3' }
+                ]}
+                value={state.formData.imageType}
+                onChange={(e) =>
+                  setState((prev) => ({ ...prev, formData: { ...prev.formData, imageType: e.target.value } }))
+                }
+              ></Radio.Group>
+              <div style={{ display: 'flex', marginTop: '12px', borderRadius: '0px' }}>
+                <Select
+                  value={state.formData.storageType}
+                  onChange={(e) => setState((prev) => ({ ...prev, formData: { ...prev.formData, storageType: e } }))}
+                  placeholder="请选择"
+                  options={[
+                    { value: '1', label: '黄金糕' },
+                    { value: '2', label: '双皮奶' }
+                  ]}
+                  style={{ width: '170px', marginRight: '10px' }}
+                ></Select>
+                <Select
+                  value={state.formData.storageSize}
+                  onChange={(e) => setState((prev) => ({ ...prev, formData: { ...prev.formData, storageSize: e } }))}
+                  placeholder="请选择"
+                  options={[
+                    { value: '1', label: '黄金糕' },
+                    { value: '2', label: '双皮奶' }
+                  ]}
+                  style={{ width: '340px' }}
+                ></Select>
+              </div>
+              <div style={{ marginTop: '12px' }}>
+                <Typography.Text label="请注意操作系统的语言类型。" style={{ color: '#e37d29' }}></Typography.Text>
+              </div>
+            </Form.Item>
+          </Form>
+        </div>
+        <div
+          style={{
+            borderWidth: '1px',
+            borderStyle: 'solid',
+            borderRadius: '4px',
+            borderColor: '#fff',
+            paddingTop: '10px',
+            paddingBottom: '10px',
+            paddingLeft: '10px',
+            paddingRight: '10px',
+            boxShadow: 'rgba(0, 0, 0, 0.1) 0px 1px 3px 0px',
+            backgroundColor: '#fff',
+            marginBottom: '10px'
+          }}
+        >
+          <Form
+            labelCol="80px"
+            layout={false}
+            label-position="left "
+            label-width="150px"
+            style={{ borderRadius: '0px' }}
+          >
+            <Form.Item label="系统盘" style={{ borderRadius: '0px' }}>
+              <div style={{ display: 'flex' }}>
+                <Select
+                  value={state.formData.storageType}
+                  onChange={(e) => setState((prev) => ({ ...prev, formData: { ...prev.formData, storageType: e } }))}
+                  placeholder="请选择"
+                  options={[
+                    { value: '1', label: '黄金糕' },
+                    { value: '2', label: '双皮奶' }
+                  ]}
+                  style={{ width: '200px', marginRight: '10px' }}
+                ></Select>
+                <Input
+                  placeholder="请输入"
+                  value={state.inputValues.systemDisk}
+                  onChange={(e) =>
+                    setState((prev) => ({ ...prev, inputValues: { ...prev.inputValues, systemDisk: e.target.value } }))
+                  }
+                  style={{ width: '120px', marginRight: '10px' }}
+                ></Input>
+                <Typography.Text
+                  label="GiB   
+IOPS上限240，IOPS突发上限5,000"
+                  style={{ color: '#575d6c', fontSize: '12px' }}
+                ></Typography.Text>
+              </div>
+            </Form.Item>
+          </Form>
+          <Form
+            labelCol="80px"
+            layout={false}
+            label-position="left "
+            label-width="150px"
+            style={{ borderRadius: '0px' }}
+          >
+            <Form.Item label="数据盘" style={{ borderRadius: '0px' }}>
+              {state.dataDisk.map((item) => (
+                <div style={{ marginTop: '12px', display: 'flex' }}>
+                  <DatabaseOutlined style={{ marginRight: '10px', width: '16px', height: '16px' }}></DatabaseOutlined>
+                  <Select
+                    value={state.formData.diskType}
+                    onChange={(e) => setState((prev) => ({ ...prev, formData: { ...prev.formData, diskType: e } }))}
+                    placeholder="请选择"
+                    options={[
+                      { value: '1', label: '黄金糕' },
+                      { value: '2', label: '双皮奶' }
+                    ]}
+                    style={{ width: '200px', marginRight: '10px' }}
+                  ></Select>
+                  <Input
+                    placeholder="请输入"
+                    value={state.inputValues.dataDiskSize}
+                    onChange={(e) =>
+                      setState((prev) => ({
+                        ...prev,
+                        inputValues: { ...prev.inputValues, dataDiskSize: e.target.value }
+                      }))
+                    }
+                    style={{ width: '120px', marginRight: '10px' }}
+                  ></Input>
+                  <Typography.Text
+                    label="GiB   
+IOPS上限600，IOPS突发上限5,000"
+                    style={{ color: '#575d6c', fontSize: '12px', marginRight: '10px' }}
+                  ></Typography.Text>
+                  <Input
+                    placeholder="请输入"
+                    value={state.inputValues.diskLabel}
+                    onChange={(e) =>
+                      setState((prev) => ({ ...prev, inputValues: { ...prev.inputValues, diskLabel: e.target.value } }))
+                    }
+                    style={{ width: '120px' }}
+                  ></Input>
+                </div>
+              ))}
+              <div style={{ display: 'flex', marginTop: '12px', borderRadius: '0px' }}>
+                <PlusOutlined style={{ width: '16px', height: '16px', marginRight: '10px' }}></PlusOutlined>
+                <Typography.Text
+                  label="增加一块数据盘"
+                  style={{ fontSize: '12px', borderRadius: '0px', marginRight: '10px' }}
+                ></Typography.Text>
+                <Typography.Text
+                  label="您还可以挂载 21 块磁盘（云硬盘）"
+                  style={{ color: '#8a8e99', fontSize: '12px' }}
+                ></Typography.Text>
+              </div>
+            </Form.Item>
+          </Form>
+        </div>
+        <div
+          style={{
+            borderWidth: '1px',
+            borderStyle: 'solid',
+            borderColor: '#ffffff',
+            paddingTop: '10px',
+            paddingLeft: '10px',
+            paddingRight: '10px',
+            boxShadow: 'rgba(0, 0, 0, 0.1) 0px 1px 3px 0px',
+            backgroundColor: '#fff',
+            position: 'fixed',
+            inset: 'auto 0% 0% 0%',
+            height: '80px',
+            lineHeight: '80px',
+            borderRadius: '0px'
+          }}
+        >
+          <Row style={{ borderRadius: '0px', height: '100%' }}>
+            <Col span="16">
+              <Row style={{ borderRadius: '0px' }}>
+                <Col span="6">
+                  <Typography.Text children="购买量" style={{ marginRight: '10px' }}></Typography.Text>
+                  <Input
+                    placeholder="请输入"
+                    value={state.formData.instanceCount}
+                    onChange={(e) =>
+                      setState((prev) => ({ ...prev, formData: { ...prev.formData, instanceCount: e.target.value } }))
+                    }
+                    style={{ width: '120px', marginRight: '10px' }}
+                  ></Input>
+                  <Typography.Text children="台"></Typography.Text>
+                </Col>
+                <Col span="7">
+                  <div>
+                    <Typography.Text children="配置费用" style={{ fontSize: '12px' }}></Typography.Text>
+                    <Typography.Text
+                      children="¥1.5776"
+                      style={{ paddingLeft: '10px', color: '#de504e' }}
+                    ></Typography.Text>
+                    <Typography.Text children="/小时" style={{ fontSize: '12px' }}></Typography.Text>
+                  </div>
+                  <div>
+                    <Typography.Text
+                      children="参考价格，具体扣费请以账单为准。"
+                      style={{ fontSize: '12px', borderRadius: '0px' }}
+                    ></Typography.Text>
+                    <Typography.Text
+                      children="了解计费详情"
+                      style={{ fontSize: '12px', color: '#344899' }}
+                    ></Typography.Text>
+                  </div>
+                </Col>
+              </Row>
+            </Col>
+            <Col
+              span="8"
+              style={{
+                display: 'flex',
+                flexDirection: 'row-reverse',
+                borderRadius: '0px',
+                height: '100%',
+                justifyContent: 'flex-start',
+                alignItems: 'center'
+              }}
+            >
+              <Button
+                type="primary"
+                style={{ maxWidth: 'unset' }}
+                danger={true}
+                onClick={function handleFormSubmit() {
+                  console.log('Form submitted with data:', state.formData)
+                  alert('Form submitted successfully!')
+                }}
+              >
+                下一步: 网络配置
+              </Button>
+            </Col>
+          </Row>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default CreateVm

--- a/packages/react-to-dsl/test/testcases/003_createVM/input/createVm.jsx
+++ b/packages/react-to-dsl/test/testcases/003_createVM/input/createVm.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import './createVm.css'
 import { Button, Input, Form, Select, Table, Row, Col, Steps, Radio, Typography } from 'antd'
-import { DatabaseOutlined, PlusOutlined } from '@ant-design/icons'
+import { DatabaseOutlined } from '@ant-design/icons'
 
 const CreateVm = (props = {}) => {
   const [state, setState] = React.useState({
@@ -386,7 +386,6 @@ IOPS上限600，IOPS突发上限5,000"
                 </div>
               ))}
               <div style={{ display: 'flex', marginTop: '12px', borderRadius: '0px' }}>
-                <PlusOutlined style={{ width: '16px', height: '16px', marginRight: '10px' }}></PlusOutlined>
                 <Typography.Text
                   label="增加一块数据盘"
                   style={{ fontSize: '12px', borderRadius: '0px', marginRight: '10px' }}

--- a/packages/react-to-dsl/test/testcases/003_createVM/input/createVm.jsx
+++ b/packages/react-to-dsl/test/testcases/003_createVM/input/createVm.jsx
@@ -25,6 +25,11 @@ const CreateVm = (props = {}) => {
 
   const utils = {}
 
+  function handleFormSubmit() {
+    console.log('Form submitted with data:', state.formData)
+    alert('Form submitted successfully!')
+  }
+
   return (
     <>
       <div>
@@ -459,15 +464,7 @@ IOPS上限600，IOPS突发上限5,000"
                 alignItems: 'center'
               }}
             >
-              <Button
-                type="primary"
-                style={{ maxWidth: 'unset' }}
-                danger={true}
-                onClick={function handleFormSubmit() {
-                  console.log('Form submitted with data:', state.formData)
-                  alert('Form submitted successfully!')
-                }}
-              >
+              <Button type="primary" style={{ maxWidth: 'unset' }} danger={true} onClick={handleFormSubmit}>
                 下一步: 网络配置
               </Button>
             </Col>

--- a/packages/react-to-dsl/test/testcases/004_lifecycle/input/lifecycle.jsx
+++ b/packages/react-to-dsl/test/testcases/004_lifecycle/input/lifecycle.jsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import './LifecycleTestPage.css'
+import { Button as TinyButton } from 'antd'
+
+class LifecycleTestPage extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {}
+  }
+
+  componentDidMount() {
+    console.log('Component mounted')
+  }
+
+  componentWillUnmount() {
+    console.log('Component unmounted')
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    console.log('Component updated')
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.log('Error caught:', error)
+  }
+
+  handleClick = () => {
+    console.log('Button clicked')
+  }
+
+  render() {
+    const { state } = this
+    const utils = {}
+
+    return (
+      <>
+        <div>
+          <div style="padding: 20px;">
+            <TinyButton onClick={this.handleClick}>点击按钮</TinyButton>
+          </div>
+        </div>
+      </>
+    )
+  }
+}
+
+export default LifecycleTestPage

--- a/packages/react-to-dsl/test/testcases/index.test.js
+++ b/packages/react-to-dsl/test/testcases/index.test.js
@@ -200,13 +200,13 @@ describe('react-to-dsl: run all testcases and output to ./output', () => {
       }
 
       if (caseName.startsWith('004_lifecycle')) {
-        // 生命周期与类方法提取
+        // 生命周期与类方法提取（Vue3 DSL 名称）
         const lc = page.lifeCycles || {}
         const methods = page.methods || {}
-        expect(!!lc.componentDidMount).toBe(true)
-        expect(!!lc.componentWillUnmount).toBe(true)
-        expect(!!lc.componentDidUpdate).toBe(true)
-        expect(!!lc.componentDidCatch).toBe(true)
+        expect(!!lc.onMounted).toBe(true)
+        expect(!!lc.onBeforeUnmount).toBe(true)
+        expect(!!lc.onUpdated).toBe(true)
+        expect(!!lc.onErrorCaptured).toBe(true)
         expect(!!methods.handleClick).toBe(true)
       }
 

--- a/packages/react-to-dsl/test/testcases/index.test.js
+++ b/packages/react-to-dsl/test/testcases/index.test.js
@@ -13,6 +13,25 @@ function getTestCaseDirs(rootDir) {
     .filter((name) => name !== 'output' && !name.startsWith('.'))
 }
 
+// 遍历 children 树的通用工具
+function walkNodes(nodes, visit) {
+  if (!Array.isArray(nodes)) return
+  for (const n of nodes) {
+    visit(n)
+    if (n && Array.isArray(n.children) && n.children.length) {
+      walkNodes(n.children, visit)
+    }
+  }
+}
+
+function someNode(nodes, predicate) {
+  let hit = false
+  walkNodes(nodes, (n) => {
+    if (!hit && predicate(n)) hit = true
+  })
+  return hit
+}
+
 // 读取指定用例 input 目录中的首个 .jsx/.tsx 文件
 function findInputSource(caseDir) {
   const inputDir = path.join(caseDir, 'input')
@@ -75,6 +94,84 @@ describe('react-to-dsl: run all testcases and output to ./output', () => {
       // 基本校验
       expect(appSchema).toBeTruthy()
       expect(Array.isArray(appSchema.pageSchema)).toBe(true)
+
+      // 获取第一个 Page/Block
+      const pageOrFolder = appSchema.pageSchema[0]
+      expect(pageOrFolder).toBeTruthy()
+      if (pageOrFolder && pageOrFolder.componentName === 'Folder') return
+      const page = pageOrFolder
+
+      // 通用结构校验
+      expect(Array.isArray(page.children)).toBe(true)
+      expect(typeof page.css).toBe('string')
+
+      // 各用例特定断言
+      if (caseName.startsWith('001_normal')) {
+        // 1) CSS 注入
+        expect(page.css.includes('.main-body')).toBe(true)
+        // 2) 组件存在（Tiny 体系）
+        expect(
+          someNode(page.children, (n) => n.componentName === 'TinyForm') &&
+            someNode(page.children, (n) => n.componentName === 'TinyGrid')
+        ).toBe(true)
+        // 3) 循环识别：state.buttons.map -> loop 表达式
+        expect(
+          someNode(
+            page.children,
+            (n) => n.loop && n.loop.type === 'JSExpression' && /state\.buttons/.test(n.loop.value)
+          )
+        ).toBe(true)
+        // 4) 方法提取
+        expect(page.methods && typeof page.methods === 'object').toBe(true)
+        expect(!!page.methods.getTableData).toBe(true)
+        expect(!!page.methods.handleSearch).toBe(true)
+      }
+
+      if (caseName.startsWith('002_data-binding')) {
+        // value/checked 等数据绑定应转为 JSExpression
+        const hasBoundValue = someNode(page.children, (n) => {
+          const v = n?.props?.value
+          return v && typeof v === 'object' && v.type === 'JSExpression' && /state\.(username|email)/.test(v.value)
+        })
+        const hasBoundChecked = someNode(page.children, (n) => {
+          const v = n?.props?.checked
+          return v && typeof v === 'object' && v.type === 'JSExpression' && /state\.isSubscribed/.test(v.value)
+        })
+        expect(hasBoundValue && hasBoundChecked).toBe(true)
+      }
+
+      if (caseName.startsWith('003_createVM')) {
+        // 组件映射校验：Steps -> TinyTimeLine
+        expect(someNode(page.children, (n) => n.componentName === 'TinyTimeLine')).toBe(true)
+        // Input.Search -> TinySearch
+        expect(someNode(page.children, (n) => n.componentName === 'TinySearch')).toBe(true)
+        // Radio.Group -> TinyButtonGroup
+        expect(someNode(page.children, (n) => n.componentName === 'TinyButtonGroup')).toBe(true)
+        // Select -> TinySelect
+        expect(someNode(page.children, (n) => n.componentName === 'TinySelect')).toBe(true)
+        // DatabaseOutlined 特殊图标映射
+        expect(
+          someNode(page.children, (n) => n.componentName === 'Icon' && n.props && n.props.name === 'IconPanelMini')
+        ).toBe(true)
+        // style 规范化为字符串（例如 padding-bottom: 10px）
+        expect(
+          someNode(
+            page.children,
+            (n) => typeof n?.props?.style === 'string' && /padding-bottom:\s*10px/.test(n.props.style)
+          )
+        ).toBe(true)
+      }
+
+      if (caseName.startsWith('004_lifecycle')) {
+        // 生命周期与类方法提取
+        const lc = page.lifeCycles || {}
+        const methods = page.methods || {}
+        expect(!!lc.componentDidMount).toBe(true)
+        expect(!!lc.componentWillUnmount).toBe(true)
+        expect(!!lc.componentDidUpdate).toBe(true)
+        expect(!!lc.componentDidCatch).toBe(true)
+        expect(!!methods.handleClick).toBe(true)
+      }
 
       // 输出到 output/<caseName>
       writeOutputs(casesRoot, caseName, appSchema)

--- a/packages/react-to-dsl/test/testcases/index.test.js
+++ b/packages/react-to-dsl/test/testcases/index.test.js
@@ -139,6 +139,42 @@ describe('react-to-dsl: run all testcases and output to ./output', () => {
           return v && typeof v === 'object' && v.type === 'JSExpression' && /state\.isSubscribed/.test(v.value)
         })
         expect(hasBoundChecked).toBe(true)
+
+        // 双向绑定：value/modelValue 与 checked 应带有 model: true 且使用 this.state 路径
+        const hasModelForValue = someNode(page.children, (n) => {
+          const mv = n?.props?.modelValue || n?.props?.value
+          return (
+            mv &&
+            typeof mv === 'object' &&
+            mv.type === 'JSExpression' &&
+            mv.model === true &&
+            /this\.state\.(username|email)/.test(mv.value)
+          )
+        })
+        expect(hasModelForValue).toBe(true)
+
+        const hasModelForChecked = someNode(page.children, (n) => {
+          const ck = n?.props?.checked
+          return (
+            ck &&
+            typeof ck === 'object' &&
+            ck.type === 'JSExpression' &&
+            ck.model === true &&
+            /this\.state\.isSubscribed/.test(ck.value)
+          )
+        })
+        expect(hasModelForChecked).toBe(true)
+
+        // 双向绑定后应移除 onChange
+        const removedOnChange = someNode(page.children, (n) => {
+          const p = n?.props || {}
+          const hasModel =
+            (p.modelValue && typeof p.modelValue === 'object' && p.modelValue.model === true) ||
+            (p.value && typeof p.value === 'object' && p.value.model === true) ||
+            (p.checked && typeof p.checked === 'object' && p.checked.model === true)
+          return hasModel && !('onChange' in p)
+        })
+        expect(removedOnChange).toBe(true)
       }
 
       if (caseName.startsWith('003_createVM')) {

--- a/packages/react-to-dsl/test/testcases/index.test.js
+++ b/packages/react-to-dsl/test/testcases/index.test.js
@@ -22,6 +22,16 @@ function findInputSource(caseDir) {
   return src ? path.join(inputDir, src) : null
 }
 
+// 读取 input 目录下的所有 .css 内容并拼接
+function readAllCss(caseDir) {
+  const inputDir = path.join(caseDir, 'input')
+  if (!fs.existsSync(inputDir)) return ''
+  const files = fs.readdirSync(inputDir)
+  const cssFiles = files.filter((f) => f.endsWith('.css'))
+  const contents = cssFiles.map((f) => fs.readFileSync(path.join(inputDir, f), 'utf-8'))
+  return contents.join('\n')
+}
+
 // 将 DSL 写入 <caseName>/output/app.schema.json，并额外导出 page.schema.json 便于查看
 function writeOutputs(rootDir, caseName, appSchema) {
   const outputDir = path.join(rootDir, caseName, 'output')
@@ -56,7 +66,11 @@ describe('react-to-dsl: run all testcases and output to ./output', () => {
       expect(srcPath, `No JSX/TSX found in ${path.join(caseDir, 'input')}`).toBeTruthy()
 
       const code = fs.readFileSync(srcPath, 'utf-8')
-      const appSchema = transformReactToDsl(code, { filename: path.basename(srcPath) })
+      const css = readAllCss(caseDir)
+      const appSchema = transformReactToDsl(code, {
+        filename: path.basename(srcPath),
+        css
+      })
 
       // 基本校验
       expect(appSchema).toBeTruthy()

--- a/packages/react-to-dsl/test/testcases/index.test.js
+++ b/packages/react-to-dsl/test/testcases/index.test.js
@@ -130,14 +130,15 @@ describe('react-to-dsl: run all testcases and output to ./output', () => {
       if (caseName.startsWith('002_data-binding')) {
         // value/checked 等数据绑定应转为 JSExpression
         const hasBoundValue = someNode(page.children, (n) => {
-          const v = n?.props?.value
+          const v = n?.props?.modelValue
           return v && typeof v === 'object' && v.type === 'JSExpression' && /state\.(username|email)/.test(v.value)
         })
+        expect(hasBoundValue).toBe(true)
         const hasBoundChecked = someNode(page.children, (n) => {
           const v = n?.props?.checked
           return v && typeof v === 'object' && v.type === 'JSExpression' && /state\.isSubscribed/.test(v.value)
         })
-        expect(hasBoundValue && hasBoundChecked).toBe(true)
+        expect(hasBoundChecked).toBe(true)
       }
 
       if (caseName.startsWith('003_createVM')) {

--- a/packages/react-to-dsl/test/testcases/index.test.js
+++ b/packages/react-to-dsl/test/testcases/index.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { transformReactToDsl } from '../../src'
+
+// 小工具：读取目录下的测试用例（形如 001_xxx），排除 output 目录
+function getTestCaseDirs(rootDir) {
+  return fs
+    .readdirSync(rootDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .filter((name) => name !== 'output' && !name.startsWith('.'))
+}
+
+// 读取指定用例 input 目录中的首个 .jsx/.tsx 文件
+function findInputSource(caseDir) {
+  const inputDir = path.join(caseDir, 'input')
+  if (!fs.existsSync(inputDir)) return null
+  const files = fs.readdirSync(inputDir)
+  const src = files.find((f) => /\.(jsx|tsx)$/.test(f))
+  return src ? path.join(inputDir, src) : null
+}
+
+// 将 DSL 写入 <caseName>/output/app.schema.json，并额外导出 page.schema.json 便于查看
+function writeOutputs(rootDir, caseName, appSchema) {
+  const outputDir = path.join(rootDir, caseName, 'output')
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true })
+  }
+  const appSchemaPath = path.join(outputDir, 'app.schema.json')
+  fs.writeFileSync(appSchemaPath, JSON.stringify(appSchema, null, 2), 'utf-8')
+
+  // 额外导出首个 page.schema.json 便于查看
+  if (Array.isArray(appSchema.pageSchema) && appSchema.pageSchema.length > 0) {
+    const pageSchemaPath = path.join(outputDir, 'page.schema.json')
+    fs.writeFileSync(pageSchemaPath, JSON.stringify(appSchema.pageSchema[0], null, 2), 'utf-8')
+  }
+}
+
+describe('react-to-dsl: run all testcases and output to ./output', () => {
+  const __filename = fileURLToPath(import.meta.url)
+  const __dirname = path.dirname(__filename)
+  const casesRoot = __dirname
+  const caseNames = getTestCaseDirs(casesRoot)
+
+  it(`should discover at least 1 testcase`, () => {
+    expect(Array.isArray(caseNames)).toBe(true)
+    // 允许为空，但给出提示；如果后续补充用例即可被自动识别
+  })
+
+  for (const caseName of caseNames) {
+    it(`transform testcase: ${caseName}`, () => {
+      const caseDir = path.join(casesRoot, caseName)
+      const srcPath = findInputSource(caseDir)
+      expect(srcPath, `No JSX/TSX found in ${path.join(caseDir, 'input')}`).toBeTruthy()
+
+      const code = fs.readFileSync(srcPath, 'utf-8')
+      const appSchema = transformReactToDsl(code, { filename: path.basename(srcPath) })
+
+      // 基本校验
+      expect(appSchema).toBeTruthy()
+      expect(Array.isArray(appSchema.pageSchema)).toBe(true)
+
+      // 输出到 output/<caseName>
+      writeOutputs(casesRoot, caseName, appSchema)
+    })
+  }
+})

--- a/packages/react-to-dsl/tsconfig.json
+++ b/packages/react-to-dsl/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "emitDeclarationOnly": false,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/packages/react-to-dsl/vite.config.ts
+++ b/packages/react-to-dsl/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite'
+import path from 'node:path'
+
+export default defineConfig({
+  publicDir: false,
+  resolve: {},
+  base: './',
+  define: {
+    'import.meta': 'import.meta'
+  },
+  build: {
+    sourcemap: true,
+    lib: {
+      entry: path.resolve(__dirname, './src/index.ts'),
+      name: 'reactToDsl',
+      fileName: () => 'index.js',
+      formats: ['es']
+    },
+    rollupOptions: {
+      external: [/^@babel.*/, 'react', 'react-dom', 'nanoid']
+    }
+  }
+})


### PR DESCRIPTION
## feat: introduce react-to-dsl plugin

English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other...

## Background and solution

### What is the current behavior?
项目缺少从 React 源码到 Tiny Engine DSL 的转换能力。

### What is the new behavior?
新增包 `@opentiny/tiny-engine-react-to-dsl`，提供从 React 代码到 TinyEngine DSL（IAppSchema）的转换能力，聚焦“单文件源 -> 单个 Page/Block schema”。核心能力如下：
- 解析 JSX/TSX 为 `children` 树；对 JS 表达式以 `{ type: 'JSExpression', value }` 形式保留。
- 从函数组件体内提取函数声明/箭头函数，填充为 `page.methods`；类组件提取生命周期方法与类方法。
- 识别最常见的 `arr.map(x => <JSX />)` 列表渲染，转换为子节点的 `loop` 表达式。
- 规范化 `props.style`：对象转为 CSS 字符串。
- 组件名映射（如 `Form` -> `TinyForm`、`Input` -> `TinyInput` 等），并包含图标特殊映射（`DatabaseOutlined` -> `Icon` 且附加 `name: 'IconPanelMini'`）。
- 支持注入外部 CSS 内容（例如来自同目录 .css 文件），写入 `page.css`。
- TypeScript 类型定义齐全（见 types.ts），并提供 Vitest 单测与集成用例输出（会生成 `test/testcases/**/output/app.schema.json` 与 `page.schema.json`）。

简要 API：
- `transformReactToDsl(code: string, options?: { filename?: string; isBlock?: boolean; css?: string | string[] }): IAppSchema`

## Docs
- 新增 README.md，包含简介、特性、API、组件映射、快速开始与测试说明。

## Tests
- 单测：basic.test.ts
- 集成用例：`test/testcases/**`，会从 `input/` 读取 .jsx/.tsx 与 .css，输出转换结果至 `output/`
- 当前状态：本地验证通过（Vitest）

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New React → TinyEngine DSL transformer package: converts JSX/TSX into Page/Block schemas with component mappings, state/methods/lifecycles extraction, loop handling, style normalization, CSS injection, and a public transform API.
  * Exposed short ID generator for schema items.

* **Documentation**
  * Added comprehensive README with installation, usage examples, API and build/test instructions.

* **Tests**
  * Added unit and integration tests covering transformation, data binding, lifecycle handling and mappings.

* **Chores**
  * Added package manifest, build/test configs, TypeScript config and ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->