### PR TITLE
Fix/element not found v2.7：Add condition for when element is null

### DIFF
--- a/packages/canvas/container/src/container.ts
+++ b/packages/canvas/container/src/container.ts
@@ -494,7 +494,7 @@ const getElementDurationTime = (elementId?: string) => {
     const transitionDelays = transitionDelay.split(',')
     delayTime += getMaxMillisecondNumber(transitionDelays)
   }
-  return delayTime === 0 ? 300 : delayTime
+  return delayTime
 }
 
 export const updateRect = (id?: string) => {

--- a/packages/canvas/container/src/container.ts
+++ b/packages/canvas/container/src/container.ts
@@ -468,9 +468,12 @@ const setSelectRect = (
 
 const getElementDurationTime = (elementId?: string) => {
   const element = elementId ? querySelectById(elementId) : getDocument().body
+  let delayTime = 50
+  if (!element) {
+    return delayTime
+  }
   const transitionDuration = window.getComputedStyle(element).getPropertyValue('transition-duration')
   const transitionDelay = window.getComputedStyle(element).getPropertyValue('transition-delay')
-  let delayTime = 0
   const getMaxMillisecondNumber = (arr: string[]) => {
     const millisecondNumber = arr.map((item) => {
       const unit = item.slice(-2)


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->
场景：当画布上元素大小变化时（如按钮大小变化）会有一个过渡动画，但选中的边框是立即检测元素变化，导致边框和组件边缘不重合，因此需要通过getElementById获取组件的animation delay
### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
elementId存在但是找不到对应的element元素，例如teleport 或者是 顶层是 fragment 的元素
Issue Number: N/A

### What is the new behavior?
如果在elementId找不到对应的元素，则直接return默认的delay毫秒50ms

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing elements in duration calculations with optimized default timing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->