### PR TITLE
feat:支持了i18n的mock的CRUD持久化，支持了预览时i18n正确使用修改后内容，移除不必要的mock json文件

### DIFF
--- a/mockServer/src/mock/post/app-center/i18n/entries/bulk/delete.json
+++ b/mockServer/src/mock/post/app-center/i18n/entries/bulk/delete.json
@@ -1,1 +1,0 @@
-{ "data": [], "locale": "zh-cn" }

--- a/mockServer/src/mock/post/app-center/i18n/entries/update.json
+++ b/mockServer/src/mock/post/app-center/i18n/entries/update.json
@@ -1,1 +1,0 @@
-{ "data": [], "locale": "zh-cn" }

--- a/mockServer/src/routes/main-routes.js
+++ b/mockServer/src/routes/main-routes.js
@@ -224,4 +224,16 @@ router.post('block-history/create', async (ctx) => {
   ctx.body = await mockService.blockHistoryService.create(ctx.request.body)
 })
 
+router.post('/app-center/api/i18n/entries/bulk/delete', async (ctx) => {
+  ctx.body = await mockService.i18nService.delete(ctx.request.body)
+})
+
+router.post('/app-center/api/i18n/entries/update', async (ctx) => {
+  ctx.body = await mockService.i18nService.update(ctx.request.body)
+})
+
+router.post('/app-center/api/i18n/entries/create', async (ctx) => {
+  ctx.body = await mockService.i18nService.create(ctx.request.body)
+})
+
 export default router

--- a/mockServer/src/services/app.js
+++ b/mockServer/src/services/app.js
@@ -10,8 +10,10 @@
  *
  */
 
+import fs from 'fs-extra'
+import path from 'path'
 import { mockService } from '../routes/main-routes'
-import { getResponseData } from '../tool/Common'
+import { getResponseData, transformI18nMock } from '../tool/Common'
 export default class AppService {
   async lock(query) {
     const { id, state } = query
@@ -27,7 +29,11 @@ export default class AppService {
   getAppPreviewMetaData() {
     const appMetaData = require('../assets/json/appinfo.json')
 
-    const { i18n: i18nEntries, source = [], extension = [], app } = appMetaData
+    const schemaFilePath = path.resolve(process.cwd(), './src/mock/get/app-center/v1/apps/schema/1.json')
+    const schemaData = fs.readJSONSync(schemaFilePath)
+    const i18nEntries = transformI18nMock(schemaData?.data || {})
+
+    const { source = [], extension = [], app } = appMetaData
     // 拼装数据源
     const dataSource = {
       list: source,

--- a/mockServer/src/services/i18n.js
+++ b/mockServer/src/services/i18n.js
@@ -1,0 +1,42 @@
+import path from 'path'
+import fs from 'fs-extra'
+import { getResponseData } from '../tool/Common'
+
+const schemaFilePath = path.resolve(process.cwd(), './src/mock/get/app-center/v1/apps/schema/1.json')
+export default class PageService {
+  constructor() {
+
+  }
+
+  async create(params) {
+    return this.update(params)
+  }
+
+  async update(params) {
+    const schemaData = fs.readJSONSync(schemaFilePath)
+
+    Object.entries(schemaData?.data?.i18n || {}).forEach(([lang, translations]) => {
+      translations[params.key] = params.contents[lang] || ''
+    })
+
+    fs.writeJSONSync(schemaFilePath, schemaData, { spaces: 2 })
+    return getResponseData({ "data": [], "locale": "zh-cn" ,"mock": true})
+  }
+
+  async delete(params) {
+    //读取schema文件
+    const schemaData = fs.readJSONSync(schemaFilePath)
+
+    Object.entries(schemaData?.data?.i18n || {}).forEach(([lang, translations]) => {
+      params.key_in.forEach((key) => {
+        if (translations.hasOwnProperty(key)) {
+          delete translations[key]
+        }
+      })
+    })
+
+    //写回schema文件
+    fs.writeJSONSync(schemaFilePath, schemaData, { spaces: 2 })
+    return getResponseData({ "data": [], "locale": "zh-cn" ,"mock": true})
+  }
+}

--- a/mockServer/src/services/mockService.js
+++ b/mockServer/src/services/mockService.js
@@ -16,6 +16,7 @@ import SourceService from './source'
 import BlockGroupService from './blockGroup'
 import BlockCategoryService from './blockCategory'
 import Schema2CodeServcice from './schema2code'
+import I18nService from './i18n'
 export default class MockService {
   schema2codeService
   pageService
@@ -24,6 +25,7 @@ export default class MockService {
   sourceService
   blockGroupService
   blockCategoryService
+  i18nService
 
   constructor() {
     this.schema2codeService = new Schema2CodeServcice()
@@ -33,5 +35,6 @@ export default class MockService {
     this.sourceService = new SourceService()
     this.blockGroupService = new BlockGroupService()
     this.blockCategoryService = new BlockCategoryService()
+    this.i18nService = new I18nService()
   }
 }

--- a/mockServer/src/tool/Common.js
+++ b/mockServer/src/tool/Common.js
@@ -80,3 +80,76 @@ export const getDatabasePath = (fileName) => {
   const databasePath = process.env.DATABASE_PATH || path.resolve(__dirname, '../database')
   return path.resolve(databasePath, fileName)
 }
+
+export const transformI18nMock = (sourceData, startId = 123) => {
+  /**
+   * 生成随机日期字符串 (ISO 格式)
+   * @returns {string} e.g., "2023-05-15T00:48:10.000Z"
+   */
+  const getRandomDate = () => {
+    const start = new Date(2022, 0, 1)
+    const end = new Date()
+    const date = new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()))
+    return date.toISOString()
+  }
+
+  /**
+   * 转换 i18n 数据为 Mock 列表格式
+   * @param {Object} sourceData - 原始 i18n 对象
+   * @param {number} startId - 起始 ID
+   * @returns {Array}
+   */
+  const transform = (sourceData, startId = 123) => {
+    // 1. 语言基础配置 (用于填充 lang 对象中的静态字段)
+    const langConfig = {
+      zh_HK: { id: 1, label: '繁體中文' },
+      en_US: { id: 2, label: '美式英文' },
+      zh_CN: { id: 3, label: '简体中文' }
+      // 可以根据需要补充更多
+    }
+
+    let currentId = startId
+    const result = []
+
+    // 2. 遍历语言 (zh_HK, en_US...)
+    if (sourceData && sourceData.i18n) {
+      Object.entries(sourceData.i18n).forEach(([langCode, translations]) => {
+        // 获取语言元数据，如果没有配置则给默认值
+        const langMeta = langConfig[langCode] || { id: 99, label: langCode }
+
+        // 生成语言对象的通用时间戳 (假设同一种语言创建时间一致，也可以移到下方循环内随机)
+        const langTimestamp = getRandomDate()
+
+        // 3. 遍历该语言下的所有 Key (lowcode.xxx)
+        Object.entries(translations).forEach(([key, content]) => {
+          const record = {
+            id: currentId++,
+            key: key,
+            content: content,
+            host: 1, // 固定值
+            host_type: 'app', // 固定值
+            lang: {
+              id: langMeta.id,
+              lang: langCode,
+              label: langMeta.label,
+              created_by: null,
+              updated_by: null,
+              created_at: langTimestamp,
+              updated_at: langTimestamp
+            },
+            created_by: null,
+            updated_by: null,
+            created_at: getRandomDate(),
+            updated_at: getRandomDate()
+          }
+
+          result.push(record)
+        })
+      })
+    }
+
+    return result
+  }
+
+  return transform(sourceData, startId)
+}


### PR DESCRIPTION
[English](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE.md) | 简体中文

# PR

## PR Checklist

请检查您的 PR 是否满足以下要求：

- [ ] commit message遵循我们的[提交贡献指南](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] 添加了更改内容的测试用例（用于bugfix/功能）
- [x] 文档已添加/更新（用于bugfix/功能）
- [x] 是否构建了自己的设计器，经过了充分的自验证

## PR 类型

这个PR的类型是？

- [x] 日常 bug 修复
- [x] 新特性支持
- [ ] 代码风格优化
- [ ] 重构
- [ ] 构建优化
- [ ] 测试用例
- [ ] 文档更新
- [ ] 分支合并
- [ ] 其他改动（请补充）


## 需求背景和解决方案

当使用mock模式时，
国际化内容的保存修改。并没有持久化，导致刷新后修改内容消失，同时由于在preview时由于拉取的i18n的位置并不一致导致，预览时也无法预览国际化后的内容

持久化没月使用nodb进行持久化，而是直接针对schema/1.json进行保存修改，预览时拉取的 i18n位置也统一至 1.json.确保一致

Issue Number: N/A

### 修改前


### 修改后

## 此PR是否含有 breaking change?

- [ ] 是
- [x] 否

## Other information
