### PR TITLE
fix: preview support custom-import-map

### DIFF
--- a/packages/design-core/src/preview/src/preview/importMap.js
+++ b/packages/design-core/src/preview/src/preview/importMap.js
@@ -10,13 +10,13 @@
  *
  */
 
-import { useEnv } from '@opentiny/tiny-engine-meta-register'
+import { useEnv, getMergeMeta } from '@opentiny/tiny-engine-meta-register'
 import { importMapConfig as importMapJSON } from '@opentiny/tiny-engine-common/js/importMap'
 
 const importMap = {}
 const opentinyVueVersion = '~3.20'
 
-function replacePlaceholder(v) {
+function replacePlaceholder(v, k) {
   const {
     VITE_CDN_TYPE,
     VITE_CDN_DOMAIN,
@@ -28,6 +28,14 @@ function replacePlaceholder(v) {
   const versionDelimiter = VITE_CDN_TYPE === 'npmmirror' && !isLocalBundle ? '/' : '@'
   const fileDelimiter = VITE_CDN_TYPE === 'npmmirror' && !isLocalBundle ? '/files' : ''
   const cdnDomain = isLocalBundle ? BASE_URL + VITE_LOCAL_IMPORT_PATH : VITE_CDN_DOMAIN
+  const customImportMap = getMergeMeta('engine.config')?.importMap
+
+  if (customImportMap?.imports?.[k]) {
+    return customImportMap.imports[k]
+      .replace('${VITE_CDN_DOMAIN}', cdnDomain)
+      .replace('${versionDelimiter}', versionDelimiter)
+      .replace('${fileDelimiter}', fileDelimiter)
+  }
 
   return v
     .replace('${VITE_CDN_DOMAIN}', cdnDomain)
@@ -38,7 +46,7 @@ function replacePlaceholder(v) {
 
 export const getImportMap = (scripts = {}) => {
   importMap.imports = {
-    ...Object.fromEntries(Object.entries(importMapJSON.imports).map(([k, v]) => [k, replacePlaceholder(v)])),
+    ...Object.fromEntries(Object.entries(importMapJSON.imports).map(([k, v]) => [k, replacePlaceholder(v, k)])),
     ...scripts
   }
 


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for an optional custom import map from configuration, enabling per-entry overrides of default imports.
  - Placeholder resolution now prioritizes user-defined mappings before falling back to defaults.
  - Improves flexibility and control over module resolution in previews without changing existing workflows.
  - No breaking changes; existing behavior remains intact when no custom map is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->