### PR TITLE
fix:  serialize page_content to resolve mockserver create page error

### DIFF
--- a/mockServer/src/services/pages.js
+++ b/mockServer/src/services/pages.js
@@ -13,6 +13,17 @@
 import DateStore from '@seald-io/nedb'
 import { getDatabasePath, getResponseData } from '../tool/Common'
 
+const parsePageContent = (item) => {
+  if (item && item.page_content && typeof item.page_content === 'string') {
+    try {
+      item.page_content = JSON.parse(item.page_content)
+    } catch (e) {
+      // ignore
+    }
+  }
+  return item
+}
+
 export default class PageService {
   constructor() {
     this.db = new DateStore({
@@ -68,32 +79,45 @@ export default class PageService {
   async create(params) {
     const model = params.isPage ? this.pageModel : this.folderModel
     const pageData = { ...model, ...params }
+
+    if (pageData.page_content && typeof pageData.page_content === 'object') {
+      pageData.page_content = JSON.stringify(pageData.page_content)
+    }
+
     const result = await this.db.insertAsync(pageData)
     const { _id } = result
     await this.db.updateAsync({ _id }, { $set: { id: _id } })
     result.id = result._id
-    return getResponseData(result)
+    return getResponseData(parsePageContent(result))
   }
 
   async update(id, params) {
-    await this.db.updateAsync({ _id: id }, { $set: params })
+    const updateData = { ...params }
+    if (updateData.page_content && typeof updateData.page_content === 'object') {
+      updateData.page_content = JSON.stringify(updateData.page_content)
+    }
+
+    await this.db.updateAsync({ _id: id }, { $set: updateData })
     const result = await this.db.findOneAsync({ _id: id })
-    return getResponseData(result)
+    return getResponseData(parsePageContent(result))
   }
 
   async list(appId) {
     const result = await this.db.findAsync({ app: appId.toString() })
+    if (Array.isArray(result)) {
+      result.forEach(parsePageContent)
+    }
     return getResponseData(result)
   }
 
   async detail(pageId) {
     const result = await this.db.findOneAsync({ _id: pageId })
-    return getResponseData(result)
+    return getResponseData(parsePageContent(result))
   }
 
   async delete(pageId) {
     const result = await this.db.findOneAsync({ _id: pageId })
     await this.db.removeAsync({ _id: pageId })
-    return getResponseData(result)
+    return getResponseData(parsePageContent(result))
   }
 }


### PR DESCRIPTION

English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

修复 mockServer 创建页面时因字段包含点号(.)导致报错的问题

背景与问题: 在调用 mockServer 的 /app-center/api/pages/create 接口创建页面时，若传入的 page_content（例如 css 的 class 名）包含 .（点号），底层依赖的 @seald-io/nedb 会因为 键名规范抛出 "Field names cannot contain a ." 错误，从而导致创建失败。

修复方案: 对mockserver pages相关接口page_content进行序列化
Create/Update：将对象的 page_content 字段通过 JSON.stringify 序列化为字符串
List/Detail：将 page_content 字符串通过 JSON.parse 重新反序列化为对象

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
