### PR TITLE
fix(ci): remove workflow-level env block exposing secrets

### DIFF
--- a/.github/workflows/deploy-cdn.yml
+++ b/.github/workflows/deploy-cdn.yml
@@ -9,12 +9,6 @@ on:
         default: true
         type: boolean
 
-env:
-  HUAWEI_CLOUD_AK: ${{ secrets.HUAWEI_CLOUD_AK }}
-  HUAWEI_CLOUD_SK: ${{ secrets.HUAWEI_CLOUD_SK }}
-  HUAWEI_CLOUD_ENDPOINT: ${{ secrets.HUAWEI_CLOUD_ENDPOINT }}
-  HUAWEI_CLOUD_BUCKET: ${{ secrets.HUAWEI_CLOUD_BUCKET }}
-
 jobs:
   check-secrets:
     runs-on: ubuntu-latest
@@ -146,12 +140,12 @@ jobs:
 
       - name: Configure and Upload to OBS
         run: |
-          obsutil config -i=${{ env.HUAWEI_CLOUD_AK }} \
-                         -k=${{ env.HUAWEI_CLOUD_SK }} \
-                         -e=${{ env.HUAWEI_CLOUD_ENDPOINT }}
+          obsutil config -i=${{ secrets.HUAWEI_CLOUD_AK }} \
+                         -k=${{ secrets.HUAWEI_CLOUD_SK }} \
+                         -e=${{ secrets.HUAWEI_CLOUD_ENDPOINT }}
           # Upload to versioned path
           obsutil cp ./designer-demo/dist \
-                    obs://${{ env.HUAWEI_CLOUD_BUCKET }}/${{ needs.build.outputs.obs-path }} \
+                    obs://${{ secrets.HUAWEI_CLOUD_BUCKET }}/${{ needs.build.outputs.obs-path }} \
                     -r -f -flat
 
           # If is_latest_release is true, also upload to latest path
@@ -160,9 +154,9 @@ jobs:
             find ./designer-demo/dist -type f \( -name "*.html" -o -name "*.js" -o -name "*.mjs" -o -name "*.css" \) \
               -exec sed -i "s|${{ needs.build.outputs.cdn-base }}|${{ needs.build.outputs.cdn-base-latest }}|g" {} +
             obsutil cp ./designer-demo/dist \
-                      obs://${{ env.HUAWEI_CLOUD_BUCKET }}/${{ needs.build.outputs.obs-path-latest }} \
+                      obs://${{ secrets.HUAWEI_CLOUD_BUCKET }}/${{ needs.build.outputs.obs-path-latest }} \
                       -r -f -flat
           fi
 
-          echo "Uploaded to: obs://${{ env.HUAWEI_CLOUD_BUCKET }}/${{ needs.build.outputs.obs-path }}"
+          echo "Uploaded to: obs://${{ secrets.HUAWEI_CLOUD_BUCKET }}/${{ needs.build.outputs.obs-path }}"
           echo "CDN URL: https://res-static.opentiny.design/${{ needs.build.outputs.obs-path }}"


### PR DESCRIPTION
[English](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE.md) | 简体中文

# PR

## PR Checklist

请检查您的 PR 是否满足以下要求：

- [ ] commit message遵循我们的[提交贡献指南](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] 添加了更改内容的测试用例（用于bugfix/功能）
- [ ] 文档已添加/更新（用于bugfix/功能）
- [ ] 是否构建了自己的设计器，经过了充分的自验证

## PR 类型

这个PR的类型是？

- [ ] 日常 bug 修复
- [ ] 新特性支持
- [ ] 代码风格优化
- [ ] 重构
- [ ] 构建优化
- [ ] 测试用例
- [ ] 文档更新
- [ ] 分支合并
- [x] 其他改动（安全修复）


## 需求背景和解决方案

`deploy-cdn.yml` 的顶层 `env:` 块将华为云 AK/SK、Endpoint、Bucket 等敏感密钥提升为工作流级别的进程环境变量，使其暴露给所有 job 和 step，存在泄露风险。

**变更内容：**

- **删除**顶层 `env:` 块，消除四个 secret 的全局环境变量映射：
  ```yaml
  # 删除
  env:
    HUAWEI_CLOUD_AK: ${{ secrets.HUAWEI_CLOUD_AK }}
    HUAWEI_CLOUD_SK: ${{ secrets.HUAWEI_CLOUD_SK }}
    HUAWEI_CLOUD_ENDPOINT: ${{ secrets.HUAWEI_CLOUD_ENDPOINT }}
    HUAWEI_CLOUD_BUCKET: ${{ secrets.HUAWEI_CLOUD_BUCKET }}
  ```
- **替换** `deploy-cdn` job 中所有 `${{ env.HUAWEI_CLOUD_* }}` 引用，改为直接引用 `${{ secrets.HUAWEI_CLOUD_* }}`，仅在 `obsutil config` 和上传命令处按需展开，不写入进程环境。

`check-secrets` job 原本已直接使用 `secrets.*`，无需改动。

### 修改前

AK/SK 作为工作流环境变量存在于所有 job 的进程环境中，任意 step（包括第三方 action）均可读取。

### 修改后

AK/SK 仅在 `deploy-cdn` job 的单一 step 中按需展开，GitHub Actions 自动 mask，不写入环境，缩小了泄露面。

## 此PR是否含有 breaking change?

- [ ] 是
- [x] 否

## Other information

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CDN deployment workflow to reference cloud storage credentials and configuration directly from secure secrets storage, streamlining the deployment process without affecting build or upload functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->