### PR TITLE
chore(ci): deploy workflow support custom backend url

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -5,14 +5,11 @@ on:
     branches: [develop]
   workflow_dispatch:
     inputs:
-      environment:
-        description: 'Backend environment'
+      backend_url:
+        description: 'Backend Base URL (e.g. https://agent.bytedev.site/)'
         required: true
-        default: 'alpha'
-        type: choice
-        options:
-          - alpha
-          - production
+        default: 'https://agent.bytedev.site/'
+        type: string
 
 jobs:
   deploy-gh-pages:
@@ -41,16 +38,11 @@ jobs:
 
       - name: add environment variable
         run: |
-          ENV=${{ github.event.inputs.environment || 'alpha' }}
-          VITE_ORIGIN_URL="https://agent-alpha.opentiny.design/"
-          if [ "$ENV" = "production" ]; then
-            VITE_ORIGIN_URL="https://agent.opentiny.design/"
-          fi
+          VITE_ORIGIN_URL="${{ github.event.inputs.backend_url || 'https://agent.bytedev.site/' }}"
           cat <<EOF >> designer-demo/env/.env.alpha
           # ---- appended by CI (gh-pages) ----
           VITE_ORIGIN=$VITE_ORIGIN_URL
           EOF
-          echo "DEPLOY_ENV=$ENV"
           echo "VITE_ORIGIN_URL=$VITE_ORIGIN_URL"
       - name: Run Build
         run: |

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -45,8 +45,8 @@ jobs:
             exit 1
           fi
 
-          if [[ ! "$ENV_BACKEND_URL" =~ ^https?://[^[:space:]/?#:]+(:[0-9]+)?(/[^[:space:]?#]*)?$ ]]; then
-            echo "::error::backend_url must be an http(s) base URL without query or hash"
+          if [[ ! "$ENV_BACKEND_URL" =~ ^https?://[a-zA-Z0-9._-]+(:[0-9]+)?(/[a-zA-Z0-9._/~:%-]*)?$ ]]; then
+            echo "::error::backend_url must be an http(s) base URL using only URL-safe characters (letters, digits, . _ - / ~ : %)"
             exit 1
           fi
 

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -40,6 +40,18 @@ jobs:
         env:
           ENV_BACKEND_URL: ${{ github.event.inputs.backend_url || 'https://agent.bytedev.site/' }}
         run: |
+          if [[ "$ENV_BACKEND_URL" == *$'\n'* || "$ENV_BACKEND_URL" == *$'\r'* ]]; then
+            echo "::error::backend_url must be a single-line value"
+            exit 1
+          fi
+
+          if [[ ! "$ENV_BACKEND_URL" =~ ^https?://[^[:space:]/?#:]+(:[0-9]+)?(/[^[:space:]?#]*)?$ ]]; then
+            echo "::error::backend_url must be an http(s) base URL without query or hash"
+            exit 1
+          fi
+
+          ENV_BACKEND_URL="${ENV_BACKEND_URL%/}/"
+
           cat <<EOF >> designer-demo/env/.env.alpha
           # ---- appended by CI (gh-pages) ----
           VITE_ORIGIN=$ENV_BACKEND_URL

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -37,13 +37,14 @@ jobs:
         run: pnpm install
 
       - name: add environment variable
+        env:
+          ENV_BACKEND_URL: ${{ github.event.inputs.backend_url || 'https://agent.bytedev.site/' }}
         run: |
-          VITE_ORIGIN_URL="${{ github.event.inputs.backend_url || 'https://agent.bytedev.site/' }}"
           cat <<EOF >> designer-demo/env/.env.alpha
           # ---- appended by CI (gh-pages) ----
-          VITE_ORIGIN=$VITE_ORIGIN_URL
+          VITE_ORIGIN=$ENV_BACKEND_URL
           EOF
-          echo "VITE_ORIGIN_URL=$VITE_ORIGIN_URL"
+          echo "VITE_ORIGIN_URL=$ENV_BACKEND_URL"
       - name: Run Build
         run: |
           set -eo pipefail


### PR DESCRIPTION
English | [简体中文](https://github.com/opentiny/tiny-engine/blob/develop/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.zh-CN.md)

# PR

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Commit Message Guidelines](https://github.com/opentiny/tiny-engine/blob/develop/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Built its own designer, fully self-validated

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Background and solution

### What is the current behavior?

- deploy-gh-pages workflow 的后端环境通过 alpha/production 下拉选择，无法指向自定义后端地址。之前默认的 agent-alpha/agent.opentiny.design 地址已失效。
- 同时 `${{ github.event.inputs }}` 直接内联在 `run` 脚本中，存在模板注入风险。

Issue Number: N/A

### What is the new behavior?

- 支持在fork/远程仓库中直接运行action, 部署到github page，并对接到自定义的backend url，将 `environment`（choice: alpha/production）替换为 `backend_url`（string 类型），默认值为 `https://agent.bytedev.site/`，支持输入任意自定义后端地址
<img width="2252" height="1376" alt="image" src="https://github.com/user-attachments/assets/92106f85-5ceb-421d-b89f-05ea3c9fe708" />

- 将 GitHub 表达式移至 step `env` 映射中赋值，`run` 内只引用普通 shell 变量，消除模板注入风险

验证：
PASS  | https://my-host.example.com/
PASS  | https://my-host.example.com:8080/api/v1/
PASS  | https://example.com/api/foo%20bar/
PASS  | https://example.com/path/%E4%B8%AD%E6%96%87/
PASS  | https://example.com/%2Fencoded/
REJECT| https://evil.com/$GITHUB_TOKEN/
REJECT| https://evil.com/$(whoami)/
REJECT| https://evil.com/`id`/
REJECT| https://evil.com/page?x=1
REJECT| https://evil.com/page#frag
REJECT| javascript:alert(1)
<img width="1910" height="310" alt="image" src="https://github.com/user-attachments/assets/175e6dd1-8e8c-4eb2-b515-b451aa8c22e5" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the deployment workflow to accept a configurable backend base URL input instead of predefined environment selection.
  * Added validation and normalization of the provided backend URL, and updated the generated build-time environment settings accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->