### PR TITLE
fix: page css miss atrule style

### DIFF
--- a/packages/settings/styles/src/components/classNamesContainer/index.vue
+++ b/packages/settings/styles/src/components/classNamesContainer/index.vue
@@ -448,11 +448,30 @@ watchEffect(() => {
 })
 
 const save = ({ content }) => {
-  const { styleObject } = parser(content)
+  const { parseList, styleObject } = parser(content)
   const cssObject = {}
-  Object.keys(styleObject).forEach((styleKey) => {
-    cssObject[styleKey] = styleObject[styleKey].rules
+
+  // 保证存入 cssObject 的键值顺序与编辑器中的源码字符顺序一致
+  parseList.forEach((item) => {
+    // parser 中的 handleRules 没有给普通 rule 赋 type 属性，只具备 selectors 和 style
+    if (!item.type && item.selectors) {
+      if (styleObject[item.selectors]) {
+        cssObject[item.selectors] = styleObject[item.selectors].rules
+      }
+    } else if (item.type === 'atrule') {
+      const rawValue = item.style?.value || ''
+      const braceIdx = rawValue.indexOf('{')
+      const key = braceIdx !== -1 ? rawValue.slice(0, braceIdx).trim() : rawValue.trim()
+      const value = braceIdx !== -1 ? rawValue.slice(braceIdx).trim() : ''
+
+      if (cssObject[key] !== undefined) {
+        cssObject[key] = Array.isArray(cssObject[key]) ? [...cssObject[key], value] : [cssObject[key], value]
+      } else {
+        cssObject[key] = value
+      }
+    }
   })
+
   const { addHistory } = useHistory()
   const { updateRect } = useCanvas().canvasApi.value
   const { updateSchema } = useCanvas()

--- a/packages/settings/styles/src/components/classNamesContainer/index.vue
+++ b/packages/settings/styles/src/components/classNamesContainer/index.vue
@@ -109,7 +109,7 @@ import { useProperties, useCanvas, useHistory, useHelp } from '@opentiny/tiny-en
 import { LinkButton } from '@opentiny/tiny-engine-common'
 import { CodeConfigurator } from '@opentiny/tiny-engine-configurator'
 import useStyle, { updateGlobalStyleStr } from '../../js/useStyle'
-import { stringify, getSelectorArr, parser } from '../../js/parser'
+import { stringify, getSelectorArr, buildCssObjectFromContent } from '../../js/parser'
 
 const { getSchema, propsUpdateKey, setProp } = useProperties()
 
@@ -448,29 +448,7 @@ watchEffect(() => {
 })
 
 const save = ({ content }) => {
-  const { parseList, styleObject } = parser(content)
-  const cssObject = {}
-
-  // 保证存入 cssObject 的键值顺序与编辑器中的源码字符顺序一致
-  parseList.forEach((item) => {
-    // parser 中的 handleRules 没有给普通 rule 赋 type 属性，只具备 selectors 和 style
-    if (!item.type && item.selectors) {
-      if (styleObject[item.selectors]) {
-        cssObject[item.selectors] = styleObject[item.selectors].rules
-      }
-    } else if (item.type === 'atrule') {
-      const rawValue = item.style?.value || ''
-      const braceIdx = rawValue.indexOf('{')
-      const key = braceIdx !== -1 ? rawValue.slice(0, braceIdx).trim() : rawValue.trim()
-      const value = braceIdx !== -1 ? rawValue.slice(braceIdx).trim() : ''
-
-      if (cssObject[key] !== undefined) {
-        cssObject[key] = Array.isArray(cssObject[key]) ? [...cssObject[key], value] : [cssObject[key], value]
-      } else {
-        cssObject[key] = value
-      }
-    }
-  })
+  const cssObject = buildCssObjectFromContent(content)
 
   const { addHistory } = useHistory()
   const { updateRect } = useCanvas().canvasApi.value

--- a/packages/settings/styles/src/js/parser.ts
+++ b/packages/settings/styles/src/js/parser.ts
@@ -42,6 +42,7 @@ const handleAtRules = (node: any) => {
 
   return {
     type,
+    hasBlock: node.nodes !== undefined,
     style: {
       type,
       value: rawString
@@ -141,6 +142,47 @@ export const parser = (css: string) => {
     selectors,
     styleObject
   }
+}
+
+/**
+ * 根据编辑器 css 内容生成对象，保留源码顺序并支持 at-rule
+ * @param {string} content
+ * @returns {Record<string, any>}
+ */
+export const buildCssObjectFromContent = (content: string) => {
+  const { parseList, styleObject } = parser(content)
+  const cssObject = {}
+
+  // 保证存入 cssObject 的键值顺序与编辑器中的源码字符顺序一致
+  parseList.forEach((item) => {
+    // parser 中的 handleRules 没有给普通 rule 赋 type 属性，只具备 selectors 和 style
+    if (!item.type && item.selectors) {
+      if (styleObject[item.selectors]) {
+        cssObject[item.selectors] = styleObject[item.selectors].rules
+      }
+    } else if (item.type === 'atrule') {
+      const rawValue = item.style?.value || ''
+      let key = ''
+      let value = ''
+
+      if (item.hasBlock) {
+        const braceIdx = rawValue.indexOf('{')
+        key = braceIdx !== -1 ? rawValue.slice(0, braceIdx).trim() : rawValue.trim()
+        value = braceIdx !== -1 ? rawValue.slice(braceIdx).trim() : ''
+      } else {
+        key = rawValue.trim()
+        value = ''
+      }
+
+      if (cssObject[key] !== undefined) {
+        cssObject[key] = Array.isArray(cssObject[key]) ? [...cssObject[key], value] : [cssObject[key], value]
+      } else {
+        cssObject[key] = value
+      }
+    }
+  })
+
+  return cssObject
 }
 
 /**

--- a/packages/utils/src/utils/index.ts
+++ b/packages/utils/src/utils/index.ts
@@ -464,9 +464,27 @@ export const objectCssToString = (css) => {
     return css
   }
   let cssString = ''
+  let topString = ''
 
   for (const selector in css) {
     const properties = css[selector]
+
+    if (typeof properties === 'string' || (Array.isArray(properties) && typeof properties[0] === 'string')) {
+      const isTopRule =
+        selector.startsWith('@charset') || selector.startsWith('@import') || selector.startsWith('@namespace')
+      const propsArray = Array.isArray(properties) ? properties : [properties]
+
+      propsArray.forEach((prop) => {
+        const line = prop ? `${selector} ${prop}\n` : `${selector}\n`
+        if (isTopRule) {
+          topString += line
+        } else {
+          cssString += line
+        }
+      })
+      continue
+    }
+
     let ruleString = `${selector} {\r\n`
 
     for (const property in properties) {
@@ -476,5 +494,5 @@ export const objectCssToString = (css) => {
     ruleString += '}\n'
     cssString += ruleString
   }
-  return cssString
+  return topString + cssString
 }


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

fix #1776 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution
<!--
1. Describe the problem and the scenario.
2. New features need to be described and attached with renderings.
3. Screenshots or GIFs involving UI/Interaction changes/Bugfix before and after modification are required.
-->
背景：
在v2.10版本中新增支持css 对象格式，系统将输入的全局 CSS 代码字符串解析并存储为 JSON 对象（`cssObject`）。保存时通过 `parser` 将 CSS 字符串转化格式并在必要时将其转化回字符串（`objectCssToString`）。

问题：
转换为 `styleObject` 的过程中没把包含 `@keyframes`、`@media` 的在内的大部分 at-rules 囊括在内，直接导致这些代码在保存刷新后丢失。见 #1776 

解决方法：
转化时增加对at-rules的支持，保存为 key,value格式

已处理的特殊场景：
- 只有key，没有value， 如 @import
- 顺序问题，保持原有顺序
- 顺序提升：部分需要在顶部的规则进行提升，如 @import
- 同名规则：使用数组格式保存

验证环境：https://hexqi.github.io/tiny-engine/?type=app&id=1&tenant=1&pageid=88

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a utility to parse CSS text into an ordered CSS object and emit top-level rules (like @charset/@import/@namespace) separately for correct output assembly.

* **Bug Fixes**
  * Preserve editor source order for CSS rules.
  * Improved handling of at-rules so their blocks and ordering appear correctly in output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->