### PR TITLE
feat: add static data source

### DIFF
--- a/packages/canvas/render/src/builtin/CanvasCollection.ts
+++ b/packages/canvas/render/src/builtin/CanvasCollection.ts
@@ -183,7 +183,7 @@ return new Promise((resolve, reject) => {
 this.dataSourceMap.${sourceName}.load().then((res) => {
   // 如果按照数据源面板的建议格式编写dataHandler
   // 那么dataSourceMap的res格式应该是：{ code: string, msg: string, data: {items: any[], total: number} }
-  resolve({ result: res?.data?.items || res, page: { total: res?.data?.total || res.length } });
+  resolve({ result: res?.data?.items ||  res?.data, page: { total: res?.data?.total || res?.total || res.data.length } });
 });
 });
 }`

--- a/packages/canvas/render/src/builtin/CanvasCollection.ts
+++ b/packages/canvas/render/src/builtin/CanvasCollection.ts
@@ -183,7 +183,7 @@ return new Promise((resolve, reject) => {
 this.dataSourceMap.${sourceName}.load().then((res) => {
   // 如果按照数据源面板的建议格式编写dataHandler
   // 那么dataSourceMap的res格式应该是：{ code: string, msg: string, data: {items: any[], total: number} }
-  resolve({ result: res.data.items, page: { total: res.data.total } });
+  resolve({ result: res?.data?.items || res, page: { total: res?.data?.total || res.length } });
 });
 });
 }`

--- a/packages/plugins/datasource/src/DataSourceForm.vue
+++ b/packages/plugins/datasource/src/DataSourceForm.vue
@@ -210,12 +210,14 @@ export default {
     }
 
     const save = async () => {
-      try {
-        // await validate() 如果验证不通过会抛出异常，而不是返回 false
-        await getServiceForm().validate()
-      } catch (error) {
-        activeTabChange('remote')
-        return
+      if (state.dataSource.data.type === 'remote') {
+        try {
+          // await validate() 如果验证不通过会抛出异常，而不是返回 false
+          await getServiceForm().validate()
+        } catch (error) {
+          activeTabChange('remote')
+          return
+        }
       }
       getDataSourceName().validate(async (valid) => {
         if (valid) {

--- a/packages/plugins/datasource/src/DataSourceList.vue
+++ b/packages/plugins/datasource/src/DataSourceList.vue
@@ -70,9 +70,9 @@ export default {
     const openDataSourceForm = (item, index) => {
       activeIndex.value = index
       fetchDataSourceDetail(item.id).then((data) => {
-        const editData = { ...data, data: { ...data.data, type: 'remote' } } || {
+        const editData = { ...data, data: { ...data.data, type: data.data.type || 'remote' } } || {
           ...item,
-          data: { ...item.data, type: 'remote' }
+          data: { ...item.data, type: data.data.type || 'remote' }
         }
         emit('edit', editData)
         getServiceForm()?.clearValidate()

--- a/packages/plugins/datasource/src/DataSourceList.vue
+++ b/packages/plugins/datasource/src/DataSourceList.vue
@@ -70,10 +70,7 @@ export default {
     const openDataSourceForm = (item, index) => {
       activeIndex.value = index
       fetchDataSourceDetail(item.id).then((data) => {
-        const editData = { ...data, data: { ...data.data, type: data.data.type || 'remote' } } || {
-          ...item,
-          data: { ...item.data, type: data.data.type || 'remote' }
-        }
+        const editData = data || item
         emit('edit', editData)
         getServiceForm()?.clearValidate()
       })

--- a/packages/plugins/datasource/src/DataSourceType.vue
+++ b/packages/plugins/datasource/src/DataSourceType.vue
@@ -44,6 +44,10 @@ export default {
       {
         name: '远程数据源',
         value: 'remote'
+      },
+      {
+        name: '静态数据源',
+        value: 'field'
       }
     ]
 

--- a/packages/vue-generator/src/templates/vue-template/templateFiles/src/lowcodeConfig/dataSource.js
+++ b/packages/vue-generator/src/templates/vue-template/templateFiles/src/lowcodeConfig/dataSource.js
@@ -27,7 +27,7 @@ const createFn = (fnContent) => {
 
 const globalDataHandle = dataSources.dataHandler
   ? createFn(dataSources.dataHandler.value)
-  : (res) => Promise.resolve(res)
+  : (res) => Promise.resolve({ data: res })
 
 const load = (http, options, dataSource, shouldFetch) => (params, customUrl) => {
   // 如果没有配置远程请求，则直接返回静态数据，返回前可能会有全局数据处理

--- a/packages/vue-generator/src/templates/vue-template/templateFiles/src/lowcodeConfig/dataSource.js
+++ b/packages/vue-generator/src/templates/vue-template/templateFiles/src/lowcodeConfig/dataSource.js
@@ -25,7 +25,9 @@ const createFn = (fnContent) => {
   }
 }
 
-const globalDataHandle = dataSources.dataHandler ? createFn(dataSources.dataHandler.value) : (res) => res
+const globalDataHandle = dataSources.dataHandler
+  ? createFn(dataSources.dataHandler.value)
+  : (res) => Promise.resolve(res)
 
 const load = (http, options, dataSource, shouldFetch) => (params, customUrl) => {
   // 如果没有配置远程请求，则直接返回静态数据，返回前可能会有全局数据处理

--- a/packages/vue-generator/test/testcases/element-plus-case/expected/appdemo01/src/lowcodeConfig/dataSource.js
+++ b/packages/vue-generator/test/testcases/element-plus-case/expected/appdemo01/src/lowcodeConfig/dataSource.js
@@ -25,7 +25,9 @@ const createFn = (fnContent) => {
   }
 }
 
-const globalDataHandle = dataSources.dataHandler ? createFn(dataSources.dataHandler.value) : (res) => res
+const globalDataHandle = dataSources.dataHandler
+  ? createFn(dataSources.dataHandler.value)
+  : Promise.resolve({ data: res })
 
 const load = (http, options, dataSource, shouldFetch) => (params, customUrl) => {
   // 如果没有配置远程请求，则直接返回静态数据，返回前可能会有全局数据处理

--- a/packages/vue-generator/test/testcases/generator/expected/appdemo01/src/lowcodeConfig/dataSource.js
+++ b/packages/vue-generator/test/testcases/generator/expected/appdemo01/src/lowcodeConfig/dataSource.js
@@ -25,7 +25,9 @@ const createFn = (fnContent) => {
   }
 }
 
-const globalDataHandle = dataSources.dataHandler ? createFn(dataSources.dataHandler.value) : (res) => res
+const globalDataHandle = dataSources.dataHandler
+  ? createFn(dataSources.dataHandler.value)
+  : Promise.resolve({ data: res })
 
 const load = (http, options, dataSource, shouldFetch) => (params, customUrl) => {
   // 如果没有配置远程请求，则直接返回静态数据，返回前可能会有全局数据处理


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a selectable "Static" data source option in the data source form.

- Bug Fixes
  - Editing a data source preserves its original type/details instead of forcing Remote.
  - Remote-specific validation runs only when Remote is selected.
  - Data loading accepts both wrapped responses and plain arrays for broader compatibility.
  - Global/default data handler fallback now returns a Promise for consistent async behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->